### PR TITLE
add Markdown media type

### DIFF
--- a/src/media.rs
+++ b/src/media.rs
@@ -37,6 +37,7 @@ impl Media {
     ("text/html;charset=utf-8", Media::Iframe, &["html"]),
     ("text/javascript", Media::Text, &["js"]),
     ("text/plain;charset=utf-8", Media::Text, &["txt"]),
+    ("text/markdown;charset=utf-8", Media::Text, &["md"]),
     ("video/mp4", Media::Video, &["mp4"]),
     ("video/webm", Media::Video, &["webm"]),
   ];


### PR DESCRIPTION
Markdown is a desirable media type to add now that we are inscribing Libraries. 
This would be a good way to document code onchain. 
You could keep the documentation in the same UTXO as the library or create a child parent using the library inscription
Clients would probably need to create a recursive markdown parser to add links and images for instance.
`[link](<inscriptionId>)`
`![Image](<inscriptionId>)`
People could even make clients like obsidian using the same recursion above.
This would also allow people to easily write a blog on inscriptions. 