### PR TITLE
Fix ordering for reinscriptions and show all reinscriptions for sat

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -3129,8 +3129,6 @@ mod tests {
           ..Default::default()
         });
 
-        dbg!(i, txid);
-
         let inscription_id = InscriptionId { txid, index: 0 };
         inscription_ids.push(inscription_id);
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -553,7 +553,7 @@ impl Index {
       let re_id_to_seq_num = rtx.open_table(REINSCRIPTION_ID_TO_SEQUENCE_NUMBER)?;
       ids.sort_by_key(
         |inscription_id| match re_id_to_seq_num.get(&inscription_id.store()) {
-          Ok(Some(num)) => num.value() + 1,
+          Ok(Some(num)) => num.value() + 1, // remove at next index refactor
           _ => 0,
         },
       );
@@ -995,7 +995,7 @@ impl Index {
 
     result.sort_by_key(|(_satpoint, inscription_id)| {
       match re_id_to_seq_num.get(&inscription_id.store()) {
-        Ok(Some(num)) => num.value() + 1,
+        Ok(Some(num)) => num.value() + 1, // remove at next index refactor
         Ok(None) => 0,
         _ => 0,
       }
@@ -3073,18 +3073,14 @@ mod tests {
       context.mine_blocks(1);
 
       let mut inscription_ids = vec![];
-
       for i in 1..=5 {
-        let inscription_text =
-          inscription("text/plain;charset=utf-8", &format!("hello {}", i)).to_witness();
         let txid = context.rpc_server.broadcast_tx(TransactionTemplate {
           inputs: &[(i, if i == 1 { 0 } else { 1 }, 0)], // for the first inscription use coinbase, otherwise use the previous tx
-          witness: inscription_text,
+          witness: inscription("text/plain;charset=utf-8", &format!("hello {}", i)).to_witness(),
           ..Default::default()
         });
 
-        let inscription_id = InscriptionId { txid, index: 0 };
-        inscription_ids.push(inscription_id);
+        inscription_ids.push(InscriptionId { txid, index: 0 });
 
         context.mine_blocks(1);
       }
@@ -3094,8 +3090,8 @@ mod tests {
 
       for (index, id) in inscription_ids.iter().enumerate() {
         match re_id_to_seq_num.get(&id.store()) {
-          Ok(Some(access_guard)) => {
-            let sequence_number = access_guard.value() + 1;
+          Ok(Some(num)) => {
+            let sequence_number = num.value() + 1; // remove at next index refactor
             assert_eq!(
               index as u64, sequence_number,
               "sequence number mismatch for {:?}",
@@ -3119,18 +3115,14 @@ mod tests {
       context.mine_blocks(1);
 
       let mut inscription_ids = vec![];
-
       for i in 1..=21 {
-        let inscription_text =
-          inscription("text/plain;charset=utf-8", &format!("hello {}", i)).to_witness();
         let txid = context.rpc_server.broadcast_tx(TransactionTemplate {
           inputs: &[(i, if i == 1 { 0 } else { 1 }, 0)], // for the first inscription use coinbase, otherwise use the previous tx
-          witness: inscription_text,
+          witness: inscription("text/plain;charset=utf-8", &format!("hello {}", i)).to_witness(),
           ..Default::default()
         });
 
-        let inscription_id = InscriptionId { txid, index: 0 };
-        inscription_ids.push(inscription_id);
+        inscription_ids.push(InscriptionId { txid, index: 0 });
 
         context.mine_blocks(1);
       }
@@ -3147,7 +3139,7 @@ mod tests {
       let expected_result = inscription_ids
         .iter()
         .map(|id| (location, *id))
-        .collect::<Vec<_>>();
+        .collect::<Vec<(SatPoint, InscriptionId)>>();
 
       assert_eq!(
         expected_result,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -169,8 +169,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
         } else if inscription.tx_in_offset != 0 {
           Some(Curse::NotAtOffsetZero)
         } else if inscribed_offsets.contains_key(&offset) {
-          let seq_num = self
-            .reinscription_id_to_seq_num.len()?;
+          let seq_num = self.reinscription_id_to_seq_num.len()?;
 
           let sat = Self::calculate_sat(input_sat_ranges, offset);
           log::info!("processing reinscription {inscription_id} on sat {:?}: sequence number {seq_num}, inscribed offsets {:?}", sat, inscribed_offsets);

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -170,12 +170,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           Some(Curse::NotAtOffsetZero)
         } else if inscribed_offsets.contains_key(&offset) {
           let seq_num = self
-            .reinscription_id_to_seq_num
-            .iter()?
-            .next_back()
-            .and_then(|result| result.ok())
-            .map(|(_id, number)| number.value() + 1)
-            .unwrap_or(0);
+            .reinscription_id_to_seq_num.len()?;
 
           let sat = Self::calculate_sat(input_sat_ranges, offset);
           log::info!("processing reinscription {inscription_id} on sat {:?}: sequence number {seq_num}, inscribed offsets {:?}", sat, inscribed_offsets);

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -390,7 +390,7 @@ impl Server {
         sat,
         satpoint,
         blocktime: index.block_time(sat.height())?,
-        inscription: index.get_inscription_id_by_sat(sat)?,
+        inscriptions: index.get_inscription_ids_by_sat(sat)?,
       }
       .page(page_config, index.has_sat_index()?),
     )

--- a/src/subcommand/wallet/inscriptions.rs
+++ b/src/subcommand/wallet/inscriptions.rs
@@ -11,8 +11,6 @@ pub(crate) fn run(options: Options) -> Result {
   let index = Index::open(&options)?;
   index.update()?;
 
-  // BACKLOG - change the logic here to only get inscriptions for outputs actually in the wallet
-
   let inscriptions = index.get_inscriptions(None)?;
   let unspent_outputs = index.get_unspent_outputs(Wallet::load(&options)?)?;
 

--- a/src/subcommand/wallet/inscriptions.rs
+++ b/src/subcommand/wallet/inscriptions.rs
@@ -11,6 +11,8 @@ pub(crate) fn run(options: Options) -> Result {
   let index = Index::open(&options)?;
   index.update()?;
 
+  // BACKLOG - change the logic here to only get inscriptions for outputs actually in the wallet
+
   let inscriptions = index.get_inscriptions(None)?;
   let unspent_outputs = index.get_unspent_outputs(Wallet::load(&options)?)?;
 

--- a/src/templates/sat.rs
+++ b/src/templates/sat.rs
@@ -5,7 +5,7 @@ pub(crate) struct SatHtml {
   pub(crate) sat: Sat,
   pub(crate) satpoint: Option<SatPoint>,
   pub(crate) blocktime: Blocktime,
-  pub(crate) inscription: Option<InscriptionId>,
+  pub(crate) inscriptions: Vec<InscriptionId>,
 }
 
 impl PageContent for SatHtml {
@@ -25,7 +25,7 @@ mod tests {
         sat: Sat(0),
         satpoint: None,
         blocktime: Blocktime::confirmed(0),
-        inscription: None,
+        inscriptions: Vec::new(),
       },
       "
         <h1>Sat 0</h1>
@@ -58,7 +58,7 @@ mod tests {
         sat: Sat(2099999997689999),
         satpoint: None,
         blocktime: Blocktime::confirmed(0),
-        inscription: None,
+        inscriptions: Vec::new(),
       },
       "
         <h1>Sat 2099999997689999</h1>
@@ -91,7 +91,7 @@ mod tests {
         sat: Sat(1),
         satpoint: None,
         blocktime: Blocktime::confirmed(0),
-        inscription: None,
+        inscriptions: Vec::new(),
       },
       r"<h1>Sat 1</h1>.*<a class=prev href=/sat/0>prev</a>\n<a class=next href=/sat/2>next</a>.*",
     );
@@ -104,9 +104,39 @@ mod tests {
         sat: Sat(0),
         satpoint: None,
         blocktime: Blocktime::confirmed(0),
-        inscription: Some(inscription_id(1)),
+        inscriptions: vec![inscription_id(1)],
       },
-      r"<h1>Sat 0</h1>.*<dt>inscription</dt><dd class=thumbnails><a href=/inscription/1{64}i1>.*</a></dd>.*",
+      "
+        <h1>Sat 0</h1>
+        .*
+          <dt>inscriptions</dt>
+          <dd class=thumbnails>
+            <a href=/inscription/1{64}i1>.*</a>
+          </dd>
+        .*"
+        .unindent(),
+    );
+  }
+
+  #[test]
+  fn sat_with_reinscription() {
+    assert_regex_match!(
+      SatHtml {
+        sat: Sat(0),
+        satpoint: None,
+        blocktime: Blocktime::confirmed(0),
+        inscriptions: vec![inscription_id(1), inscription_id(2)],
+      },
+      "
+        <h1>Sat 0</h1>
+        .*
+          <dt>inscriptions</dt>
+          <dd class=thumbnails>
+            <a href=/inscription/1{64}i1>.*</a>
+            <a href=/inscription/2{64}i2>.*</a>
+          </dd>
+        .*"
+        .unindent(),
     );
   }
 
@@ -117,7 +147,7 @@ mod tests {
         sat: Sat::LAST,
         satpoint: None,
         blocktime: Blocktime::confirmed(0),
-        inscription: None,
+        inscriptions: Vec::new(),
       },
       r"<h1>Sat 2099999997689999</h1>.*<a class=prev href=/sat/2099999997689998>prev</a>\nnext.*",
     );
@@ -130,7 +160,7 @@ mod tests {
         sat: Sat(0),
         satpoint: Some(satpoint(1, 0)),
         blocktime: Blocktime::confirmed(0),
-        inscription: None,
+        inscriptions: Vec::new(),
       },
       "<h1>Sat 0</h1>.*<dt>location</dt><dd class=monospace>1{64}:1:0</dd>.*",
     );

--- a/templates/sat.html
+++ b/templates/sat.html
@@ -11,8 +11,13 @@
   <dt>offset</dt><dd>{{ self.sat.third() }}</dd>
   <dt>rarity</dt><dd><span class={{self.sat.rarity()}}>{{ self.sat.rarity() }}</span></dd>
   <dt>timestamp</dt><dd><time>{{self.blocktime.timestamp()}}</time>{{self.blocktime.suffix()}}</dd>
-%% if let Some((inscription)) = &self.inscription {
-  <dt>inscription</dt><dd class=thumbnails>{{ Iframe::thumbnail(*inscription) }}</dd>
+%% if !self.inscriptions.is_empty() {
+  <dt>inscriptions</dt>
+  <dd class=thumbnails>
+%% for inscription in &self.inscriptions {
+    {{Iframe::thumbnail(*inscription)}}
+%% }
+  </dd>
 %% }
 %% if let Some(satpoint) = self.satpoint {
   <dt>location</dt><dd class=monospace>{{ satpoint }}</dd>


### PR DESCRIPTION
This PR fixes a bug in the assignment of reinscription sequence numbers and allows to correctly order reinscriptions in chronological order. It also implements showing all inscriptions for a given sat (and not just a random one) in the correct sequence.
