### PR TITLE
Allow blobs in content CSP

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -788,11 +788,11 @@ impl Server {
     );
     headers.insert(
       header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src 'self' 'unsafe-eval' 'unsafe-inline' data:"),
+      HeaderValue::from_static("default-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob:"),
     );
     headers.append(
       header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime 'unsafe-eval' 'unsafe-inline' data:"),
+      HeaderValue::from_static("default-src *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime 'unsafe-eval' 'unsafe-inline' data: blob:"),
     );
     headers.insert(
       header::CACHE_CONTROL,


### PR DESCRIPTION
I've been experimenting w/ recursive inscriptions and came across an error loading blobs using three.js/model-veiwer. I am using canvas to modify textures in the browser, and need to load these blobs to do so. This PR fixes the errors.

Here is the inscription and the csp errors im seeing:
https://ordinals.com/content/487bd19407d60235323772a4e75cf2d50f2398bbf2a9e7eb8943ad74971c0b69i0
<img width="926" alt="Screen Shot 1402-04-01 at 09 57 45" src="https://github.com/ordinals/ord/assets/8557965/f7e25cfc-08a1-427e-a0a7-8455d15c7105">

w/o `blob:` in CSP
<img width="401" alt="Screen Shot 1402-04-01 at 09 55 33" src="https://github.com/ordinals/ord/assets/8557965/7d6f8ca0-528b-4181-968e-37c482ad27d1">

w/ `blob:` in CSP
<img width="437" alt="Screen Shot 1402-04-01 at 09 56 49" src="https://github.com/ordinals/ord/assets/8557965/241f1a72-1dbb-4e43-82fb-101165fa36d0">

