### PR TITLE
Json API for Ord

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,6 +2148,7 @@ name = "ord"
 version = "0.5.2"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "axum-server",
  "base64 0.21.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [".", "test-bitcoincore-rpc"]
 
 [dependencies]
 anyhow = { version = "1.0.56", features = ["backtrace"] }
+async-trait = "0.1.63"
 axum = { version = "0.6.1", features = ["headers"] }
 axum-server = "0.4.0"
 base64 = "0.21.0"

--- a/docs/src/guides/restapi.md
+++ b/docs/src/guides/restapi.md
@@ -16,6 +16,7 @@ Open endpoints require no Authentication.
 * [Sat details](#sat) : `GET /sat/:sat`
 * [Transaction details](#transaction) : `GET /tx/:tx`
 * [Output details](#output) : `GET /output/:tx`
+* [Address details](#address) : `GET /address/:address`
 * [Block details](#block) : `GET /block/:block_num`
 * [Content](#content) : `GET /content/:inscription_id`
 * [Preview (thumbnail)](#preview) : `GET /preview/:inscription_id`
@@ -264,6 +265,48 @@ Get transaction outputs.
   "script_pubkey": "OP_0 OP_PUSHBYTES_20 52551656d3a270e967a4627928e540aeb00d81ab", 
   "transaction": "ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039", 
   "value": 10000
+}
+```
+
+# Address
+
+Get inscriptions held by address.
+
+**URL** : `/address/:address`
+
+**URL Parameters** : `address=[string]` where `address` is the address on the blockchain.
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data**: `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links":
+  {
+    "self":
+    {
+      "href": "/address/rltc1qxdnvy4s3tnz8q8spj8cmkhz7j6dlf7mhksjtug"
+    }
+  },
+  "address": "rltc1qxdnvy4s3tnz8q8spj8cmkhz7j6dlf7mhksjtug",
+  "inscriptions":
+  [
+    {
+      "href": "/inscription/51308c35c3e6fe2d93d7b51bb77c9e99ed97bd2b58085a8ba7f04d1951dc4de9i0"
+    },
+    {
+      "href": "/inscription/5f651869974362575b57f461e06aa6c8d369cd7390f2d3f5b897232adcd9e1d9i0"
+    }
+  ]
 }
 ```
 

--- a/docs/src/guides/restapi.md
+++ b/docs/src/guides/restapi.md
@@ -1,0 +1,573 @@
+Rest API Documentation
+======================
+
+This API allows you to query the Ordinal block explorer as well as interact with 
+your wallet to create and manage inscriptions.
+
+Where full URLs are provided in responses they will be rendered as if service
+is running on 'https://ordinals.com/'.
+
+## Open Endpoints
+
+Open endpoints require no Authentication.
+
+* [Feed](#feed) : `GET /feed`
+* [Inscription details](#inscription) : `GET /inscription/:inscription_id`
+* [Sat details](#sat) : `GET /sat/:sat`
+* [Transaction details](#transaction) : `GET /tx/:tx`
+* [Output details](#output) : `GET /output/:tx`
+* [Block details](#block) : `GET /block/:block_num`
+* [Content](#content) : `GET /content/:inscription_id`
+* [Preview (thumbnail)](#preview) : `GET /preview/:inscription_id`
+
+## Endpoints that require Authentication
+
+The wallet endpoint require a valid API key `x-api-key` to be included in the header of the
+request. The API key is set with the `api_key` field in the `ord.yaml` located in the ordinal configuration directory.
+
+### Wallet Endpoints
+
+Endpoints for viewing and manipulating the Wallet that the Authenticated User
+has permissions to access.
+
+* [Get Wallet Balance](#balance) : `GET /wallet/balance`
+* [Create Wallet Receiving Address](#receive) : `GET /wallet/receive`
+* [See All Wallet Transactions](#receive) : `GET /wallet/transactions`
+* [Inscribe Inscription](#inscribe) : `POST /wallet/inscribe`
+* [Send Inscription](#send) : `POST /wallet/send`
+
+# Feed
+
+Get the latest Ordinal inscriptions (latest 300).
+
+**URL** : `/feed`
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data**: `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links": {
+    "inscriptions": [
+      {
+        "href": "/inscription/c2656bb3907f6dc21c9297f631108fb165933d58b5f633dee619594e27c0d414i0",
+        "title": "Inscription 213970"
+      },
+      {
+        "href": "/inscription/9dc46c5494cc663b07294c3bfbfb10ee69204252e9c80de9b33d1245550d8e11i0",
+        "title": "Inscription 213969"
+      },
+      ... Results truncated
+    ]
+  }
+}
+```
+
+# Inscription
+
+Get the inscription details.
+
+**URL** : `/inscription/:inscription_id`
+
+**URL Parameters** : `inscription_id=[string]` where `inscription_id` is the ID of the Inscription on the
+explorer.
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data**: `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links": {
+    "content": {
+      "href": "/content/ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039i0"
+    }, 
+    "genesis_transaction": {
+      "href": "/tx/ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039"
+    }, 
+    "next": {
+      "href": "/inscription/632fac2718cb902eb2172d4b66e75e508d4f5ba9f2290df309959c1a5b8cc3fdi0"
+    }, 
+    "output": {
+      "href": "/output/ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039:0"
+    }, 
+    "prev": {
+      "href": "/inscription/5c34b2bc3ac76c4a4ce9fde4b6a6d7795d7835dfe6305c4cb4bb0cd026d63a5ci0"
+    }, 
+    "preview": {
+      "href": "/preview/ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039i0"
+    }, 
+    "sat": null, 
+    "self": {
+      "href": "/inscription/ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039i0"
+    }
+  }, 
+  "address": "ltc1q2f23v4kn5fcwjeayvfuj3e2q46cqmqdtzd4mec", 
+  "content_length": 21039, 
+  "content_type": "image/png", 
+  "genesis_fee": 5818, 
+  "genesis_height": 2442205, 
+  "genesis_transaction": "ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039", 
+  "location": "ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039:0:0", 
+  "number": 213966, 
+  "offset": 0, 
+  "output": "ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039:0", 
+  "sat": null, 
+  "timestamp": "2023-03-20 20:08:40 UTC"
+}
+```
+
+# Sat
+
+Get sat details.
+
+**URL** : `/sat/:sat`
+
+**URL Parameters** : `sat=[integer]` where `sat` is the sat number on the explorer.
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data**: `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links": {
+    "block": {
+      "href": "/block/0"
+    }, 
+    "inscription": null, 
+    "next": {
+      "href": "/sat/10000001"
+    }, 
+    "prev": {
+      "href": "/sat/9999999"
+    }, 
+    "self": {
+      "href": "/sat/10000000"
+    }
+  }, 
+  "block": 0, 
+  "cycle": 0, 
+  "decimal": "0.10000000", 
+  "degree": "0°0′0″10000000‴", 
+  "epoch": 0, 
+  "name": "bgmbqkpmtuab", 
+  "offset": 10000000, 
+  "percentile": "0.00000011904761917857144%", 
+  "period": 0, 
+  "rarity": "common", 
+  "timestamp": "2011-10-07 07:31:05 UTC"
+}
+```
+
+# Transaction
+
+Get transaction.
+
+**URL** : `/tx/:tx`
+
+**URL Parameters** : `tx=[string]` where `tx` is the transaction on the blockchain.
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data**: `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links": {
+    "block": null, 
+    "inputs": [
+      {
+        "href": "/output/4d4971a90f19470d244cb91e0ff2263af548b624fc1d102c983f7b29dbad8049:0"
+      }
+    ], 
+    "inscription": {
+      "href": "/inscription/ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039i0"
+    }, 
+    "outputs": [
+      {
+        "href": "/output/ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039:0"
+      }
+    ], 
+    "self": {
+      "href": "/tx/ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039"
+    }
+  }, 
+  "transaction": "ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039"
+}
+```
+
+# Output
+
+Get transaction outputs.
+
+**URL** : `/output/:tx`
+
+**URL Parameters** : `tx=[string]` where `tx` is the transaction on the blockchain.
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data**: `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links": {
+    "self": {
+      "href": "/output/ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039:0"
+    }, 
+    "transaction": {
+      "href": "/tx/ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039"
+    }
+  }, 
+  "address": "ltc1q2f23v4kn5fcwjeayvfuj3e2q46cqmqdtzd4mec", 
+  "script_pubkey": "OP_0 OP_PUSHBYTES_20 52551656d3a270e967a4627928e540aeb00d81ab", 
+  "transaction": "ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039", 
+  "value": 10000
+}
+```
+
+# Block
+
+Get block.
+
+**URL** : `/block/:block_num`
+
+**URL Parameters** : `block_num=[integer]` where `block_num` is the block number on the blockchain.
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data**: `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links": {
+    "prev": {
+      "href": "/block/12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2"
+    }, 
+    "self": {
+      "href": "/block/80ca095ed10b02e53d769eb6eaf92cd04e9e0759e5be4a8477b42911ba49c78f"
+    }
+  }, 
+  "hash": "80ca095ed10b02e53d769eb6eaf92cd04e9e0759e5be4a8477b42911ba49c78f", 
+  "previous_blockhash": "12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2", 
+  "size": 215, 
+  "target": "00000ffff0000000000000000000000000000000000000000000000000000000", 
+  "timestamp": "2011-10-08 06:29:19 UTC", 
+  "weight": 860
+}
+```
+
+# Content
+
+Get inscription content.
+
+**URL** : `/content/:inscription_id`
+
+**URL Parameters** : `inscription_id=[string]` where `inscription_id` is the inscription id on the explorer.
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data**: `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+`Response as file content.`
+
+# Preview
+
+Get inscription thumbnail preview.
+
+**URL** : `/preview/:inscription_id`
+
+**URL Parameters** : `inscription_id=[string]` where `inscription_id` is the inscription id on the explorer.
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data**: `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+`Response as thumbnail image preview of the content.`
+
+# Balance
+
+Get wallet balance.
+
+**URL** : `/wallet/balance`
+
+**Method** : `GET`
+
+**Auth required** : YES
+
+**Data** : `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links":
+  {
+    "self":
+    {
+      "href": "/wallet/balance"
+    }
+  },
+  "cardinal":29776159
+}
+```
+
+# Receive
+
+Generate a new receiving wallet address.
+
+**URL** : `/wallet/receive`
+
+**Method** : `GET`
+
+**Auth required** : YES
+
+**Data** : `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links":
+  {
+    "self":
+    {
+      "href": "/wallet/receive"
+    }
+  },
+  "address": "tltc1qxymtfz3kmcu72twmcwskq2dejhnnszsxj272s4"
+}
+```
+
+# Transactions
+
+See all wallet transactions.
+
+**URL** : `/wallet/transactions`
+
+**Method** : `GET`
+
+**Auth required** : YES
+
+**Data** : `{}`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links": {
+    "self": {
+      "href": "/wallet/transactions"
+    }
+  },
+  "count": 979,
+  "transactions": [
+    {
+      "_links": {
+        "transaction": {
+          "href": "/tx/92ba6106b74e6973af91dcc184966ba2751f26ce375982c455aa12cbcfc583c9"
+        }
+      },
+      "confirmations": 69799,
+      "transaction": "92ba6106b74e6973af91dcc184966ba2751f26ce375982c455aa12cbcfc583c9"
+    },
+    {
+      "_links": {
+        "transaction": {
+          "href": "/tx/9586f83204057e61633dcf98b1d609dfdb8c86770bb01e60e1d86f7b0f25600e"
+        }
+      },
+      "confirmations": 69463,
+      "transaction": "9586f83204057e61633dcf98b1d609dfdb8c86770bb01e60e1d86f7b0f25600e"
+    }
+  ]
+}
+```
+
+# Inscribe
+
+Inscribe an ordinal from your wallet.
+
+**URL** : `/wallet/inscribe`
+
+**Method** : `POST`
+
+**Auth required** : YES
+
+**Data constraints**
+
+Provide details for the ordinal to be sent.
+
+```json
+{
+  "destination": "[destination address]",
+  "fee_rate": "[decimal]",
+  "no_backup": [boolean],
+  "no_limit": [boolean],
+  "dry_run": [boolean],
+  "file": "[file path]"
+}
+```
+
+**Data example** All fields must be sent.
+
+```json
+{
+  "destination": "tltc1qxymtfz3kmcu72twmcwskq2dejhnnszsxj272s4",
+  "fee_rate": "1.1",
+  "no_backup": false,
+  "no_limit": false,
+  "dry_run": false, 
+  "file": "C:\\ord\\upload\\file.png"
+}
+```
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links": 
+  {
+    "self":
+    {
+      "href": "/wallet/inscribe"
+    }
+  },
+  "commit_tx": "cbc2eca5a0af2751bcb198dee36bbca969853e9304bed7dde593ac9f5ee5468c",
+  "reveal_tx": "29e8b65f0f0122c26c018a7e3e6ffeabb6e357f2f0f05bb97868f4b5ca158d6c",
+  "inscription_id": "29e8b65f0f0122c26c018a7e3e6ffeabb6e357f2f0f05bb97868f4b5ca158d6ci0",
+  "fees": 359
+}
+```
+
+# Send
+
+Send an ordinal from your wallet.
+
+**URL** : `/wallet/send`
+
+**Method** : `POST`
+
+**Auth required** : YES
+
+**Data constraints**
+
+Provide details for the ordinal to be sent.
+
+```json
+{
+  "fee_rate": "[decimal]",
+  "address": "[destination address]",
+  "outgoing": "[inscription id, satpoint, amount]"
+}
+```
+
+**Data example** All fields must be sent.
+
+```json
+{
+  "fee_rate": "1.3",
+  "address": "ltc1q2f23v4kn5fcwjeayvfuj3e2q46cqmqdtzd4mec",
+  "outgoing": "ae1266bdb59ba2794471100beea8ce6449d901e9ceead477f3e1fa61d841a039i0"
+}
+```
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+{
+  "_links":
+  {
+    "self":
+    {
+      "href": "/wallet/send"
+    }
+  },
+  "txid": "6904a154ceba5016e1b2b94f4c885bfc5c7a83c394e5fc1bd9553b934fd1d9c7"
+}
+```

--- a/docs/src/guides/restapi.md
+++ b/docs/src/guides/restapi.md
@@ -32,7 +32,7 @@ has permissions to access.
 
 * [Get Wallet Balance](#balance) : `GET /wallet/balance`
 * [Create Wallet Receiving Address](#receive) : `GET /wallet/receive`
-* [See All Wallet Transactions](#receive) : `GET /wallet/transactions`
+* [See All Wallet Transactions](#transactions) : `GET /wallet/transactions`
 * [Inscribe Inscription](#inscribe) : `POST /wallet/inscribe`
 * [Send Inscription](#send) : `POST /wallet/send`
 
@@ -65,12 +65,12 @@ Get the latest Ordinal inscriptions (latest 300).
       {
         "href": "/inscription/9dc46c5494cc663b07294c3bfbfb10ee69204252e9c80de9b33d1245550d8e11i0",
         "title": "Inscription 213969"
-      },
-      ... Results truncated
+      }
     ]
   }
 }
 ```
+`Results truncated`
 
 # Inscription
 
@@ -460,6 +460,7 @@ See all wallet transactions.
   ]
 }
 ```
+`Results truncated`
 
 # Inscribe
 
@@ -479,9 +480,9 @@ Provide details for the ordinal to be sent.
 {
   "destination": "[destination address]",
   "fee_rate": "[decimal]",
-  "no_backup": [boolean],
-  "no_limit": [boolean],
-  "dry_run": [boolean],
+  "no_backup": "[boolean]",
+  "no_limit": "[boolean]",
+  "dry_run": "[boolean]",
   "file": "[file path]"
 }
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use super::*;
 
 #[derive(Deserialize, Default, PartialEq, Debug)]
 pub(crate) struct Config {
+  pub(crate) api_key: Option<String>,
   pub(crate) hidden: HashSet<InscriptionId>,
 }
 
@@ -26,6 +27,7 @@ mod tests {
       .unwrap();
 
     let config = Config {
+      api_key: None,
       hidden: iter::once(a).collect(),
     };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use super::*;
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
   pub(crate) api_key: Option<String>,
+  pub(crate) api_wallet_enable: Option<bool>,
   pub(crate) hidden: HashSet<InscriptionId>,
   pub(crate) bitcoin_rpc_pass: Option<String>,
   pub(crate) bitcoin_rpc_user: Option<String>,

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Serialize)]
 pub(crate) struct Decimal {
   height: Height,
   offset: u64,

--- a/src/degree.rs
+++ b/src/degree.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Serialize)]
 pub(crate) struct Degree {
   pub(crate) hour: u64,
   pub(crate) minute: u64,

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Display, PartialOrd)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Display, PartialOrd, Serialize)]
 pub(crate) struct Epoch(pub(crate) u64);
 
 impl Epoch {

--- a/src/fee_rate.rs
+++ b/src/fee_rate.rs
@@ -32,18 +32,18 @@ impl Serialize for FeeRate {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
   where
     S: Serializer,
-{
-  serializer.collect_str(self)
-}
+  {
+    serializer.collect_str(self)
+  }
 }
 
 impl<'de> Deserialize<'de> for FeeRate {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where
     D: Deserializer<'de>,
-{
-  Ok(DeserializeFromStr::deserialize(deserializer)?.0)
-}
+  {
+    Ok(DeserializeFromStr::deserialize(deserializer)?.0)
+  }
 }
 
 impl FeeRate {

--- a/src/fee_rate.rs
+++ b/src/fee_rate.rs
@@ -22,6 +22,30 @@ impl TryFrom<f64> for FeeRate {
   }
 }
 
+impl Display for FeeRate {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    write!(f, "{}", self.0)
+  }
+}
+
+impl Serialize for FeeRate {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+  {
+    serializer.collect_str(self)
+  }
+}
+
+impl<'de> Deserialize<'de> for FeeRate {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+  {
+    Ok(DeserializeFromStr::deserialize(deserializer)?.0)
+  }
+}
+
 impl FeeRate {
   pub(crate) fn fee(&self, vsize: usize) -> Amount {
     #[allow(clippy::cast_possible_truncation)]

--- a/src/fee_rate.rs
+++ b/src/fee_rate.rs
@@ -30,20 +30,20 @@ impl Display for FeeRate {
 
 impl Serialize for FeeRate {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-  {
-    serializer.collect_str(self)
-  }
+  where
+    S: Serializer,
+{
+  serializer.collect_str(self)
+}
 }
 
 impl<'de> Deserialize<'de> for FeeRate {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-  {
-    Ok(DeserializeFromStr::deserialize(deserializer)?.0)
-  }
+  where
+    D: Deserializer<'de>,
+{
+  Ok(DeserializeFromStr::deserialize(deserializer)?.0)
+}
 }
 
 impl FeeRate {

--- a/src/height.rs
+++ b/src/height.rs
@@ -1,6 +1,7 @@
 use super::*;
 
-#[derive(Copy, Clone, Debug, Display, FromStr, Ord, Eq, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Display, FromStr, Ord, Eq, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
 pub(crate) struct Height(pub(crate) u64);
 
 impl Height {

--- a/src/index.rs
+++ b/src/index.rs
@@ -9,7 +9,7 @@ use {
   super::*,
   crate::wallet::Wallet,
   bitcoin::BlockHeader,
-  bitcoincore_rpc::{json::GetBlockHeaderResult, Client},
+  bitcoincore_rpc::{json::GetBlockHeaderResult, json::GetRawTransactionResult, Client},
   chrono::SubsecRound,
   indicatif::{ProgressBar, ProgressStyle},
   log::log_enabled,
@@ -573,6 +573,7 @@ impl Index {
     }
   }
 
+  #[allow(dead_code)]
   pub(crate) fn get_transaction_blockhash(&self, txid: Txid) -> Result<Option<BlockHash>> {
     Ok(
       self
@@ -598,6 +599,13 @@ impl Index {
         .and_then(|info| info.in_active_chain)
         .unwrap_or(false),
     )
+  }
+
+  pub(crate) fn get_raw_transaction(&self, txid: Txid) -> Result<Option<GetRawTransactionResult>> {
+    self
+      .client
+      .get_raw_transaction_info(&txid, None)
+      .into_option()
   }
 
   pub(crate) fn find(&self, sat: u64) -> Result<Option<SatPoint>> {

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -143,3 +143,15 @@ impl Entry for SatRange {
     n.to_le_bytes()[0..11].try_into().unwrap()
   }
 }
+
+impl Entry for u64 {
+  type Value = [u8; 8];
+
+  fn load([b0, b1, b2, b3, b4, b5, b6, b7]: Self::Value) -> Self {
+    u64::from_le_bytes([b0, b1, b2, b3, b4, b5, b6, b7])
+  }
+
+  fn store(self) -> Self::Value {
+    self.to_le_bytes()
+  }
+}

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -409,6 +409,7 @@ impl Updater {
     let mut inscription_id_to_satpoint = wtx.open_table(INSCRIPTION_ID_TO_SATPOINT)?;
     let mut inscription_number_to_inscription_id =
       wtx.open_table(INSCRIPTION_NUMBER_TO_INSCRIPTION_ID)?;
+    let mut address_to_inscription_number = wtx.open_table(ADDRESS_TO_INSCRIPTION_NUMBERS)?;
     let mut sat_to_inscription_id = wtx.open_table(SAT_TO_INSCRIPTION_ID)?;
     let mut satpoint_to_inscription_id = wtx.open_table(SATPOINT_TO_INSCRIPTION_ID)?;
     let mut statistic_to_count = wtx.open_table(STATISTIC_TO_COUNT)?;
@@ -419,12 +420,14 @@ impl Updater {
       .unwrap_or(0);
 
     let mut inscription_updater = InscriptionUpdater::new(
+      index,
       self.height,
       &mut inscription_id_to_satpoint,
       value_receiver,
       &mut inscription_id_to_inscription_entry,
       lost_sats,
       &mut inscription_number_to_inscription_id,
+      &mut address_to_inscription_number,
       &mut outpoint_to_value,
       &mut sat_to_inscription_id,
       &mut satpoint_to_inscription_id,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -136,6 +136,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
             outpoint: unbound_outpoint(),
             offset: self.unbound_inscriptions,
           },
+          None,
         )?;
         self.unbound_inscriptions += 1;
       } else {

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -214,7 +214,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
       Origin::Old(old_satpoint) => {
         self.satpoint_to_id.remove(&old_satpoint.store())?;
 
-        let entry = self.id_to_entry.get(&inscription_id).unwrap().unwrap().value();
+        let entry = self.id_to_entry.get(&inscription_id)?.unwrap().value();
         inscription_number = entry.2;
 
         if let Some(old_output) = self

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -214,9 +214,8 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
       Origin::Old(old_satpoint) => {
         self.satpoint_to_id.remove(&old_satpoint.store())?;
 
-        if let Some(entry) = self.index.get_inscription_entry(flotsam.inscription_id)? {
-          inscription_number = entry.number;
-        }
+        let entry = self.id_to_entry.get(&inscription_id).unwrap().unwrap().value();
+        inscription_number = entry.2;
 
         if let Some(old_output) = self
           .index

--- a/src/options.rs
+++ b/src/options.rs
@@ -560,6 +560,7 @@ mod tests {
         .load_config()
         .unwrap(),
       Config {
+        api_key: None,
         hidden: iter::once(id).collect(),
       }
     );
@@ -591,6 +592,7 @@ mod tests {
       .load_config()
       .unwrap(),
       Config {
+        api_key: None,
         hidden: iter::once(id).collect(),
       }
     );

--- a/src/outgoing.rs
+++ b/src/outgoing.rs
@@ -7,6 +7,15 @@ pub(crate) enum Outgoing {
   SatPoint(SatPoint),
 }
 
+impl<'de> Deserialize<'de> for Outgoing {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+  {
+    Ok(DeserializeFromStr::deserialize(deserializer)?.0)
+  }
+}
+
 impl FromStr for Outgoing {
   type Err = Error;
 

--- a/src/outgoing.rs
+++ b/src/outgoing.rs
@@ -9,8 +9,8 @@ pub(crate) enum Outgoing {
 
 impl<'de> Deserialize<'de> for Outgoing {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
+  where
+    D: Deserializer<'de>,
   {
     Ok(DeserializeFromStr::deserialize(deserializer)?.0)
   }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1028,6 +1028,14 @@ impl Server {
       .nth(satpoint.outpoint.vout.try_into().unwrap())
       .ok_or_not_found(|| format!("inscription {inscription_id} current transaction output"))?;
 
+    let genesis_output = index
+        .get_transaction(inscription_id.txid)?
+        .ok_or_not_found(|| format!("inscription {inscription_id} current transaction"))?
+        .output
+        .into_iter()
+        .nth(0)
+        .ok_or_not_found(|| format!("inscription {inscription_id} genesis transaction output"))?;
+
     let previous = if let Some(previous) = entry.number.checked_sub(1) {
       Some(
         index
@@ -1045,6 +1053,7 @@ impl Server {
         "genesis_fee": entry.fee,
         "genesis_height": entry.height,
         "genesis_transaction": inscription_id.txid,
+        "genesis_address": page_config.chain.address_from_script(&genesis_output.script_pubkey).unwrap(),
         "address": page_config.chain.address_from_script(&output.script_pubkey).unwrap(),
         "number": entry.number,
         "content_length": inscription.content_length(),
@@ -1093,6 +1102,7 @@ impl Server {
         chain: page_config.chain,
         genesis_fee: entry.fee,
         genesis_height: entry.height,
+        genesis_output: genesis_output,
         inscription,
         inscription_id,
         next,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -5,7 +5,6 @@ use {
     error::{OptionExt, ServerError, ServerResult},
   },
   super::*,
-  crate::wallet::Wallet,
   crate::page_config::PageConfig,
   crate::subcommand::wallet::transactions::Output,
   crate::templates::{
@@ -13,6 +12,7 @@ use {
     PageContent, PageHtml, PreviewAudioHtml, PreviewImageHtml, PreviewPdfHtml, PreviewTextHtml,
     PreviewUnknownHtml, PreviewVideoHtml, RangeHtml, RareTxt, SatHtml, TransactionHtml,
   },
+  crate::wallet::Wallet,
   axum::{
     body,
     extract::{Extension, Path, Query},
@@ -30,6 +30,7 @@ use {
     caches::DirCache,
     AcmeConfig,
   },
+  std::collections::BTreeSet,
   std::{cmp::Ordering, str},
   tokio_stream::StreamExt,
   tower_http::{
@@ -37,7 +38,6 @@ use {
     cors::{Any, CorsLayer},
     set_header::SetResponseHeaderLayer,
   },
-  std::collections::BTreeSet,
 };
 
 mod accept_json;
@@ -1107,9 +1107,12 @@ impl Server {
     Extension(config): Extension<Arc<Config>>,
     Extension(client): Extension<Arc<Client>>,
     accept_json: AcceptJson,
+    header: HeaderMap,
   ) -> ServerResult<Response> {
-    if config.api_key.is_none() || !header.contains_key("x-api-key") ||
-        config.api_key.as_ref().unwrap().as_str() != header.get("x-api-key").unwrap() {
+    if config.api_key.is_none()
+      || !header.contains_key("x-api-key")
+      || config.api_key.as_ref().unwrap().as_str() != header.get("x-api-key").unwrap()
+    {
       return Err(ServerError::Unauthorized(
         "Authentication failure".to_string(),
       ));
@@ -1167,9 +1170,12 @@ impl Server {
     Extension(config): Extension<Arc<Config>>,
     Extension(options): Extension<Arc<Options>>,
     accept_json: AcceptJson,
+    header: HeaderMap,
   ) -> ServerResult<Response> {
-    if config.api_key.is_none() || !header.contains_key("x-api-key") ||
-        config.api_key.as_ref().unwrap().as_str() != header.get("x-api-key").unwrap() {
+    if config.api_key.is_none()
+      || !header.contains_key("x-api-key")
+      || config.api_key.as_ref().unwrap().as_str() != header.get("x-api-key").unwrap()
+    {
       return Err(ServerError::Unauthorized(
         "Authentication failure".to_string(),
       ));
@@ -1181,10 +1187,10 @@ impl Server {
     }
 
     let inscription_outputs = index
-        .get_inscriptions(None)?
-        .keys()
-        .map(|satpoint| satpoint.outpoint)
-        .collect::<BTreeSet<OutPoint>>();
+      .get_inscriptions(None)?
+      .keys()
+      .map(|satpoint| satpoint.outpoint)
+      .collect::<BTreeSet<OutPoint>>();
 
     let mut balance = 0;
     for (outpoint, amount) in index.get_unspent_outputs(Wallet::load(&options)?)? {
@@ -1202,7 +1208,7 @@ impl Server {
           },
         }
       }))
-      .into_response()
+      .into_response(),
     )
   }
 
@@ -1212,8 +1218,10 @@ impl Server {
     accept_json: AcceptJson,
     header: HeaderMap,
   ) -> ServerResult<Response> {
-    if config.api_key.is_none() || !header.contains_key("x-api-key") ||
-        config.api_key.as_ref().unwrap().as_str() != header.get("x-api-key").unwrap() {
+    if config.api_key.is_none()
+      || !header.contains_key("x-api-key")
+      || config.api_key.as_ref().unwrap().as_str() != header.get("x-api-key").unwrap()
+    {
       return Err(ServerError::Unauthorized(
         "Authentication failure".to_string(),
       ));

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1167,10 +1167,6 @@ impl Server {
       )));
     }
     for tx in transactions.unwrap() {
-      if tx.detail.vout.is_none() {
-        // MWEB transactions do not have a vout
-        continue;
-      }
       outputs.push(Output {
         transaction: tx.info.txid,
         confirmations: tx.info.confirmations,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -6,7 +6,7 @@ use {
   },
   super::*,
   crate::page_config::PageConfig,
-  crate::subcommand::wallet::transactions::Output,
+  crate::subcommand::wallet::{inscribe, send, transactions::Output},
   crate::templates::{
     BlockHtml, ClockSvg, HomeHtml, InputHtml, InscriptionHtml, InscriptionsHtml, OutputHtml,
     PageContent, PageHtml, PreviewAudioHtml, PreviewImageHtml, PreviewPdfHtml, PreviewTextHtml,
@@ -15,7 +15,7 @@ use {
   crate::wallet::Wallet,
   axum::{
     body,
-    extract::{Extension, Path, Query, Json},
+    extract::{Extension, Json, Path, Query},
     headers::UserAgent,
     http::{header, HeaderMap, HeaderValue, StatusCode, Uri},
     response::{IntoResponse, Redirect, Response},
@@ -40,8 +40,6 @@ use {
     set_header::SetResponseHeaderLayer,
   },
 };
-use crate::subcommand::wallet::inscribe;
-use crate::subcommand::wallet::send;
 
 mod accept_json;
 mod error;
@@ -1274,8 +1272,8 @@ impl Server {
     Json(inscribe): Json<inscribe::Inscribe>,
   ) -> ServerResult<Response> {
     if config.api_key.is_none()
-        || !header.contains_key("x-api-key")
-        || config.api_key.as_ref().unwrap().as_str() != header.get("x-api-key").unwrap()
+      || !header.contains_key("x-api-key")
+      || config.api_key.as_ref().unwrap().as_str() != header.get("x-api-key").unwrap()
     {
       return Err(ServerError::Unauthorized(
         "Authentication failure".to_string(),
@@ -1321,8 +1319,8 @@ impl Server {
     Json(send): Json<send::Send>,
   ) -> ServerResult<Response> {
     if config.api_key.is_none()
-        || !header.contains_key("x-api-key")
-        || config.api_key.as_ref().unwrap().as_str() != header.get("x-api-key").unwrap()
+      || !header.contains_key("x-api-key")
+      || config.api_key.as_ref().unwrap().as_str() != header.get("x-api-key").unwrap()
     {
       return Err(ServerError::Unauthorized(
         "Authentication failure".to_string(),
@@ -1345,7 +1343,7 @@ impl Server {
           },
         }
       }))
-          .into_response(),
+      .into_response(),
     )
   }
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1292,7 +1292,10 @@ impl Server {
 
     Ok(
       axum::Json(serde_json::json!({
-        "output": format!("{:?}", output),
+        "commit_tx": output.commit,
+        "reveal_tx": output.reveal,
+        "inscription_id": output.inscription,
+        "fees": output.fees,
         "_links": {
           "self": {
             "href": format!("/wallet/inscribe"),

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -665,7 +665,9 @@ impl Server {
     Extension(index): Extension<Arc<Index>>,
     Path(DeserializeFromStr(address)): Path<DeserializeFromStr<Address>>,
   ) -> ServerResult<Response> {
-    let inscription_ids = index.get_inscriptions_by_address(&address)?.unwrap();
+    let inscription_ids = index
+      .get_inscriptions_by_address(&address)?
+      .ok_or_not_found(|| format!("Address {address}"))?;
 
     Ok(
       axum::Json(serde_json::json!({

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -153,6 +153,7 @@ impl Server {
 
       let router = Router::new()
         .route("/", get(Self::home))
+        .route("/api", get(Self::api))
         .route("/block-count", get(Self::block_count))
         .route("/block/:query", get(Self::block))
         .route("/bounties", get(Self::bounties))
@@ -870,6 +871,10 @@ impl Server {
 
   async fn bounties() -> Redirect {
     Redirect::to("https://docs.ordinals.com/bounty/")
+  }
+
+  async fn api() -> Redirect {
+    Redirect::to("https://ynohtna92.github.io/ord-litecoin/guides/restapi.html")
   }
 
   async fn content(

--- a/src/subcommand/server/accept_json.rs
+++ b/src/subcommand/server/accept_json.rs
@@ -1,0 +1,24 @@
+use super::*;
+
+pub(crate) struct AcceptJson(pub(crate) bool);
+
+#[async_trait::async_trait]
+impl<S> axum::extract::FromRequestParts<S> for AcceptJson
+where
+  S: Send + Sync,
+{
+  type Rejection = ();
+
+  async fn from_request_parts(
+    parts: &mut http::request::Parts,
+    _state: &S,
+  ) -> Result<Self, Self::Rejection> {
+    Ok(Self(
+      parts
+        .headers
+        .get("accept")
+        .map(|value| value == "application/json")
+        .unwrap_or_default(),
+    ))
+  }
+}

--- a/src/subcommand/server/error.rs
+++ b/src/subcommand/server/error.rs
@@ -3,6 +3,7 @@ use super::*;
 pub(super) enum ServerError {
   Internal(Error),
   BadRequest(String),
+  Unauthorized(String),
   NotFound(String),
 }
 
@@ -21,6 +22,7 @@ impl IntoResponse for ServerError {
         )
           .into_response()
       }
+      Self::Unauthorized(message) => (StatusCode::UNAUTHORIZED, message).into_response(),
       Self::NotFound(message) => (StatusCode::NOT_FOUND, message).into_response(),
       Self::BadRequest(message) => (StatusCode::BAD_REQUEST, message).into_response(),
     }

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -80,12 +80,12 @@ impl Inscribe {
     inscriptions: BTreeMap<SatPoint, InscriptionId>,
     client: &Client,
   ) -> Result<Output> {
-    let commit_tx_change = [get_change_address(&client)?, get_change_address(&client)?];
+    let commit_tx_change = [get_change_address(client)?, get_change_address(client)?];
 
     let reveal_tx_destination = self
       .destination
       .map(Ok)
-      .unwrap_or_else(|| get_change_address(&client))?;
+      .unwrap_or_else(|| get_change_address(client))?;
 
     let (unsigned_commit_tx, reveal_tx, _recovery_key_pair) =
       Inscribe::create_inscription_transactions(

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -72,27 +72,34 @@ impl Inscribe {
     Ok(())
   }
 
-  pub fn inscribe(self, options: &Options, inscription: Inscription, mut utxos: BTreeMap<OutPoint, Amount>, inscriptions: BTreeMap<SatPoint, InscriptionId>, client: &Client) -> Result<Output> {
+  pub fn inscribe(
+    self,
+    options: &Options,
+    inscription: Inscription,
+    mut utxos: BTreeMap<OutPoint, Amount>,
+    inscriptions: BTreeMap<SatPoint, InscriptionId>,
+    client: &Client,
+  ) -> Result<Output> {
     let commit_tx_change = [get_change_address(&client)?, get_change_address(&client)?];
 
     let reveal_tx_destination = self
-        .destination
-        .map(Ok)
-        .unwrap_or_else(|| get_change_address(&client))?;
+      .destination
+      .map(Ok)
+      .unwrap_or_else(|| get_change_address(&client))?;
 
     let (unsigned_commit_tx, reveal_tx, _recovery_key_pair) =
-        Inscribe::create_inscription_transactions(
-          self.satpoint,
-          inscription,
-          inscriptions,
-          options.chain().network(),
-          utxos.clone(),
-          commit_tx_change,
-          reveal_tx_destination,
-          self.commit_fee_rate.unwrap_or(self.fee_rate),
-          self.fee_rate,
-          self.no_limit,
-        )?;
+      Inscribe::create_inscription_transactions(
+        self.satpoint,
+        inscription,
+        inscriptions,
+        options.chain().network(),
+        utxos.clone(),
+        commit_tx_change,
+        reveal_tx_destination,
+        self.commit_fee_rate.unwrap_or(self.fee_rate),
+        self.fee_rate,
+        self.no_limit,
+      )?;
 
     utxos.insert(
       reveal_tx.input[0].previous_output,
@@ -102,7 +109,7 @@ impl Inscribe {
     );
 
     let fees =
-        Self::calculate_fee(&unsigned_commit_tx, &utxos) + Self::calculate_fee(&reveal_tx, &utxos);
+      Self::calculate_fee(&unsigned_commit_tx, &utxos) + Self::calculate_fee(&reveal_tx, &utxos);
 
     if self.dry_run {
       Ok(Output {
@@ -117,16 +124,16 @@ impl Inscribe {
       }
 
       let signed_raw_commit_tx = client
-          .sign_raw_transaction_with_wallet(&unsigned_commit_tx, None, None)?
-          .hex;
+        .sign_raw_transaction_with_wallet(&unsigned_commit_tx, None, None)?
+        .hex;
 
       let commit = client
-          .send_raw_transaction(&signed_raw_commit_tx)
-          .context("Failed to send commit transaction")?;
+        .send_raw_transaction(&signed_raw_commit_tx)
+        .context("Failed to send commit transaction")?;
 
       let reveal = client
-          .send_raw_transaction(&reveal_tx)
-          .context("Failed to send reveal transaction")?;
+        .send_raw_transaction(&reveal_tx)
+        .context("Failed to send reveal transaction")?;
 
       Ok(Output {
         commit,

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -87,7 +87,7 @@ impl Inscribe {
       .map(Ok)
       .unwrap_or_else(|| get_change_address(client))?;
 
-    let (unsigned_commit_tx, reveal_tx, _recovery_key_pair) =
+    let (unsigned_commit_tx, reveal_tx, recovery_key_pair) =
       Inscribe::create_inscription_transactions(
         self.satpoint,
         inscription,

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -41,7 +41,7 @@ impl Send {
     index: &Index,
     client: &Client,
   ) -> Result<Txid> {
-    let unspent_outputs = index.get_unspent_outputs(Wallet::load(&options)?)?;
+    let unspent_outputs = index.get_unspent_outputs(Wallet::load(options)?)?;
 
     let inscriptions = index.get_inscriptions(None)?;
 
@@ -80,7 +80,7 @@ impl Send {
       }
     };
 
-    let change = [get_change_address(&client)?, get_change_address(&client)?];
+    let change = [get_change_address(client)?, get_change_address(client)?];
 
     let unsigned_transaction = TransactionBuilder::build_transaction_with_postage(
       satpoint,

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -35,7 +35,12 @@ impl Send {
     Ok(())
   }
 
-  pub(crate) fn send_inscription(self, options: &Options, index: &Index, client: &Client) -> Result<Txid> {
+  pub(crate) fn send_inscription(
+    self,
+    options: &Options,
+    index: &Index,
+    client: &Client,
+  ) -> Result<Txid> {
     let unspent_outputs = index.get_unspent_outputs(Wallet::load(&options)?)?;
 
     let inscriptions = index.get_inscriptions(None)?;
@@ -50,26 +55,26 @@ impl Send {
         satpoint
       }
       Outgoing::InscriptionId(id) => index
-          .get_inscription_satpoint_by_id(id)?
-          .ok_or_else(|| anyhow!("Inscription {id} not found"))?,
+        .get_inscription_satpoint_by_id(id)?
+        .ok_or_else(|| anyhow!("Inscription {id} not found"))?,
       Outgoing::Amount(amount) => {
         let all_inscription_outputs = inscriptions
-            .keys()
-            .map(|satpoint| satpoint.outpoint)
-            .collect::<HashSet<OutPoint>>();
+          .keys()
+          .map(|satpoint| satpoint.outpoint)
+          .collect::<HashSet<OutPoint>>();
 
         let wallet_inscription_outputs = unspent_outputs
-            .keys()
-            .filter(|utxo| all_inscription_outputs.contains(utxo))
-            .cloned()
-            .collect::<Vec<OutPoint>>();
+          .keys()
+          .filter(|utxo| all_inscription_outputs.contains(utxo))
+          .cloned()
+          .collect::<Vec<OutPoint>>();
 
         if !client.lock_unspent(&wallet_inscription_outputs)? {
           bail!("failed to lock ordinal UTXOs");
         }
 
         let txid =
-            client.send_to_address(&self.address, amount, None, None, None, None, None, None)?;
+          client.send_to_address(&self.address, amount, None, None, None, None, None, None)?;
 
         return Ok(txid);
       }
@@ -87,8 +92,8 @@ impl Send {
     )?;
 
     let signed_tx = client
-        .sign_raw_transaction_with_wallet(&unsigned_transaction, None, None)?
-        .hex;
+      .sign_raw_transaction_with_wallet(&unsigned_transaction, None, None)?
+      .hex;
 
     let txid = client.send_raw_transaction(&signed_tx)?;
 

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -76,7 +76,7 @@ mod tests {
           <dt>genesis transaction</dt>
           <dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
           <dt>genesis address</dt>
-          <dd class=monospace>ltc1qw508d6qejxtdg4y5r3zarvary0c5xw7kgmn4n9</dd>
+          <dd class=monospace>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</dd>
           <dt>location</dt>
           <dd class=monospace>1{64}:1:0</dd>
           <dt>output</dt>
@@ -96,6 +96,7 @@ mod tests {
         chain: Chain::Mainnet,
         genesis_fee: 1,
         genesis_height: 0,
+        genesis_output: tx_out(1, address()),
         inscription: inscription("text/plain;charset=utf-8", "HELLOWORLD"),
         inscription_id: inscription_id(1),
         next: None,

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -5,6 +5,7 @@ pub(crate) struct InscriptionHtml {
   pub(crate) chain: Chain,
   pub(crate) genesis_fee: u64,
   pub(crate) genesis_height: u64,
+  pub(crate) genesis_output: TxOut,
   pub(crate) inscription: Inscription,
   pub(crate) inscription_id: InscriptionId,
   pub(crate) next: Option<InscriptionId>,
@@ -37,6 +38,7 @@ mod tests {
         chain: Chain::Mainnet,
         genesis_fee: 1,
         genesis_height: 0,
+        genesis_output: tx_out(1, address()),
         inscription: inscription("text/plain;charset=utf-8", "HELLOWORLD"),
         inscription_id: inscription_id(1),
         next: None,
@@ -77,6 +79,8 @@ mod tests {
           <dd>1</dd>
           <dt>genesis transaction</dt>
           <dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
+          <dt>genesis address</dt>
+          <dd class=monospace>ltc1qw508d6qejxtdg4y5r3zarvary0c5xw7kgmn4n9</dd>
           <dt>location</dt>
           <dd class=monospace>1{64}:1:0</dd>
           <dt>output</dt>
@@ -96,6 +100,7 @@ mod tests {
         chain: Chain::Mainnet,
         genesis_fee: 1,
         genesis_height: 0,
+        genesis_output: tx_out(1, address()),
         inscription: inscription("text/plain;charset=utf-8", "HELLOWORLD"),
         inscription_id: inscription_id(1),
         next: None,
@@ -128,6 +133,7 @@ mod tests {
         chain: Chain::Mainnet,
         genesis_fee: 1,
         genesis_height: 0,
+        genesis_output: tx_out(1, address()),
         inscription: inscription("text/plain;charset=utf-8", "HELLOWORLD"),
         inscription_id: inscription_id(2),
         next: Some(inscription_id(3)),

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -45,6 +45,10 @@
   <dd>{{ self.genesis_fee }}</dd>
   <dt>genesis transaction</dt>
   <dd><a class=monospace href=/tx/{{ self.inscription_id.txid }}>{{ self.inscription_id.txid }}</a></dd>
+%% if let Ok(address) = self.chain.address_from_script(&self.genesis_output.script_pubkey ) {
+  <dt>genesis address</dt>
+  <dd class=monospace>{{ address }}</dd>
+%% }
   <dt>location</dt>
   <dd class=monospace>{{ self.satpoint }}</dd>
   <dt>output</dt>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -14,7 +14,7 @@ use {
     net::TcpListener,
     path::Path,
     process::{Child, Command, Stdio},
-    str::{self, FromStr},
+    str::{self},
     thread,
     time::Duration,
   },

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,3 +1,4 @@
+use ord::subcommand::wallet::send;
 use {super::*, crate::command_builder::ToArgs};
 
 #[test]
@@ -77,6 +78,8 @@ fn inscription_page() {
   <dd>138</dd>
   <dt>genesis transaction</dt>
   <dd><a class=monospace href=/tx/{reveal}>{reveal}</a></dd>
+  <dt>genesis address</dt>
+  <dd class=monospace>bc1.*</dd>
   <dt>location</dt>
   <dd class=monospace>{reveal}:0:0</dd>
   <dt>output</dt>
@@ -147,12 +150,11 @@ fn inscription_page_after_send() {
     "wallet send --fee-rate 1 bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv {inscription}"
   ))
   .rpc_server(&rpc_server)
-  .stdout_regex(".*")
-  .run();
+  .output::<send::Output>();
 
   rpc_server.mine_blocks(1);
 
-  let send = txid.trim();
+  let send = txid.transaction;
 
   let ord_server = TestServer::spawn_with_args(&rpc_server, &[]);
   ord_server.assert_response_regex(

--- a/tests/wallet/inscriptions.rs
+++ b/tests/wallet/inscriptions.rs
@@ -1,6 +1,6 @@
 use {
   super::*,
-  ord::subcommand::wallet::{inscriptions::Output, receive},
+  ord::subcommand::wallet::{inscriptions::Output, receive, send::Output as send},
 };
 
 #[test]
@@ -32,15 +32,15 @@ fn inscriptions() {
     .output::<receive::Output>()
     .address;
 
-  let stdout = CommandBuilder::new(format!("wallet send --fee-rate 1 {address} {inscription}"))
+  let output = CommandBuilder::new(format!("wallet send --fee-rate 1 {address} {inscription}"))
     .rpc_server(&rpc_server)
     .expected_exit_code(0)
     .stdout_regex(".*")
-    .run();
+    .output::<send>();
 
   rpc_server.mine_blocks(1);
 
-  let txid = Txid::from_str(stdout.trim()).unwrap();
+  let txid = output.transaction;
 
   let output = CommandBuilder::new("wallet inscriptions")
     .rpc_server(&rpc_server)

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -10,19 +10,19 @@ fn inscriptions_can_be_sent() {
 
   rpc_server.mine_blocks(1);
 
-  let stdout = CommandBuilder::new(format!(
+  let output = CommandBuilder::new(format!(
     "wallet send --fee-rate 1 bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4 {inscription}",
   ))
   .rpc_server(&rpc_server)
   .stdout_regex(r".*")
-  .run();
+  .output::<Output>();
 
   let txid = rpc_server.mempool()[0].txid();
-  assert_eq!(format!("{txid}\n"), stdout);
+  assert_eq!(format!("{txid}"), output.transaction.to_string());
 
   rpc_server.mine_blocks(1);
 
-  let send_txid = stdout.trim();
+  let send_txid = output.transaction;
 
   let ord_server = TestServer::spawn_with_args(&rpc_server, &[]);
   ord_server.assert_response_regex(
@@ -69,16 +69,16 @@ fn send_inscribed_sat() {
 
   rpc_server.mine_blocks(1);
 
-  let stdout = CommandBuilder::new(format!(
+  let output = CommandBuilder::new(format!(
     "wallet send --fee-rate 1 bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv {inscription}",
   ))
   .rpc_server(&rpc_server)
-  .stdout_regex("[[:xdigit:]]{64}\n")
-  .run();
+  .stdout_regex(".*[[:xdigit:]]{64}.*")
+  .output::<Output>();
 
   rpc_server.mine_blocks(1);
 
-  let send_txid = stdout.trim();
+  let send_txid = output.transaction;
 
   let ord_server = TestServer::spawn_with_args(&rpc_server, &[]);
   ord_server.assert_response_regex(
@@ -102,7 +102,7 @@ fn send_on_mainnnet_works_with_wallet_named_foo() {
     "--wallet foo wallet send --fee-rate 1 bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4 {txid}:0:0"
   ))
   .rpc_server(&rpc_server)
-  .stdout_regex(r"[[:xdigit:]]{64}\n")
+  .stdout_regex(r".*[[:xdigit:]]{64}.*")
   .run();
 }
 
@@ -129,15 +129,15 @@ fn send_on_mainnnet_works_with_wallet_named_ord() {
   let txid = rpc_server.mine_blocks_with_subsidy(1, 1_000_000)[0].txdata[0].txid();
   create_wallet(&rpc_server);
 
-  let stdout = CommandBuilder::new(format!(
+  let output = CommandBuilder::new(format!(
     "wallet send --fee-rate 1 bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4 {txid}:0:0"
   ))
   .rpc_server(&rpc_server)
   .stdout_regex(r".*")
-  .run();
+  .output::<Output>();
 
   let txid = rpc_server.mempool()[0].txid();
-  assert_eq!(format!("{txid}\n"), stdout);
+  assert_eq!(format!("{txid}"), output.transaction.to_string());
 }
 
 #[test]
@@ -305,7 +305,7 @@ fn wallet_send_with_fee_rate() {
     "wallet send bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4 {inscription} --fee-rate 2.0"
   ))
   .rpc_server(&rpc_server)
-  .stdout_regex("[[:xdigit:]]{64}\n")
+  .stdout_regex(r".*[[:xdigit:]]{64}.*")
   .run();
 
   let tx = &rpc_server.mempool()[0];


### PR DESCRIPTION
Adds several json API endpoints following the API sketch @casey derived in https://github.com/casey/ord/pull/1662.

See [docs/src/guides/restapi.md](https://github.com/ynohtna92/ord-litecoin/blob/json-api/docs/src/guides/restapi.md) for full list of changes.

Things still to do:
- Fixes tests so they pass! Failing due to the wallet client having to be injected into server.rs resulting in mismatch of chain type when running tests
- Figure out how errors will be handled and shown. They need to be wrapped in json but only when accept_json.0 is true.