### PR TITLE
Added checksum to eth address, added teleburn to inscriptions page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,6 +1204,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "futures"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1323,12 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
+
+[[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -2187,6 +2199,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rss",
+ "rust-crypto",
  "rust-embed",
  "rustls",
  "rustls-acme",
@@ -2466,6 +2479,29 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2506,6 +2542,15 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
 ]
 
 [[package]]
@@ -2551,6 +2596,15 @@ dependencies = [
  "ring",
  "time 0.3.17",
  "yasna",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2674,6 +2728,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-crypto"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+dependencies = [
+ "gcc",
+ "libc",
+ "rand 0.3.23",
+ "rustc-serialize",
+ "time 0.1.45",
+]
+
+[[package]]
 name = "rust-embed"
 version = "6.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,6 +2779,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ ord-bitcoincore-rpc = "0.16.5"
 redb = "0.13.0"
 regex = "1.6.0"
 rss = "2.0.1"
+rust-crypto = "0.2"
 rust-embed = "6.4.0"
 rustls = "0.20.6"
 rustls-acme = { version = "0.5.0", features = ["axum"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ mod sat;
 mod sat_point;
 pub mod subcommand;
 mod tally;
+mod teleburn_address;
 mod templates;
 mod wallet;
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1,4 +1,3 @@
-use crate::teleburn_address::EthereumTeleburnAddress;
 use {
   self::{
     deserialize_from_str::DeserializeFromStr,
@@ -6,6 +5,7 @@ use {
   },
   super::*,
   crate::page_config::PageConfig,
+  crate::teleburn_address::EthereumTeleburnAddress,
   crate::templates::{
     BlockHtml, ClockSvg, HomeHtml, InputHtml, InscriptionHtml, InscriptionsHtml, OutputHtml,
     PageContent, PageHtml, PreviewAudioHtml, PreviewImageHtml, PreviewPdfHtml, PreviewTextHtml,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1,3 +1,4 @@
+use crate::teleburn_address::EthereumTeleburnAddress;
 use {
   self::{
     deserialize_from_str::DeserializeFromStr,
@@ -837,6 +838,8 @@ impl Server {
       .nth(satpoint.outpoint.vout.try_into().unwrap())
       .ok_or_not_found(|| format!("inscription {inscription_id} current transaction output"))?;
 
+    let teleburn_address = EthereumTeleburnAddress::from(inscription_id).address;
+
     let previous = if let Some(previous) = entry.number.checked_sub(1) {
       Some(
         index
@@ -862,6 +865,7 @@ impl Server {
         previous,
         sat: entry.sat,
         satpoint,
+        teleburn_address,
         timestamp: timestamp(entry.timestamp),
       }
       .page(page_config, index.has_sat_index()?),

--- a/src/subcommand/teleburn.rs
+++ b/src/subcommand/teleburn.rs
@@ -1,5 +1,4 @@
-use super::*;
-use crate::teleburn_address::EthereumTeleburnAddress;
+use {super::*, crate::teleburn_address::EthereumTeleburnAddress};
 
 #[derive(Debug, Parser)]
 pub(crate) struct Teleburn {

--- a/src/subcommand/teleburn.rs
+++ b/src/subcommand/teleburn.rs
@@ -1,3 +1,5 @@
+use crypto::digest::Digest;
+use crypto::sha3::Sha3;
 use {super::*, crate::index::entry::Entry};
 
 #[derive(Debug, Parser)]
@@ -7,39 +9,65 @@ pub(crate) struct Teleburn {
 
 #[derive(Debug, PartialEq, Serialize)]
 pub struct Output {
-  ethereum: EthereumTeleburnAddress,
-}
-
-#[derive(Debug, PartialEq)]
-struct EthereumTeleburnAddress([u8; 20]);
-
-impl Serialize for EthereumTeleburnAddress {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.collect_str(self)
-  }
-}
-
-impl Display for EthereumTeleburnAddress {
-  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-    write!(f, "0x")?;
-
-    for byte in self.0 {
-      write!(f, "{:02x}", byte)?;
-    }
-
-    Ok(())
-  }
+  ethereum: String,
 }
 
 impl Teleburn {
   pub(crate) fn run(self) -> Result {
     let digest = bitcoin::hashes::sha256::Hash::hash(&self.recipient.store());
-    print_json(Output {
-      ethereum: EthereumTeleburnAddress(digest[0..20].try_into().unwrap()),
-    })?;
+    let eth_addr = create_address_with_checksum(&digest[0..20]);
+    print_json(Output { ethereum: eth_addr })?;
     Ok(())
+  }
+}
+
+/// Given an Ethereum address, return that address with a checksum
+/// as per https://eips.ethereum.org/EIPS/eip-55
+fn create_address_with_checksum(addr_bytes: &[u8]) -> String {
+  let normalized_addr = String::from_utf8(addr_bytes.to_vec())
+    .unwrap()
+    .trim_start_matches("0x")
+    .to_ascii_lowercase();
+  let mut hasher = Sha3::keccak256();
+  hasher.input(normalized_addr.as_bytes());
+  let hashed_addr = hasher.result_str();
+  normalized_addr
+    .char_indices()
+    .fold("0x".to_string(), |mut buff, (idx, c)| {
+      if c.is_numeric() {
+        buff.push(c);
+      } else {
+        // safe to unwrap because we have a hex string
+        let value =
+          u8::from_str_radix(&hashed_addr.chars().nth(idx).unwrap().to_string(), 16).unwrap();
+        if value > 7 {
+          buff.push(c.to_ascii_uppercase());
+        } else {
+          buff.push(c);
+        }
+      }
+      buff
+    })
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::subcommand::teleburn::create_address_with_checksum;
+
+  #[test]
+  fn test_eth_checksum_generation() {
+    // test addresses from https://eips.ethereum.org/EIPS/eip-55
+    for addr in &[
+      "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+      "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+      "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB",
+      "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+    ] {
+      let lowercased = String::from(*addr).to_ascii_lowercase();
+      assert_eq!(
+        addr.to_string(),
+        create_address_with_checksum(lowercased.as_bytes())
+      );
+    }
   }
 }

--- a/src/subcommand/teleburn.rs
+++ b/src/subcommand/teleburn.rs
@@ -1,6 +1,5 @@
-use crypto::digest::Digest;
-use crypto::sha3::Sha3;
-use {super::*, crate::index::entry::Entry};
+use super::*;
+use crate::teleburn_address::EthereumTeleburnAddress;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Teleburn {
@@ -9,65 +8,14 @@ pub(crate) struct Teleburn {
 
 #[derive(Debug, PartialEq, Serialize)]
 pub struct Output {
-  ethereum: String,
+  ethereum: EthereumTeleburnAddress,
 }
 
 impl Teleburn {
   pub(crate) fn run(self) -> Result {
-    let digest = bitcoin::hashes::sha256::Hash::hash(&self.recipient.store());
-    let eth_addr = create_address_with_checksum(&digest[0..20]);
-    print_json(Output { ethereum: eth_addr })?;
+    print_json(Output {
+      ethereum: self.recipient.into(),
+    })?;
     Ok(())
-  }
-}
-
-/// Given an Ethereum address, return that address with a checksum
-/// as per https://eips.ethereum.org/EIPS/eip-55
-fn create_address_with_checksum(addr_bytes: &[u8]) -> String {
-  let normalized_addr = String::from_utf8(addr_bytes.to_vec())
-    .unwrap()
-    .trim_start_matches("0x")
-    .to_ascii_lowercase();
-  let mut hasher = Sha3::keccak256();
-  hasher.input(normalized_addr.as_bytes());
-  let hashed_addr = hasher.result_str();
-  normalized_addr
-    .char_indices()
-    .fold("0x".to_string(), |mut buff, (idx, c)| {
-      if c.is_numeric() {
-        buff.push(c);
-      } else {
-        // safe to unwrap because we have a hex string
-        let value =
-          u8::from_str_radix(&hashed_addr.chars().nth(idx).unwrap().to_string(), 16).unwrap();
-        if value > 7 {
-          buff.push(c.to_ascii_uppercase());
-        } else {
-          buff.push(c);
-        }
-      }
-      buff
-    })
-}
-
-#[cfg(test)]
-mod tests {
-  use crate::subcommand::teleburn::create_address_with_checksum;
-
-  #[test]
-  fn test_eth_checksum_generation() {
-    // test addresses from https://eips.ethereum.org/EIPS/eip-55
-    for addr in &[
-      "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
-      "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
-      "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB",
-      "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
-    ] {
-      let lowercased = String::from(*addr).to_ascii_lowercase();
-      assert_eq!(
-        addr.to_string(),
-        create_address_with_checksum(lowercased.as_bytes())
-      );
-    }
   }
 }

--- a/src/teleburn_address.rs
+++ b/src/teleburn_address.rs
@@ -1,8 +1,7 @@
-use super::*;
-use crate::index::entry::Entry;
-use bitcoin::hashes::hex::ToHex;
-use crypto::digest::Digest;
-use crypto::sha3::Sha3;
+use {
+  super::*, crate::index::entry::Entry, bitcoin::hashes::hex::ToHex, crypto::digest::Digest,
+  crypto::sha3::Sha3,
+};
 
 #[derive(Debug, PartialEq, Serialize)]
 pub(crate) struct EthereumTeleburnAddress {
@@ -46,11 +45,13 @@ fn create_address_with_checksum(addr: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-  use crate::inscription_id::InscriptionId;
-  use crate::teleburn_address::{create_address_with_checksum, EthereumTeleburnAddress};
-  use bitcoin::hashes::Hash;
-  use bitcoin::Txid;
-  use std::str::FromStr;
+  use {
+    crate::inscription_id::InscriptionId,
+    crate::teleburn_address::{create_address_with_checksum, EthereumTeleburnAddress},
+    bitcoin::hashes::Hash,
+    bitcoin::Txid,
+    std::str::FromStr,
+  };
 
   #[test]
   fn test_eth_checksum_generation() {

--- a/src/teleburn_address.rs
+++ b/src/teleburn_address.rs
@@ -1,0 +1,93 @@
+use super::*;
+use crate::index::entry::Entry;
+use bitcoin::hashes::hex::ToHex;
+use crypto::digest::Digest;
+use crypto::sha3::Sha3;
+
+#[derive(Debug, PartialEq, Serialize)]
+pub(crate) struct EthereumTeleburnAddress {
+  pub(crate) address: String,
+}
+
+impl From<InscriptionId> for EthereumTeleburnAddress {
+  fn from(inscription_id: InscriptionId) -> Self {
+    let digest = bitcoin::hashes::sha256::Hash::hash(&inscription_id.store());
+    Self {
+      address: create_address_with_checksum(&digest[0..20].to_hex()),
+    }
+  }
+}
+
+/// Given an Ethereum address, return that address with a checksum
+/// as per https://eips.ethereum.org/EIPS/eip-55
+fn create_address_with_checksum(addr: &str) -> String {
+  let normalized_addr = addr.trim_start_matches("0x").to_ascii_lowercase();
+  let mut hasher = Sha3::keccak256();
+  hasher.input(normalized_addr.as_bytes());
+  let hashed_addr = hasher.result_str();
+  normalized_addr
+    .char_indices()
+    .fold("0x".to_string(), |mut buff, (idx, c)| {
+      if c.is_numeric() {
+        buff.push(c);
+      } else {
+        // safe to unwrap because we have a hex string
+        let value =
+          u8::from_str_radix(&hashed_addr.chars().nth(idx).unwrap().to_string(), 16).unwrap();
+        if value > 7 {
+          buff.push(c.to_ascii_uppercase());
+        } else {
+          buff.push(c);
+        }
+      }
+      buff
+    })
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::inscription_id::InscriptionId;
+  use crate::teleburn_address::{create_address_with_checksum, EthereumTeleburnAddress};
+  use bitcoin::hashes::Hash;
+  use bitcoin::Txid;
+  use std::str::FromStr;
+
+  #[test]
+  fn test_eth_checksum_generation() {
+    // test addresses from https://eips.ethereum.org/EIPS/eip-55
+    for addr in &[
+      "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+      "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+      "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB",
+      "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+    ] {
+      let lowercased = String::from(*addr).to_ascii_lowercase();
+      assert_eq!(addr.to_string(), create_address_with_checksum(&lowercased));
+    }
+  }
+
+  #[test]
+  fn test_inscription_id_to_teleburn_address() {
+    for (inscription_id, addr) in &[
+      (
+        InscriptionId {
+          txid: Txid::all_zeros(),
+          index: 0,
+        },
+        "0x6db65fD59fd356F6729140571B5BCd6bB3b83492",
+      ),
+      (
+        InscriptionId::from_str(
+          "6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0",
+        )
+        .unwrap(),
+        "0xe43A06530BdF8A4e067581f48Fae3b535559dA9e",
+      ),
+    ] {
+      assert_eq!(
+        *addr,
+        EthereumTeleburnAddress::from(*inscription_id).address
+      );
+    }
+  }
+}

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -13,6 +13,7 @@ pub(crate) struct InscriptionHtml {
   pub(crate) previous: Option<InscriptionId>,
   pub(crate) sat: Option<Sat>,
   pub(crate) satpoint: SatPoint,
+  pub(crate) teleburn_address: String,
   pub(crate) timestamp: DateTime<Utc>,
 }
 
@@ -29,6 +30,7 @@ impl PageContent for InscriptionHtml {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use teleburn_address::EthereumTeleburnAddress;
 
   #[test]
   fn without_sat_or_nav_links() {
@@ -45,6 +47,7 @@ mod tests {
         previous: None,
         sat: None,
         satpoint: satpoint(1, 0),
+        teleburn_address: EthereumTeleburnAddress::from(inscription_id(1)).address,
         timestamp: timestamp(0),
       },
       "
@@ -83,6 +86,8 @@ mod tests {
           <dd><a class=monospace href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
+          <dt>Ethereum Teleburn Address</dt>
+          <dd>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
       "
       .unindent()
@@ -104,6 +109,7 @@ mod tests {
         previous: None,
         sat: Some(Sat(1)),
         satpoint: satpoint(1, 0),
+        teleburn_address: EthereumTeleburnAddress::from(inscription_id(1)).address,
         timestamp: timestamp(0),
       },
       "
@@ -136,6 +142,7 @@ mod tests {
         previous: Some(inscription_id(1)),
         sat: None,
         satpoint: satpoint(1, 0),
+        teleburn_address: EthereumTeleburnAddress::from(inscription_id(2)).address,
         timestamp: timestamp(0),
       },
       "

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -51,4 +51,6 @@
   <dd><a class=monospace href=/output/{{ self.satpoint.outpoint }}>{{ self.satpoint.outpoint }}</a></dd>
   <dt>offset</dt>
   <dd>{{ self.satpoint.offset }}</dd>
+  <dt>Ethereum Teleburn Address</dt>
+  <dd>{{ self.teleburn_address }}</dd>
 </dl>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -69,6 +69,22 @@ fn create_wallet(rpc_server: &test_bitcoincore_rpc::Handle) {
     .output::<Create>();
 }
 
+#[derive(Deserialize)]
+struct EthereumTeleburnAddress {
+  address: String,
+}
+#[derive(Deserialize)]
+struct Teleburn {
+  ethereum: EthereumTeleburnAddress,
+}
+
+fn teleburn(rpc_server: &test_bitcoincore_rpc::Handle, inscription: &str) -> Teleburn {
+  let output = CommandBuilder::new(format!("teleburn {inscription}"))
+    .rpc_server(rpc_server)
+    .output();
+  output
+}
+
 mod command_builder;
 mod core;
 mod epochs;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -46,6 +46,8 @@ fn inscription_page() {
     ..
   } = inscribe(&rpc_server);
 
+  let teleburn_address = teleburn(&rpc_server, &inscription).ethereum.address;
+
   TestServer::spawn_with_args(&rpc_server, &[]).assert_response_regex(
     format!("/inscription/{inscription}"),
     format!(
@@ -83,6 +85,8 @@ fn inscription_page() {
   <dd><a class=monospace href=/output/{reveal}:0>{reveal}:0</a></dd>
   <dt>offset</dt>
   <dd>0</dd>
+  <dt>Ethereum Teleburn Address</dt>
+  <dd>{teleburn_address}</dd>
 </dl>.*",
     ),
   );


### PR DESCRIPTION
In this PR:
- eth teleburn addresses now have checksums in them. Had to take a dependency on rust-crypto, but didn't take any eth-specific dependencies
- added the ethereum teleburn address to the inscription detail page
- tests!