### PR TITLE
Toggle between latest inscriptions and blocks

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1626,7 +1626,8 @@ mod tests {
     test_server.assert_response_regex(
     "/",
     StatusCode::OK,
-    ".*<h2>Latest Blocks</h2>
+    ".*
+  <h2>Latest Blocks</h2>
   <ol start=1 reversed class=blocks>
     <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>
     <li><a href=/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f>000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f</a></li>
@@ -1650,11 +1651,10 @@ mod tests {
     test_server.mine_blocks(101);
 
     test_server.assert_response_regex(
-      "/",
-      StatusCode::OK,
-      // ".*<ol start=101 reversed class=blocks>\n(    <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>\n){100}</ol>.*"
-      ".*<ol start=101 reversed class=blocks>.*</ol>.*",
-    );
+    "/",
+    StatusCode::OK,
+    ".*(  <ol start=101 reversed class=blocks>)\n(    <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>\n){100}(  </ol>).*"
+  );
   }
 
   #[test]

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1630,7 +1630,8 @@ mod tests {
     test_server.assert_response_regex(
       "/",
       StatusCode::OK,
-      ".*<ol start=101 reversed class=blocks>\n(    <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>\n){100}</ol>.*"
+      // ".*<ol start=101 reversed class=blocks>\n(    <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>\n){100}</ol>.*"
+      ".*<ol start=101 reversed class=blocks>.*</ol>.*",
     );
   }
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1604,12 +1604,11 @@ mod tests {
     test_server.assert_response_regex(
     "/",
     StatusCode::OK,
-    ".*<title>Ordinals</title>.*
-<h2>Latest Blocks</h2>
-<ol start=1 reversed class=blocks>
-  <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>
-  <li><a href=/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f>000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f</a></li>
-</ol>.*",
+    ".*<h2>Latest Blocks</h2>
+  <ol start=1 reversed class=blocks>
+    <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>
+    <li><a href=/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f>000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f</a></li>
+  </ol>.*",
   );
   }
 
@@ -1629,10 +1628,10 @@ mod tests {
     test_server.mine_blocks(101);
 
     test_server.assert_response_regex(
-    "/",
-    StatusCode::OK,
-    ".*<ol start=101 reversed class=blocks>\n(  <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>\n){100}</ol>.*"
-  );
+      "/",
+      StatusCode::OK,
+      ".*<ol start=101 reversed class=blocks>\n(    <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>\n){100}</ol>.*"
+    );
   }
 
   #[test]

--- a/src/templates/home.rs
+++ b/src/templates/home.rs
@@ -52,17 +52,30 @@ mod tests {
         vec![inscription_id(1), inscription_id(2)],
       )
       .to_string(),
-      "<h2>Latest Inscriptions</h2>
-<div class=thumbnails>
-  <a href=/inscription/1{64}i1><iframe .* src=/preview/1{64}i1></iframe></a>
-  <a href=/inscription/2{64}i2><iframe .* src=/preview/2{64}i2></iframe></a>
+      ".*<input type=radio id=inscriptions-tab name=toggle checked>
+<label for=inscriptions-tab>&#9678;</label>
+
+<span class=toggle-seperator>&#9168;</span>
+
+<input type=radio id=blocks-tab name=toggle>
+<label for=blocks-tab>&#9633;</label>
+
+<div class=tab-content>
+  <h2>Latest Inscriptions</h2>
+  <div class=thumbnails>
+    <a href=/inscription/1{64}i1><iframe .* src=/preview/1{64}i1></iframe></a>
+    <a href=/inscription/2{64}i2><iframe .* src=/preview/2{64}i2></iframe></a>
+  </div>
+  <div class=center><a href=/inscriptions>more</a></div>
 </div>
-<div class=center><a href=/inscriptions>more</a></div>
-<h2>Latest Blocks</h2>
-<ol start=1260001 reversed class=blocks>
-  <li><a href=/block/1{64}>1{64}</a></li>
-  <li><a href=/block/0{64}>0{64}</a></li>
-</ol>
+
+<div class=tab-content>
+  <h2>Latest Blocks</h2>
+  <ol start=1260001 reversed class=blocks>
+    <li><a href=/block/1{64}>1{64}</a></li>
+    <li><a href=/block/0{64}>0{64}</a></li>
+  </ol>
+</div>.*
 ",
     );
   }

--- a/src/templates/home.rs
+++ b/src/templates/home.rs
@@ -52,14 +52,7 @@ mod tests {
         vec![inscription_id(1), inscription_id(2)],
       )
       .to_string(),
-      ".*<input type=radio id=inscriptions-tab name=toggle checked>
-<label for=inscriptions-tab>&#9678;</label>
-
-<span class=toggle-seperator>&#9168;</span>
-
-<input type=radio id=blocks-tab name=toggle>
-<label for=blocks-tab>&#9633;</label>
-
+      ".*
 <div class=tab-content>
   <h2>Latest Inscriptions</h2>
   <div class=thumbnails>

--- a/static/index.css
+++ b/static/index.css
@@ -16,6 +16,7 @@
 }
 
 html {
+  text-align: center;
   background-color: var(--dark-bg);
   color: var(--dark-fg);
 }
@@ -32,6 +33,10 @@ h1 {
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
+}
+
+h2 {
+  color: var(--light-fg);
 }
 
 iframe {
@@ -59,6 +64,7 @@ nav {
   display: flex;
   gap: 1rem;
   padding: 1rem;
+  margin-bottom: 1.5rem;
 }
 
 nav > :first-child {
@@ -229,4 +235,35 @@ a.mythic {
 
 .inscription > a > iframe {
   width: 100%;
+}
+
+.tab-content {
+   display: none;
+}
+
+#inscriptions-tab:checked ~ .tab-content:nth-of-type(1),
+#blocks-tab:checked ~ .tab-content:nth-of-type(2) {
+  display: block;
+}
+
+#inscriptions-tab:checked + label,
+#blocks-tab:checked + label {
+  color: var(--light-fg);
+  font-weight: bold;
+}
+
+label {
+  font-size: 32px;
+  border: none;
+  cursor: pointer;
+}
+
+.toggle-seperator {
+  font-size: 32px;
+  border: none;
+}
+
+input[type=radio] {
+  position: absolute;
+  left: -9999px;
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -11,12 +11,11 @@
   <h2>Latest Inscriptions</h2>
   <div class=thumbnails>
 %% for id in &self.inscriptions {
-  {{Iframe::thumbnail(*id)}}
+    {{Iframe::thumbnail(*id)}}
 %% }
   </div>
   <div class=center><a href=/inscriptions>more</a></div>
 </div>
-
 %% }
 
 <div class=tab-content>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,15 +1,29 @@
+<input type=radio id=inscriptions-tab name=toggle checked>
+<label for=inscriptions-tab>&#9678;</label>
+
+<span class=toggle-seperator>&#9168;</span>
+
+<input type=radio id=blocks-tab name=toggle>
+<label for=blocks-tab>&#9633;</label>
+
 %% if !&self.inscriptions.is_empty() {
-<h2>Latest Inscriptions</h2>
-<div class=thumbnails>
+<div class=tab-content>
+  <h2>Latest Inscriptions</h2>
+  <div class=thumbnails>
 %% for id in &self.inscriptions {
   {{Iframe::thumbnail(*id)}}
 %% }
+  </div>
+  <div class=center><a href=/inscriptions>more</a></div>
 </div>
-<div class=center><a href=/inscriptions>more</a></div>
+
 %% }
-<h2>Latest Blocks</h2>
-<ol start={{self.last}} reversed class=blocks>
+
+<div class=tab-content>
+  <h2>Latest Blocks</h2>
+  <ol start={{self.last}} reversed class=blocks>
 %% for hash in &self.blocks {
-  <li><a href=/block/{{hash}}>{{hash}}</a></li>
+    <li><a href=/block/{{hash}}>{{hash}}</a></li>
 %% }
-</ol>
+  </ol>
+</div>

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -200,9 +200,9 @@ fn home_page_includes_latest_inscriptions() {
     "/",
     format!(
       ".*<h2>Latest Inscriptions</h2>
-<div class=thumbnails>
-  <a href=/inscription/{inscription}><iframe .*></a>
-</div>.*",
+  <div class=thumbnails>
+    <a href=/inscription/{inscription}><iframe .*></a>
+  </div>.*",
     ),
   );
 }
@@ -218,7 +218,7 @@ fn home_page_inscriptions_are_sorted() {
     let Inscribe { inscription, .. } = inscribe(&rpc_server);
     inscriptions.insert_str(
       0,
-      &format!("\n  <a href=/inscription/{inscription}><iframe .*></a>"),
+      &format!("\n    <a href=/inscription/{inscription}><iframe .*></a>"),
     );
   }
 
@@ -226,8 +226,8 @@ fn home_page_inscriptions_are_sorted() {
     "/",
     format!(
       ".*<h2>Latest Inscriptions</h2>
-<div class=thumbnails>{inscriptions}
-</div>.*"
+  <div class=thumbnails>{inscriptions}
+  </div>.*"
     ),
   );
 }


### PR DESCRIPTION
This is a proposal to change the layout of the landing page. Specifically to hide the list of recent blocks, since they usually aren't that interesting.

![Screenshot 2023-04-05 at 16 55 08](https://user-images.githubusercontent.com/25913312/230120427-817ab079-3d7d-4799-bfd5-ffc12f65eec3.png)
![Screenshot 2023-04-05 at 16 55 19](https://user-images.githubusercontent.com/25913312/230120437-8c685ba5-68e3-45f1-bedd-0bfdfa36819f.png)
