### PR TITLE
Recursive inscriptions

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -144,7 +144,6 @@ impl Server {
 
       let router = Router::new()
         .route("/", get(Self::home))
-        .route("/-/content/:inscription_id", get(Self::content))
         .route("/block-count", get(Self::block_count))
         .route("/block/:query", get(Self::block))
         .route("/bounties", get(Self::bounties))
@@ -750,7 +749,7 @@ impl Server {
     );
     headers.append(
       header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src *:*/-/ 'unsafe-eval' 'unsafe-inline' data:"),
+      HeaderValue::from_static("default-src *:*/content/ 'unsafe-eval' 'unsafe-inline' data:"),
     );
     headers.insert(
       header::CACHE_CONTROL,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -144,6 +144,7 @@ impl Server {
 
       let router = Router::new()
         .route("/", get(Self::home))
+        .route("/-/content/:inscription_id", get(Self::content))
         .route("/block-count", get(Self::block_count))
         .route("/block/:query", get(Self::block))
         .route("/bounties", get(Self::bounties))
@@ -745,7 +746,11 @@ impl Server {
     );
     headers.insert(
       header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src 'unsafe-eval' 'unsafe-inline' data:"),
+      HeaderValue::from_static("default-src 'self' 'unsafe-eval' 'unsafe-inline' data:"),
+    );
+    headers.append(
+      header::CONTENT_SECURITY_POLICY,
+      HeaderValue::from_static("default-src *:*/-/ 'unsafe-eval' 'unsafe-inline' data:"),
     );
     headers.insert(
       header::CACHE_CONTROL,
@@ -2202,7 +2207,7 @@ mod tests {
     server.assert_response_csp(
       format!("/preview/{}", InscriptionId::from(txid)),
       StatusCode::OK,
-      "default-src 'unsafe-eval' 'unsafe-inline' data:",
+      "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:",
       "hello",
     );
   }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -190,7 +190,7 @@ fn inscription_content() {
       .collect::<Vec<&http::HeaderValue>>(),
     &[
       "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:",
-      "default-src *:*/-/ 'unsafe-eval' 'unsafe-inline' data:"
+      "default-src *:*/content/ 'unsafe-eval' 'unsafe-inline' data:"
     ]
   );
   assert_eq!(response.bytes().unwrap(), "FOO");

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -183,8 +183,15 @@ fn inscription_content() {
     "text/plain;charset=utf-8"
   );
   assert_eq!(
-    response.headers().get("content-security-policy").unwrap(),
-    "default-src 'unsafe-eval' 'unsafe-inline' data:"
+    response
+      .headers()
+      .get_all("content-security-policy")
+      .into_iter()
+      .collect::<Vec<&http::HeaderValue>>(),
+    &[
+      "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:",
+      "default-src *:*/-/ 'unsafe-eval' 'unsafe-inline' data:"
+    ]
   );
   assert_eq!(response.bytes().unwrap(), "FOO");
 }


### PR DESCRIPTION
Modify inscription content security policy header to allow for requests to `/-/`-prefixed endpoints, and add a `/-/content/:inscription_id` endpoint to allow inscriptions to request the content of other inscriptions.

Two CSP headers are required because it is not possible in a single CSP header to specify a policy that restricts requests to sub-paths of the current origin. So, we use two CSP headers, one to limit requests to `'self'`, the current origin, and one to limit requests to `*:*/-/`, the `/-/` sub-path of any origin. Browsers check both CSP headers, which has the net effect of restricting requests to the `/-/` sub-path of the current origin. 

Restricts requests to `/-/` instead of `/content/` because we may wish to add more endpoints that inscriptions can access, for example block time or block height, and this allows putting them all under the `/-/` path prefix, instead of having to add them all to the CSP header.

Works in Chrome and Firefox, nothing loads in Safari. I'm guessing that Safari doesn't correctly implement checking multiple CSP headers.

Questions:
- Are we okay with Safari being broken?
- Is `/-/` reasonable, or should we just use `/content/`?

Closes #1082.