### PR TITLE
Update server.rs to fix recursive inscriptions on iOS/Safari

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -790,7 +790,7 @@ impl Server {
     );
     headers.insert(
       header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob:"),
+      HeaderValue::from_static("default-src 'unsafe-eval' 'unsafe-inline' 'self' data: blob:"),
     );
     headers.append(
       header::CONTENT_SECURITY_POLICY,


### PR DESCRIPTION
Recursive inscriptions on ordinals.com are currently broken on iOS and Safari. Moving 'self' further down fixes this so recursive inscriptions can render on iOS and Safari on Ordinals.com.