### PR TITLE
Update ord dependency in lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ord"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
Update the `ord` dependency in `Cargo.lock` to latest release.