### PR TITLE
use backported miniscript branch from apoelstra (should hit mainline …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,9 +1952,8 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniscript"
-version = "9.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9601439f168c13bdc5bf84349c2e61c815be4a4dcebe8c4ff4af58f4e8a6d20"
+version = "9.0.2"
+source = "git+https://github.com/apoelstra/rust-miniscript?rev=f1c1272#f1c12724d04b7ad28d25c866383a948cd493e698"
 dependencies = [
  "bitcoin",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ lazy_static = "1.4.0"
 log = "0.4.14"
 mime = "0.3.16"
 mime_guess = "2.0.4"
-miniscript = "9.0.1"
+miniscript = { git = "https://github.com/apoelstra/rust-miniscript", rev = "f1c1272" }
 mp4 = "0.13.0"
 ord-bitcoincore-rpc = "0.16.5"
 redb = "1.0.2"


### PR DESCRIPTION
Temporary patch to fix rust build errors for miniscript; this should be updated when a backport to `9.0.x` is released

Tho note that `10.0.0` of miniscript is already released w/ a fix; should probs upgrade to that instead?