### PR TITLE
Remove unused content_response match statement

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -875,15 +875,9 @@ impl Server {
       header::CONTENT_SECURITY_POLICY,
       HeaderValue::from_static("default-src *:*/content/ *:*/blockheight *:*/blockhash *:*/blockhash/ *:*/blocktime 'unsafe-eval' 'unsafe-inline' data: blob:"),
     );
-
-    let body = inscription.into_body();
-    let cache_control = match body {
-      Some(_) => "max-age=31536000, immutable",
-      None => "max-age=600",
-    };
     headers.insert(
       header::CACHE_CONTROL,
-      HeaderValue::from_str(cache_control).unwrap(),
+      HeaderValue::from_static("max-age=31536000, immutable").unwrap(),
     );
 
     Some((headers, body?))

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -907,10 +907,10 @@ impl Server {
     );
     headers.insert(
       header::CACHE_CONTROL,
-      HeaderValue::from_static("max-age=31536000, immutable").unwrap(),
+      HeaderValue::from_static("max-age=31536000, immutable"),
     );
 
-    Some((headers, body?))
+    Some((headers, inscription.into_body()?))
   }
 
   async fn preview(


### PR DESCRIPTION
The `None` case of this match statement will never have an effect, since we do `body?` later one, which will case the whole function to return `None` if the body is empty.