### PR TITLE
brotli except iframe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotlic"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d5a350a871e06f5274bc1206bcd0da426522b4d0fbfad5fcec92806d854e5b"
+dependencies = [
+ "brotlic-sys",
+]
+
+[[package]]
+name = "brotlic-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdec5c62bc97b56349053cf66ba503af5c2448591be61c3ad70a5f11b57e574"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "bstr"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,6 +2190,7 @@ dependencies = [
  "bip39",
  "bitcoin",
  "boilerplate",
+ "brotlic",
  "chrono",
  "clap",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bech32 = "0.9.1"
 bip39 = "2.0.0"
 bitcoin = { version = "0.29.1", features = ["rand"] }
 boilerplate = { version = "0.2.3", features = ["axum"] }
+brotlic = "0.8.1"
 chrono = "0.4.19"
 clap = { version = "3.2.18", features = ["derive", "deprecated"] }
 ctrlc = "3.2.1"

--- a/src/media.rs
+++ b/src/media.rs
@@ -17,10 +17,10 @@ pub(crate) enum Media {
 
 impl Media {
   const TABLE: &'static [(&'static str, Media, &'static [&'static str])] = &[
-    ("application/json", Media::Text, &["json"]),
+    ("application/json;br", Media::Text, &["json"]),
     ("application/pdf", Media::Pdf, &["pdf"]),
-    ("application/pgp-signature", Media::Text, &["asc"]),
-    ("application/yaml", Media::Text, &["yaml", "yml"]),
+    ("application/pgp-signature;br", Media::Text, &["asc"]),
+    ("application/yaml;br", Media::Text, &["yaml", "yml"]),
     ("audio/flac", Media::Audio, &["flac"]),
     ("audio/mpeg", Media::Audio, &["mp3"]),
     ("audio/wav", Media::Audio, &["wav"]),
@@ -33,11 +33,11 @@ impl Media {
     ("image/webp", Media::Image, &["webp"]),
     ("model/gltf-binary", Media::Unknown, &["glb"]),
     ("model/stl", Media::Unknown, &["stl"]),
-    ("text/css", Media::Text, &["css"]),
+    ("text/css;br", Media::Text, &["css"]),
     ("text/html;charset=utf-8", Media::Iframe, &["html"]),
-    ("text/javascript", Media::Text, &["js"]),
-    ("text/plain;charset=utf-8", Media::Text, &["txt"]),
-    ("text/markdown;charset=utf-8", Media::Text, &["md"]),
+    ("text/javascript;br", Media::Text, &["js"]),
+    ("text/plain;charset=utf-8;br", Media::Text, &["txt"]),
+    ("text/markdown;charset=utf-8;br", Media::Text, &["md"]),
     ("video/mp4", Media::Video, &["mp4"]),
     ("video/webm", Media::Video, &["webm"]),
   ];

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -66,9 +66,9 @@ fn inscription_page() {
   <dt>content</dt>
   <dd><a href=/content/{inscription}>link</a></dd>
   <dt>content length</dt>
-  <dd>3 bytes</dd>
+  <dd>7 bytes</dd>
   <dt>content type</dt>
-  <dd>text/plain;charset=utf-8</dd>
+  <dd>text/plain;charset=utf-8;br</dd>
   <dt>timestamp</dt>
   <dd><time>1970-01-01 00:00:02 UTC</time></dd>
   <dt>genesis height</dt>
@@ -180,7 +180,7 @@ fn inscription_content() {
   assert_eq!(response.status(), StatusCode::OK);
   assert_eq!(
     response.headers().get("content-type").unwrap(),
-    "text/plain;charset=utf-8"
+    "text/plain;charset=utf-8;br"
   );
   assert_eq!(
     response

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -30,9 +30,9 @@ fn inscriptions_can_be_sent() {
     format!(
       ".*<h1>Inscription 0</h1>.*<dl>.*
   <dt>content length</dt>
-  <dd>3 bytes</dd>
+  <dd>7 bytes</dd>
   <dt>content type</dt>
-  <dd>text/plain;charset=utf-8</dd>
+  <dd>text/plain;charset=utf-8;br</dd>
   .*
   <dt>location</dt>
   <dd class=monospace>{send_txid}:0:0</dd>


### PR DESCRIPTION
A much better brotli commit, designed to compress / decompress any text.

A little more research is required.

Todo: fix remaining tests (aware of iframe).

done: backwards compatible with noncompressed text ordinals, and forwards everything that is Media::Text will be compressed( and rendered) including brc-20 or whatever the cool kids are doing now.