### PR TITLE
Shadow inscriptions

### DIFF
--- a/src/media.rs
+++ b/src/media.rs
@@ -37,6 +37,7 @@ impl Media {
     ("text/html;charset=utf-8", Media::Iframe, &["html"]),
     ("text/javascript", Media::Text, &["js"]),
     ("text/plain;charset=utf-8", Media::Text, &["txt"]),
+    ("text/shadow", Media::Text, &["shadow"]),
     ("text/markdown;charset=utf-8", Media::Text, &["md"]),
     ("video/mp4", Media::Video, &["mp4"]),
     ("video/webm", Media::Video, &["webm"]),


### PR DESCRIPTION
I wasn't sure if creating a PR right away was the best approach, but I figured it would allow me to present my idea as simply as possible.

**Problem**
Recursive inscriptions are great. However:

1. Every inscription that assembles HTML (or svg) traits from a collection (e.g. [this one](https://ordinals.com/content/181be382241e90692b2dff3d02f926e4b40a254fd62823e9181ff5a2280f0ebfi0)) has overhead.
3. There is no clean way to let a recursive inscription determine traits based on e.g. block height or other inputs. With recursive endpoints an inscription can fetch that info for itself. But then again, every inscription needs to have that logic.

**Solution**
The proposed concept of shadow inscriptions allows users to inscribe a shadow of an existing (recursive) inscription by using the `text/shadow` content type and the shadowed inscription ID as the content. Internally, ord will resolve the content of the shadow inscription with the shadowed inscription and pass some arguments in the query string.

**Potential positive side effects**
This may also reduce the number of internal HTTP requests because ord can pass info directly to the shadowed inscription.