### PR TITLE
Add blob urls to Content Security Policy headers

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -788,11 +788,11 @@ impl Server {
     );
     headers.insert(
       header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src 'self' 'unsafe-eval' 'unsafe-inline' data:"),
+      HeaderValue::from_static("default-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob:"),
     );
     headers.append(
       header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime 'unsafe-eval' 'unsafe-inline' data:"),
+      HeaderValue::from_static("default-src *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime 'unsafe-eval' 'unsafe-inline' data: blob:"),
     );
     headers.insert(
       header::CACHE_CONTROL,
@@ -2302,7 +2302,7 @@ mod tests {
     server.assert_response_csp(
       format!("/preview/{}", InscriptionId::from(txid)),
       StatusCode::OK,
-      "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:",
+      "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob:",
       "hello",
     );
   }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -189,8 +189,8 @@ fn inscription_content() {
       .into_iter()
       .collect::<Vec<&http::HeaderValue>>(),
     &[
-      "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:",
-      "default-src *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime 'unsafe-eval' 'unsafe-inline' data:",
+      "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob:",
+      "default-src *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime 'unsafe-eval' 'unsafe-inline' data: blob:",
     ]
   );
   assert_eq!(response.bytes().unwrap(), "FOO");


### PR DESCRIPTION
This PR is to allow HTML/JS inscriptions to use Blob urls by adding it to the Content Security Policy headers.

### Why is this needed?

I am creating a javascript inscription where I draw some stuff onto a canvas, then convert that canvas into a HTML img. I have successfully done this with the following JS code:
```javascript
let canvas = document.createElement('canvas')
// Draw stuff onto canvas...
let img = document.querySelector('img')
img.src = canvas.toDataURL('image/png')
```
This works because `data:` is included in the Content Security Policy, so data urls are allowed. However, many sources state that blob urls should be used over data urls because they are more performant. So, I would like to do something like this:
```javascript
let canvas = new OffscreenCanvas(1024, 1024)
// Draw stuff onto canvas...
let img = document.querySelector('img')
img.src = URL.createObjectURL(await canvas.convertToBlob())
```
However, this gets blocked because blob urls are not included in the Content Security Policy.

Two errors get reported from this:
```
Refused to load the image 'blob:<URL>' because it violates the following Content Security Policy directive: "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback.
```
```
Refused to load the image 'blob:<URL>' because it violates the following Content Security Policy directive: "default-src *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime 'unsafe-eval' 'unsafe-inline' data:". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback.
```

This is a very simple change to add `blob:` to the Content Security Policy, which resolves these errors.
I have run all tests and they pass. I have also run the server locally and verified that the above code inscription runs successfully after the changes.