### PR TITLE
Fix reorg typo

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -417,7 +417,7 @@ impl Index {
           log::info!("{}", err.to_string());
 
           match err.downcast_ref() {
-            Some(&ReorgError::Recoverable((height, depth))) => {
+            Some(&ReorgError::Recoverable { height, depth }) => {
               Reorg::handle_reorg(self, height, depth)?;
 
               updater = Updater::new(self)?;

--- a/src/index/reorg.rs
+++ b/src/index/reorg.rs
@@ -43,7 +43,7 @@ impl Reorg {
             .into_option()?;
 
           if index_block_hash == bitcoind_block_hash {
-            return Err(anyhow!(ReorgError::Recoverable((depth, height))));
+            return Err(anyhow!(ReorgError::Recoverable((height, depth))));
           }
         }
 

--- a/src/index/reorg.rs
+++ b/src/index/reorg.rs
@@ -2,14 +2,14 @@ use {super::*, updater::BlockData};
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum ReorgError {
-  Recoverable((u64, u64)),
+  Recoverable { height: u64, depth: u64 },
   Unrecoverable,
 }
 
 impl fmt::Display for ReorgError {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      ReorgError::Recoverable((height, depth)) => {
+      ReorgError::Recoverable { height, depth } => {
         write!(f, "{depth} block deep reorg detected at height {height}")
       }
       ReorgError::Unrecoverable => write!(f, "unrecoverable reorg detected"),
@@ -43,7 +43,7 @@ impl Reorg {
             .into_option()?;
 
           if index_block_hash == bitcoind_block_hash {
-            return Err(anyhow!(ReorgError::Recoverable((height, depth))));
+            return Err(anyhow!(ReorgError::Recoverable { height, depth }));
           }
         }
 


### PR DESCRIPTION
Height and depth are in the wrong order, leading to wrong log messages