### PR TITLE
Set lower max age for not found

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -805,7 +805,7 @@ impl Server {
     let cache_control = format!("max-age={}, immutable", max_age);
     headers.insert(
       header::CACHE_CONTROL,
-      HeaderValue::from_str(&cache_control).unwrap()
+      HeaderValue::from_str(&cache_control).unwrap(),
     );
 
     Some((headers, body?))

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -804,7 +804,7 @@ impl Server {
     };
     headers.insert(
       header::CACHE_CONTROL,
-      HeaderValue::from_str(&cache_control).unwrap(),
+      HeaderValue::from_str(cache_control).unwrap(),
     );
 
     Some((headers, body?))

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -798,11 +798,10 @@ impl Server {
     );
 
     let body = inscription.into_body();
-    let max_age = match body {
-      Some(_) => "31536000",
-      None => "600",
+    let cache_control = match body {
+      Some(_) => "max-age=31536000, immutable",
+      None => "max-age=600",
     };
-    let cache_control = format!("max-age={}, immutable", max_age);
     headers.insert(
       header::CACHE_CONTROL,
       HeaderValue::from_str(&cache_control).unwrap(),

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -796,12 +796,19 @@ impl Server {
       header::CONTENT_SECURITY_POLICY,
       HeaderValue::from_static("default-src *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime 'unsafe-eval' 'unsafe-inline' data: blob:"),
     );
+
+    let body = inscription.into_body();
+    let max_age = match body {
+      Some(_) => "31536000",
+      None => "600",
+    };
+    let cache_control = format!("max-age={}, immutable", max_age);
     headers.insert(
       header::CACHE_CONTROL,
-      HeaderValue::from_static("max-age=31536000, immutable"),
+      HeaderValue::from_str(&cache_control).unwrap()
     );
 
-    Some((headers, inscription.into_body()?))
+    Some((headers, body?))
   }
 
   async fn preview(


### PR DESCRIPTION
Lower cache time to 600 (10 minutes) when an inscription is not found

Resolve issue #2232 