### PR TITLE
fix: server corrupting index

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bitcoin = { version = "0.29.1", features = ["rand"] }
 boilerplate = { version = "0.2.3", features = ["axum"] }
 chrono = "0.4.19"
 clap = { version = "3.2.18", features = ["derive", "deprecated"] }
-ctrlc = "3.2.1"
+ctrlc = { version = "3.2.1", features = ["termination"] }
 derive_more = "0.99.17"
 dirs = "5.0.0"
 env_logger = "0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,8 @@ fn gracefully_shutdown_update_thread() {
   let mut update_thread_lock = UPDATE_THREAD.lock().unwrap();
 
   if let Some(update_thread) = update_thread_lock.take() {
+    // We explicitly set this to true to notify the thread to not take on new work
+    SHUTTING_DOWN.store(true, atomic::Ordering::Relaxed);
     log::info!("Update thread running; waiting for it to finish...");
     if update_thread.join().is_err() {
       log::warn!("Update thread panicked; join failed");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,17 @@ fn unbound_outpoint() -> OutPoint {
   }
 }
 
+fn gracefully_shutdown_update_thread() {
+  let mut update_thread_lock = UPDATE_THREAD.lock().unwrap();
+
+  if let Some(update_thread) = update_thread_lock.take() {
+    log::info!("Update thread running; waiting for it to finish...");
+    if update_thread.join().is_err() {
+      log::warn!("Update thread panicked; join failed");
+    }
+  }
+}
+
 pub fn main() {
   env_logger::init();
 
@@ -180,14 +191,11 @@ pub fn main() {
     {
       eprintln!("{}", err.backtrace());
     }
+
+    gracefully_shutdown_update_thread();
+
     process::exit(1);
   }
 
-  let mut update_thread_lock = UPDATE_THREAD.lock().unwrap();
-
-  if let Some(update_thread) = update_thread_lock.take() {
-    if update_thread.join().is_err() {
-      log::warn!("Update thread panicked; join failed");
-    }
-  }
+  gracefully_shutdown_update_thread();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,19 +154,11 @@ pub fn main() {
   env_logger::init();
 
   ctrlc::set_handler(move || {
-    println!("Shutting down gracefully. Press <CTRL-C> again to shutdown immediately.");
-
     if SHUTTING_DOWN.fetch_or(true, atomic::Ordering::Relaxed) {
       process::exit(1);
     }
 
-    let mut update_thread_lock = UPDATE_THREAD.lock().unwrap();
-
-    if let Some(update_thread) = update_thread_lock.take() {
-      if update_thread.join().is_err() {
-        log::warn!("Update thread panicked; join failed");
-      }
-    }
+    println!("Shutting down gracefully. Press <CTRL-C> again to shutdown immediately.");
 
     LISTENERS
       .lock()
@@ -189,5 +181,13 @@ pub fn main() {
       eprintln!("{}", err.backtrace());
     }
     process::exit(1);
+  }
+
+  let mut update_thread_lock = UPDATE_THREAD.lock().unwrap();
+
+  if let Some(update_thread) = update_thread_lock.take() {
+    if update_thread.join().is_err() {
+      log::warn!("Update thread panicked; join failed");
+    }
   }
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -127,12 +127,13 @@ impl Server {
   pub(crate) fn run(self, options: Options, index: Arc<Index>, handle: Handle) -> Result {
     Runtime::new()?.block_on(async {
       let clone = index.clone();
-      thread::spawn(move || loop {
+      let update_thread = thread::spawn(move || loop {
         if let Err(error) = clone.update() {
           log::warn!("{error}");
         }
         thread::sleep(Duration::from_millis(5000));
       });
+      UPDATE_THREAD.lock().unwrap().replace(update_thread);
 
       let config = options.load_config()?;
       let acme_domains = self.acme_domains()?;

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -128,6 +128,9 @@ impl Server {
     Runtime::new()?.block_on(async {
       let clone = index.clone();
       let update_thread = thread::spawn(move || loop {
+        if SHUTTING_DOWN.load(atomic::Ordering::Relaxed) {
+          break;
+        }
         if let Err(error) = clone.update() {
           log::warn!("{error}");
         }


### PR DESCRIPTION
This PR fixes the issue where the index would be corrupted after running and shutting down the web server.

The issue occured from the update thread not being joined on shutdown and, hence, not gracefully closing its connection to the index.

2 things have been added in this PR: 
- termination feature for ctrlc crate. This allows graceful shutting down on a SIGTERM signal which docker and kubernetes use to shut down processes. Currently, running ord in a docker container completely bypasses shutting down gracefully without this.
- an UPDATE_THREAD mutex which holds the update thread which the server creates and joins onto it when shutting down gracefully. This allows the update thread to go through the graceful shutdown procedure of committing any uncommitted entries to the index and closing the connection to it. 

This has been tested with the following steps:
- Run ord in server mode
- curl the blockheight endpoint until the server is up and we get the blockheight returned
- Send SIGTERM/SIGINT signal
- Run the server again
- curl the blockheight endpoint
At this point, before the changes, the server would not accept connections and would take a while to start up while it fixes the index. After these proposed changes, it starts up straight away.
