### PR TITLE
Implement provenance in the index

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ tower-http = { version = "0.4.0", features = ["compression-br", "compression-gzi
 [dev-dependencies]
 executable-path = "1.0.0"
 pretty_assertions = "1.2.1"
-reqwest = { version = "0.11.10", features = ["blocking"] }
+reqwest = { version = "0.11.10", features = ["blocking", "json"] }
 test-bitcoincore-rpc = { path = "test-bitcoincore-rpc" }
 unindent = "0.2.1"
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -3741,7 +3741,7 @@ mod tests {
   }
 
   #[test]
-  fn parents_can_be_in_proceeding_input() {
+  fn parents_can_be_in_preceding_input() {
     for context in Context::configurations() {
       context.mine_blocks(1);
 

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -385,6 +385,7 @@ impl<'index> Updater<'_> {
       wtx.open_table(INSCRIPTION_NUMBER_TO_INSCRIPTION_ID)?;
     let mut reinscription_id_to_seq_num = wtx.open_table(REINSCRIPTION_ID_TO_SEQUENCE_NUMBER)?;
     let mut sat_to_inscription_id = wtx.open_multimap_table(SAT_TO_INSCRIPTION_ID)?;
+    let mut inscription_id_to_children = wtx.open_multimap_table(INSCRIPTION_ID_TO_CHILDREN)?;
     let mut satpoint_to_inscription_id = wtx.open_multimap_table(SATPOINT_TO_INSCRIPTION_ID)?;
     let mut statistic_to_count = wtx.open_table(STATISTIC_TO_COUNT)?;
 
@@ -400,6 +401,7 @@ impl<'index> Updater<'_> {
 
     let mut inscription_updater = InscriptionUpdater::new(
       self.height,
+      &mut inscription_id_to_children,
       &mut inscription_id_to_satpoint,
       value_receiver,
       &mut inscription_id_to_inscription_entry,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -10,8 +10,9 @@ pub(super) struct Flotsam {
 #[derive(Debug, Clone)]
 enum Origin {
   New {
-    fee: u64,
     cursed: bool,
+    fee: u64,
+    parent: Option<InscriptionId>,
     unbound: bool,
   },
   Old {
@@ -22,6 +23,8 @@ enum Origin {
 pub(super) struct InscriptionUpdater<'a, 'db, 'tx> {
   flotsam: Vec<Flotsam>,
   height: u64,
+  id_to_children:
+    &'a mut MultimapTable<'db, 'tx, &'static InscriptionIdValue, &'static InscriptionIdValue>,
   id_to_satpoint: &'a mut Table<'db, 'tx, &'static InscriptionIdValue, &'static SatPointValue>,
   value_receiver: &'a mut Receiver<u64>,
   id_to_entry: &'a mut Table<'db, 'tx, &'static InscriptionIdValue, InscriptionEntryValue>,
@@ -43,6 +46,12 @@ pub(super) struct InscriptionUpdater<'a, 'db, 'tx> {
 impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
   pub(super) fn new(
     height: u64,
+    id_to_children: &'a mut MultimapTable<
+      'db,
+      'tx,
+      &'static InscriptionIdValue,
+      &'static InscriptionIdValue,
+    >,
     id_to_satpoint: &'a mut Table<'db, 'tx, &'static InscriptionIdValue, &'static SatPointValue>,
     value_receiver: &'a mut Receiver<u64>,
     id_to_entry: &'a mut Table<'db, 'tx, &'static InscriptionIdValue, InscriptionEntryValue>,
@@ -78,6 +87,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     Ok(Self {
       flotsam: Vec::new(),
       height,
+      id_to_children,
       id_to_satpoint,
       value_receiver,
       id_to_entry,
@@ -229,14 +239,34 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           inscription_id,
           offset,
           origin: Origin::New {
-            fee: 0,
             cursed,
+            fee: 0,
+            parent: inscription.inscription.parent(),
             unbound,
           },
         });
 
         new_inscriptions.next();
         id_counter += 1;
+      }
+    }
+
+    let potential_parents = floating_inscriptions
+      .iter()
+      .map(|flotsam| flotsam.inscription_id)
+      .collect::<HashSet<InscriptionId>>();
+
+    for flotsam in &mut floating_inscriptions {
+      if let Flotsam {
+        origin: Origin::New { parent, .. },
+        ..
+      } = flotsam
+      {
+        if let Some(purported_parent) = parent {
+          if !potential_parents.contains(purported_parent) {
+            *parent = None;
+          }
+        }
       }
     }
 
@@ -250,8 +280,9 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           offset,
           origin:
             Origin::New {
-              fee: _,
               cursed,
+              fee: _,
+              parent,
               unbound,
             },
         } = flotsam
@@ -260,8 +291,9 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
             inscription_id,
             offset,
             origin: Origin::New {
-              fee: (input_value - total_output_value) / u64::from(id_counter),
               cursed,
+              fee: (input_value - total_output_value) / u64::from(id_counter),
+              parent,
               unbound,
             },
           }
@@ -373,8 +405,9 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
         false
       }
       Origin::New {
-        fee,
         cursed,
+        fee,
+        parent,
         unbound,
       } => {
         let number = if cursed {
@@ -417,11 +450,18 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
             fee,
             height: self.height,
             number,
+            parent,
             sat,
             timestamp: self.timestamp,
           }
           .store(),
         )?;
+
+        if let Some(parent) = parent {
+          self
+            .id_to_children
+            .insert(&parent.store(), &inscription_id)?;
+        }
 
         unbound
       }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -273,16 +273,12 @@ impl<'a> InscriptionParser<'a> {
     let body = fields.remove(BODY_TAG.as_slice());
     let content_type = fields.remove(CONTENT_TYPE_TAG.as_slice());
     let parent = fields.remove(PARENT_TAG.as_slice());
+    let mut unrecognized_even_field = false;
 
     for tag in fields.keys() {
       if let Some(lsb) = tag.first() {
         if lsb % 2 == 0 {
-          return Ok(Inscription {
-            body,
-            content_type,
-            parent,
-            unrecognized_even_field: true,
-          });
+          unrecognized_even_field = true;
         }
       }
     }
@@ -291,7 +287,7 @@ impl<'a> InscriptionParser<'a> {
       body,
       content_type,
       parent,
-      unrecognized_even_field: false,
+      unrecognized_even_field,
     })
   }
 

--- a/src/inscription_id.rs
+++ b/src/inscription_id.rs
@@ -6,6 +6,26 @@ pub struct InscriptionId {
   pub index: u32,
 }
 
+impl InscriptionId {
+  #[cfg(test)]
+  pub(crate) fn parent_value(self) -> Vec<u8> {
+    let index = self.index.to_le_bytes();
+    let mut index_slice = index.as_slice();
+
+    while index_slice.last().copied() == Some(0) {
+      index_slice = &index_slice[0..index_slice.len() - 1];
+    }
+
+    self
+      .txid
+      .to_byte_array()
+      .iter()
+      .chain(index_slice)
+      .copied()
+      .collect()
+  }
+}
+
 impl<'de> Deserialize<'de> for InscriptionId {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -2988,6 +2988,13 @@ mod tests {
 
     assert_eq!(
       server
+        .get_json::<InscriptionJson>(format!("/inscription/{inscription_id}"))
+        .parent,
+      Some(parent_inscription_id),
+    );
+
+    assert_eq!(
+      server
         .get_json::<InscriptionJson>(format!("/inscription/{parent_inscription_id}"))
         .children,
       [inscription_id],

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -19,6 +19,10 @@
 <dl>
   <dt>id</dt>
   <dd class=monospace>{{ self.inscription_id }}</dd>
+%% if let Some(parent) = &self.parent {
+  <dt>parent</dt>
+  <dd><a class=monospace href=/inscription/{{ parent }}>{{ parent }}</a></dd>
+%% }
 %% if let Some(output) = &self.output {
 %% if let Ok(address) = self.chain.address_from_script(&output.script_pubkey ) {
   <dt>address</dt>
@@ -63,4 +67,14 @@
 %% }
   <dt>offset</dt>
   <dd>{{ self.satpoint.offset }}</dd>
+%% if !self.children.is_empty() {
+  <dt>children</dt>
+  <dd>
+    <div class=thumbnails>
+%% for id in &self.children {
+      {{Iframe::thumbnail(*id)}}
+%% }
+    </div>
+  </dd>
+%% }
 </dl>

--- a/test-bitcoincore-rpc/src/lib.rs
+++ b/test-bitcoincore-rpc/src/lib.rs
@@ -119,10 +119,9 @@ pub fn spawn() -> Handle {
 #[derive(Clone)]
 pub struct TransactionTemplate<'a> {
   pub fee: u64,
-  pub inputs: &'a [(usize, usize, usize)],
+  pub inputs: &'a [(usize, usize, usize, Witness)],
   pub output_values: &'a [u64],
   pub outputs: usize,
-  pub witness: Witness,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -154,7 +153,6 @@ impl<'a> Default for TransactionTemplate<'a> {
       inputs: &[],
       output_values: &[],
       outputs: 1,
-      witness: Witness::default(),
     }
   }
 }

--- a/test-bitcoincore-rpc/src/state.rs
+++ b/test-bitcoincore-rpc/src/state.rs
@@ -131,14 +131,14 @@ impl State {
   pub(crate) fn broadcast_tx(&mut self, template: TransactionTemplate) -> Txid {
     let mut total_value = 0;
     let mut input = Vec::new();
-    for (height, tx, vout) in template.inputs.iter() {
+    for (height, tx, vout, witness) in template.inputs.iter() {
       let tx = &self.blocks.get(&self.hashes[*height]).unwrap().txdata[*tx];
       total_value += tx.output[*vout].value;
       input.push(TxIn {
         previous_output: OutPoint::new(tx.txid(), *vout as u32),
         script_sig: ScriptBuf::new(),
         sequence: Sequence::MAX,
-        witness: template.witness.clone(),
+        witness: witness.clone(),
       });
     }
 

--- a/tests/json_api.rs
+++ b/tests/json_api.rs
@@ -152,6 +152,8 @@ fn get_inscription() {
   pretty_assert_eq!(
     inscription_json,
     InscriptionJson {
+      parent: None,
+      children: Vec::new(),
       inscription_id,
       number: 0,
       genesis_height: 2,
@@ -184,8 +186,11 @@ fn create_210_inscriptions(
     rpc_server.mine_blocks(1);
 
     let txid = rpc_server.broadcast_tx(TransactionTemplate {
-      inputs: &[(i * 3 + 1, 0, 0), (i * 3 + 2, 0, 0), (i * 3 + 3, 0, 0)],
-      witness: witness.clone(),
+      inputs: &[
+        (i * 3 + 1, 0, 0, witness.clone()),
+        (i * 3 + 2, 0, 0, witness.clone()),
+        (i * 3 + 3, 0, 0, witness.clone()),
+      ],
       ..Default::default()
     });
 
@@ -316,9 +321,14 @@ fn get_inscriptions_in_block() {
   create_wallet(&rpc_server);
   rpc_server.mine_blocks(10);
 
+  let envelope = envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]);
+
   let txid = rpc_server.broadcast_tx(TransactionTemplate {
-    inputs: &[(1, 0, 0), (2, 0, 0), (3, 0, 0)],
-    witness: envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]),
+    inputs: &[
+      (1, 0, 0, envelope.clone()),
+      (2, 0, 0, envelope.clone()),
+      (3, 0, 0, envelope.clone()),
+    ],
     ..Default::default()
   });
   rpc_server.mine_blocks(1);
@@ -362,9 +372,14 @@ fn get_output() {
   create_wallet(&rpc_server);
   rpc_server.mine_blocks(3);
 
+  let envelope = envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]);
+
   let txid = rpc_server.broadcast_tx(TransactionTemplate {
-    inputs: &[(1, 0, 0), (2, 0, 0), (3, 0, 0)],
-    witness: envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]),
+    inputs: &[
+      (1, 0, 0, envelope.clone()),
+      (2, 0, 0, envelope.clone()),
+      (3, 0, 0, envelope.clone()),
+    ],
     ..Default::default()
   });
   rpc_server.mine_blocks(1);

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -215,10 +215,15 @@ fn splitting_merged_inscriptions_is_possible() {
   create_wallet(&rpc_server);
   rpc_server.mine_blocks(3);
 
+  let inscription = envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]);
+
   // merging 3 inscriptions into one utxo
   let reveal_txid = rpc_server.broadcast_tx(TransactionTemplate {
-    inputs: &[(1, 0, 0), (2, 0, 0), (3, 0, 0)],
-    witness: envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]),
+    inputs: &[
+      (1, 0, 0, inscription.clone()),
+      (2, 0, 0, inscription.clone()),
+      (3, 0, 0, inscription.clone()),
+    ],
     outputs: 1,
     ..Default::default()
   });


### PR DESCRIPTION
This is an initial PR implementing [draft spec](https://github.com/ordinals/ord/pull/2278/) for parent/child inscriptions. It only implements indexing parent inscriptions and displaying them on the front end and returning them from the JSON API.

Other features are not implemented and are deferred to a future PR:
- Creating inscriptions with parents in the wallet
- Displaying child inscriptions on the parent inscription page