### PR TITLE
Add Solana teleburn address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base58"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,6 +2164,7 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-server",
+ "base58",
  "bech32",
  "bip39",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [".", "test-bitcoincore-rpc"]
 anyhow = { version = "1.0.56", features = ["backtrace"] }
 axum = { version = "0.6.1", features = ["headers"] }
 axum-server = "0.4.0"
+base58 = "0.2.0"
 bech32 = "0.9.1"
 bip39 = "1.0.1"
 bitcoin = { version = "0.29.1", features = ["rand"] }

--- a/src/subcommand/teleburn.rs
+++ b/src/subcommand/teleburn.rs
@@ -1,4 +1,5 @@
 use {super::*, crate::index::entry::Entry};
+use base58::ToBase58;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Teleburn {
@@ -8,10 +9,14 @@ pub(crate) struct Teleburn {
 #[derive(Debug, PartialEq, Serialize)]
 pub struct Output {
   ethereum: EthereumTeleburnAddress,
+  solana: SolanaTeleburnAddress,
 }
 
 #[derive(Debug, PartialEq)]
 struct EthereumTeleburnAddress([u8; 20]);
+
+#[derive(Debug, PartialEq)]
+struct SolanaTeleburnAddress([u8; 32]);
 
 impl Serialize for EthereumTeleburnAddress {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -34,11 +39,29 @@ impl Display for EthereumTeleburnAddress {
   }
 }
 
+impl Serialize for SolanaTeleburnAddress {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    serializer.collect_str(self)
+  }
+}
+
+impl Display for SolanaTeleburnAddress {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    write!(f, "{}", self.0.to_base58())?;
+
+    Ok(())
+  }
+}
+
 impl Teleburn {
   pub(crate) fn run(self) -> Result {
     let digest = bitcoin::hashes::sha256::Hash::hash(&self.recipient.store());
     print_json(Output {
       ethereum: EthereumTeleburnAddress(digest[0..20].try_into().unwrap()),
+      solana: SolanaTeleburnAddress(digest[0..32].try_into().unwrap()),
     })?;
     Ok(())
   }


### PR DESCRIPTION
Example output:
```
$ ord teleburn 4e27441f9c9e535868bf4778179c23ae306c7f0608e439b5f8f1a4953d5badf3i0
{
  "ethereum": "0xcc6251db97730972a4e1875afa27f07600dbcdcc",
  "solana": "Ekq8Ewm6dpkjrTiznHKiBBa6t6faP87Dhjpgan6fdFUC"
}
```

Implementing #1705