### PR TITLE
Only fetch inscriptions that are owned by the ord wallet

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -826,24 +826,15 @@ impl Index {
 
   pub(crate) fn get_inscriptions(
     &self,
-    n: Option<usize>,
+    utxos: BTreeMap<OutPoint, Amount>,
   ) -> Result<BTreeMap<SatPoint, InscriptionId>> {
     let rtx = self.database.begin_read()?;
 
     let mut result = BTreeMap::new();
 
-    for range_result in rtx
-      .open_multimap_table(SATPOINT_TO_INSCRIPTION_ID)?
-      .range::<&[u8; 44]>(&[0; 44]..)?
-    {
-      let (satpoint, ids) = range_result?;
-      for id_result in ids {
-        let id = id_result?;
-        result.insert(Entry::load(*satpoint.value()), Entry::load(*id.value()));
-      }
-      if result.len() >= n.unwrap_or(usize::MAX) {
-        break;
-      }
+    let table = rtx.open_multimap_table(SATPOINT_TO_INSCRIPTION_ID)?;
+    for utxo in utxos.keys() {
+      result.extend(Self::inscriptions_on_output_unordered(&table, *utxo)?);
     }
 
     Ok(result)

--- a/src/subcommand/wallet/balance.rs
+++ b/src/subcommand/wallet/balance.rs
@@ -9,8 +9,10 @@ pub(crate) fn run(options: Options) -> Result {
   let index = Index::open(&options)?;
   index.update()?;
 
+  let unspent_outputs = index.get_unspent_outputs(Wallet::load(&options)?)?;
+
   let inscription_outputs = index
-    .get_inscriptions(None)?
+    .get_inscriptions(unspent_outputs)?
     .keys()
     .map(|satpoint| satpoint.outpoint)
     .collect::<BTreeSet<OutPoint>>();

--- a/src/subcommand/wallet/cardinals.rs
+++ b/src/subcommand/wallet/cardinals.rs
@@ -10,14 +10,15 @@ pub(crate) fn run(options: Options) -> Result {
   let index = Index::open(&options)?;
   index.update()?;
 
+  let unspent_outputs = index.get_unspent_outputs(Wallet::load(&options)?)?;
+
   let inscribed_utxos = index
-    .get_inscriptions(None)?
+    .get_inscriptions(unspent_outputs.clone())?
     .keys()
     .map(|satpoint| satpoint.outpoint)
     .collect::<BTreeSet<OutPoint>>();
 
-  let cardinal_utxos = index
-    .get_unspent_outputs(Wallet::load(&options)?)?
+  let cardinal_utxos = unspent_outputs
     .iter()
     .filter_map(|(output, amount)| {
       if inscribed_utxos.contains(output) {

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -64,7 +64,7 @@ impl Inscribe {
 
     let mut utxos = index.get_unspent_outputs(Wallet::load(&options)?)?;
 
-    let inscriptions = index.get_inscriptions(None)?;
+    let inscriptions = index.get_inscriptions(utxos.clone())?;
 
     let commit_tx_change = [
       get_change_address(&client, &options)?,

--- a/src/subcommand/wallet/inscriptions.rs
+++ b/src/subcommand/wallet/inscriptions.rs
@@ -12,8 +12,8 @@ pub(crate) fn run(options: Options) -> Result {
   let index = Index::open(&options)?;
   index.update()?;
 
-  let inscriptions = index.get_inscriptions(None)?;
   let unspent_outputs = index.get_unspent_outputs(Wallet::load(&options)?)?;
+  let inscriptions = index.get_inscriptions(unspent_outputs.clone())?;
 
   let explorer = match options.chain() {
     Chain::Mainnet => "https://ordinals.com/inscription/",

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -24,7 +24,7 @@ impl Send {
 
     let unspent_outputs = index.get_unspent_outputs(Wallet::load(&options)?)?;
 
-    let inscriptions = index.get_inscriptions(None)?;
+    let inscriptions = index.get_inscriptions(unspent_outputs.clone())?;
 
     let satpoint = match self.outgoing {
       Outgoing::SatPoint(satpoint) => {


### PR DESCRIPTION
This makes most ord commands run a few hundred times faster:

before:

```
$ time ord wallet balance > /dev/null
real	3m39.900s, user	0m23.681s, sys	0m20.880s
```

after:

```
$ time ord wallet balance > /dev/null
real	0m0.648s, user	0m0.025s, sys	0m0.199s
$ time ord wallet balance > /dev/null
real	0m0.477s, user	0m0.010s, sys	0m0.095s
$ time ord wallet balance > /dev/null
real	0m0.415s, user	0m0.021s, sys	0m0.067s
```