### PR TITLE
Safari doesn't like multiple CSP headers

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -790,11 +790,7 @@ impl Server {
     );
     headers.insert(
       header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob:"),
-    );
-    headers.append(
-      header::CONTENT_SECURITY_POLICY,
-      HeaderValue::from_static("default-src *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime 'unsafe-eval' 'unsafe-inline' data: blob:"),
+      HeaderValue::from_static("default-src 'self' 'unsafe-eval' 'unsafe-inline' *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime data: blob:"),
     );
 
     let body = inscription.into_body();

--- a/src/templates/iframe.rs
+++ b/src/templates/iframe.rs
@@ -29,7 +29,7 @@ impl Display for Iframe {
 
     write!(
       f,
-      "<iframe sandbox=allow-scripts scrolling=no loading=lazy src=/preview/{}></iframe>",
+      "<iframe sandbox='allow-scripts allow-same-origin' scrolling=no loading=lazy src=/preview/{}></iframe>",
       self.inscription_id
     )?;
 

--- a/src/templates/iframe.rs
+++ b/src/templates/iframe.rs
@@ -29,7 +29,7 @@ impl Display for Iframe {
 
     write!(
       f,
-      "<iframe sandbox='allow-scripts allow-same-origin' scrolling=no loading=lazy src=/preview/{}></iframe>",
+      "<iframe sandbox=allow-scripts scrolling=no loading=lazy src=/preview/{}></iframe>",
       self.inscription_id
     )?;
 


### PR DESCRIPTION
Recursive Ordinals aren't working on Safari because Safari only uses the first CSP header from the response.
By moving all values to the insert en removing the append Recursive Ordinals will also work on Safari.

You can use this recursive ordinal to test
https://ordinals.com/inscription/370706072e6a03c3eb1349bf4531fe20e60d28063fac1f1c3a0774b094efb931i0