### PR TITLE
allow ajax requests from 'self' same origin within inscriptions

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -745,7 +745,7 @@ impl Server {
     );
     headers.insert(
       header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src 'unsafe-eval' 'unsafe-inline' data:; connect-src /content/;"),
+      HeaderValue::from_static("default-src 'unsafe-eval' 'unsafe-inline' data:; connect-src 'self';"),
     );
     headers.insert(
       header::CACHE_CONTROL,
@@ -2202,7 +2202,7 @@ mod tests {
     server.assert_response_csp(
       format!("/preview/{}", InscriptionId::from(txid)),
       StatusCode::OK,
-      "default-src 'unsafe-eval' 'unsafe-inline' data:; connect-src /content/;",
+      "default-src 'unsafe-eval' 'unsafe-inline' data:; connect-src 'self';",
       "hello",
     );
   }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -745,7 +745,7 @@ impl Server {
     );
     headers.insert(
       header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src 'unsafe-eval' 'unsafe-inline' data:"),
+      HeaderValue::from_static("default-src 'unsafe-eval' 'unsafe-inline' data:; connect-src /content/;"),
     );
     headers.insert(
       header::CACHE_CONTROL,
@@ -2202,7 +2202,7 @@ mod tests {
     server.assert_response_csp(
       format!("/preview/{}", InscriptionId::from(txid)),
       StatusCode::OK,
-      "default-src 'unsafe-eval' 'unsafe-inline' data:",
+      "default-src 'unsafe-eval' 'unsafe-inline' data:; connect-src /content/;",
       "hello",
     );
   }


### PR DESCRIPTION
Relating to discussion here:
https://github.com/ordinals/ord/issues/1082

Allow browser ajax requests to same origin `/content/` path for flexibility and composability in the ord protocol.