### PR TITLE
Change Recursion to Composition

### DIFF
--- a/docs/src/inscriptions.md
+++ b/docs/src/inscriptions.md
@@ -79,10 +79,10 @@ This is accomplished by loading HTML and SVG inscriptions inside `iframes` with
 the `sandbox` attribute, as well as serving inscription content with
 `Content-Security-Policy` headers.
 
-Recursion
+Composition
 ---------
 
-An important exception to sandboxing is recursion: access to `ord`'s `/content`
+An important exception to sandboxing is composition: access to `ord`'s `/content`
 endpoint is permitted, allowing inscriptions to access the content of other
 inscriptions by requesting `/content/<INSCRIPTION_ID>`.
 


### PR DESCRIPTION
We should change the name of "recursive" inscriptions as referenced in the docs. Nothing about them is self-referential. A better and more appropriate name would be "composite" inscriptions, as they are made by composing multiple inscriptions (layers) together to create a single image. (I realize this is not the only use case. Regardless other ways folks are using them are still not recursive, e.g. importing JS libs from other inscriptions)