### PR TITLE
Add `ord decode` command

### DIFF
--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -23,11 +23,11 @@ pub(crate) enum Curse {
   UnrecognizedEvenField,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Eq)]
 pub struct Inscription {
-  body: Option<Vec<u8>>,
-  content_type: Option<Vec<u8>>,
-  pub(crate) unrecognized_even_field: bool,
+  pub body: Option<Vec<u8>>,
+  pub content_type: Option<Vec<u8>>,
+  pub unrecognized_even_field: bool,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -23,7 +23,7 @@ pub(crate) enum Curse {
   UnrecognizedEvenField,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct Inscription {
   body: Option<Vec<u8>>,
   content_type: Option<Vec<u8>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ use {
     epoch::Epoch,
     height::Height,
     index::{Index, List},
-    inscription::Inscription,
     inscription_id::InscriptionId,
     media::Media,
     options::Options,
@@ -75,8 +74,8 @@ use {
 };
 
 pub use crate::{
-  fee_rate::FeeRate, object::Object, rarity::Rarity, sat::Sat, sat_point::SatPoint,
-  subcommand::wallet::transaction_builder::TransactionBuilder,
+  fee_rate::FeeRate, inscription::Inscription, object::Object, rarity::Rarity, sat::Sat,
+  sat_point::SatPoint, subcommand::wallet::transaction_builder::TransactionBuilder,
 };
 
 #[cfg(test)]

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod decode;
 pub mod epochs;
 pub mod find;
 mod index;
@@ -15,6 +16,8 @@ pub mod wallet;
 
 #[derive(Debug, Parser)]
 pub(crate) enum Subcommand {
+  #[clap(about = "Decode a transaction")]
+  Decode(decode::Decode),
   #[clap(about = "List the first satoshis of each reward epoch")]
   Epochs,
   #[clap(about = "Run an explorer server populated with inscriptions")]
@@ -44,6 +47,7 @@ pub(crate) enum Subcommand {
 impl Subcommand {
   pub(crate) fn run(self, options: Options) -> SubcommandResult {
     match self {
+      Self::Decode(decode) => decode.run(),
       Self::Epochs => epochs::run(),
       Self::Preview(preview) => preview.run(),
       Self::Find(find) => find.run(options),

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-mod decode;
+pub mod decode;
 pub mod epochs;
 pub mod find;
 mod index;

--- a/src/subcommand/decode.rs
+++ b/src/subcommand/decode.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+#[derive(Serialize)]
+pub struct Output {
+  pub inscriptions: Vec<Inscription>,
+}
+
+#[derive(Debug, Parser)]
+pub(crate) struct Decode {
+  transaction: PathBuf,
+}
+
+impl Decode {
+  pub(crate) fn run(self) -> SubcommandResult {
+    let mut file = File::open(self.transaction)?;
+
+    let transaction = Transaction::consensus_decode(&mut file)?;
+
+    let inscriptions = Inscription::from_transaction(&transaction);
+
+    Ok(Box::new(Output {
+      inscriptions: inscriptions
+        .into_iter()
+        .map(|inscription| inscription.inscription)
+        .collect(),
+    }))
+  }
+}

--- a/src/subcommand/decode.rs
+++ b/src/subcommand/decode.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Serialize)]
+#[derive(Serialize, Eq, PartialEq, Deserialize, Debug)]
 pub struct Output {
   pub inscriptions: Vec<Inscription>,
 }

--- a/src/subcommand/decode.rs
+++ b/src/subcommand/decode.rs
@@ -7,14 +7,16 @@ pub struct Output {
 
 #[derive(Debug, Parser)]
 pub(crate) struct Decode {
-  transaction: PathBuf,
+  transaction: Option<PathBuf>,
 }
 
 impl Decode {
   pub(crate) fn run(self) -> SubcommandResult {
-    let mut file = File::open(self.transaction)?;
-
-    let transaction = Transaction::consensus_decode(&mut file)?;
+    let transaction = if let Some(path) = self.transaction {
+      Transaction::consensus_decode(&mut File::open(path)?)?
+    } else {
+      Transaction::consensus_decode(&mut io::stdin())?
+    };
 
     let inscriptions = Inscription::from_transaction(&transaction);
 

--- a/tests/command_builder.rs
+++ b/tests/command_builder.rs
@@ -34,6 +34,7 @@ pub(crate) struct CommandBuilder {
   expected_stderr: Expected,
   expected_stdout: Expected,
   rpc_server_url: Option<String>,
+  stdin: Vec<u8>,
   tempdir: TempDir,
 }
 
@@ -45,6 +46,7 @@ impl CommandBuilder {
       expected_stderr: Expected::String(String::new()),
       expected_stdout: Expected::String(String::new()),
       rpc_server_url: None,
+      stdin: Vec::new(),
       tempdir: TempDir::new().unwrap(),
     }
   }
@@ -59,6 +61,10 @@ impl CommandBuilder {
       rpc_server_url: Some(rpc_server.url()),
       ..self
     }
+  }
+
+  pub(crate) fn stdin(self, stdin: Vec<u8>) -> Self {
+    Self { stdin, ..self }
   }
 
   pub(crate) fn stdout_regex(self, expected_stdout: impl AsRef<str>) -> Self {
@@ -109,7 +115,7 @@ impl CommandBuilder {
 
     command
       .env("ORD_INTEGRATION_TEST", "1")
-      .stdin(Stdio::null())
+      .stdin(Stdio::piped())
       .stdout(Stdio::piped())
       .stderr(Stdio::piped())
       .current_dir(&self.tempdir)
@@ -120,8 +126,18 @@ impl CommandBuilder {
     command
   }
 
-  pub(crate) fn run_and_extract_file(self, path: impl AsRef<Path>) -> String {
-    let output = self.command().output().unwrap();
+  fn run(self) -> (TempDir, String) {
+    let child = self.command().spawn().unwrap();
+
+    child
+      .stdin
+      .as_ref()
+      .unwrap()
+      .write_all(&self.stdin)
+      .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+
     let stdout = str::from_utf8(&output.stdout).unwrap();
     let stderr = str::from_utf8(&output.stderr).unwrap();
     if output.status.code() != Some(self.expected_exit_code) {
@@ -134,24 +150,16 @@ impl CommandBuilder {
     self.expected_stderr.assert_match(stderr);
     self.expected_stdout.assert_match(stdout);
 
-    fs::read_to_string(self.tempdir.path().join(path)).unwrap()
+    (self.tempdir, stdout.into())
+  }
+
+  pub(crate) fn run_and_extract_file(self, path: impl AsRef<Path>) -> String {
+    let tempdir = self.run().0;
+    fs::read_to_string(tempdir.path().join(path)).unwrap()
   }
 
   pub(crate) fn run_and_extract_stdout(self) -> String {
-    let output = self.command().output().unwrap();
-    let stdout = str::from_utf8(&output.stdout).unwrap();
-    let stderr = str::from_utf8(&output.stderr).unwrap();
-    if output.status.code() != Some(self.expected_exit_code) {
-      panic!(
-        "Test failed: {}\nstdout:\n{}\nstderr:\n{}",
-        output.status, stdout, stderr
-      );
-    }
-
-    self.expected_stderr.assert_match(stderr);
-    self.expected_stdout.assert_match(stdout);
-
-    stdout.into()
+    self.run().1
   }
 
   pub(crate) fn run_and_deserialize_output<T: DeserializeOwned>(self) -> T {

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -1,0 +1,59 @@
+use {
+  super::*,
+  bitcoin::{
+    absolute::LockTime, consensus::Encodable, opcodes, script, ScriptBuf, Sequence, Transaction,
+    TxIn, Witness,
+  },
+  ord::{subcommand::decode::Output, Inscription},
+};
+
+#[test]
+fn decode_inscription() {
+  let script = script::Builder::new()
+    .push_opcode(opcodes::OP_FALSE)
+    .push_opcode(opcodes::all::OP_IF)
+    .push_slice(b"ord")
+    .push_slice([1])
+    .push_slice(b"text/plain;charset=utf-8")
+    .push_slice([])
+    .push_slice([0, 1, 2, 3])
+    .push_opcode(opcodes::all::OP_ENDIF)
+    .into_script();
+
+  let mut witness = Witness::new();
+
+  witness.push(script);
+  witness.push([]);
+
+  let transaction = Transaction {
+    version: 0,
+    lock_time: LockTime::ZERO,
+    input: vec![TxIn {
+      previous_output: OutPoint::null(),
+      script_sig: ScriptBuf::new(),
+      sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+      witness,
+    }],
+    output: Vec::new(),
+  };
+
+  let mut buffer = Vec::new();
+
+  transaction.consensus_encode(&mut buffer).unwrap();
+
+  assert_eq!(
+    CommandBuilder::new("decode transaction.bin")
+      .write("transaction.bin", buffer)
+      .run_and_deserialize_output::<Output>(),
+    Output {
+      inscriptions: vec![Inscription {
+        body: Some(vec![0, 1, 2, 3]),
+        content_type: Some(vec![
+          116, 101, 120, 116, 47, 112, 108, 97, 105, 110, 59, 99, 104, 97, 114, 115, 101, 116, 61,
+          117, 116, 102, 45, 56
+        ]),
+        unrecognized_even_field: false
+      }],
+    }
+  );
+}

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -8,7 +8,7 @@ use {
 };
 
 #[test]
-fn decode_inscription() {
+fn from_file() {
   let script = script::Builder::new()
     .push_opcode(opcodes::OP_FALSE)
     .push_opcode(opcodes::all::OP_IF)
@@ -44,6 +44,57 @@ fn decode_inscription() {
   assert_eq!(
     CommandBuilder::new("decode transaction.bin")
       .write("transaction.bin", buffer)
+      .run_and_deserialize_output::<Output>(),
+    Output {
+      inscriptions: vec![Inscription {
+        body: Some(vec![0, 1, 2, 3]),
+        content_type: Some(vec![
+          116, 101, 120, 116, 47, 112, 108, 97, 105, 110, 59, 99, 104, 97, 114, 115, 101, 116, 61,
+          117, 116, 102, 45, 56
+        ]),
+        unrecognized_even_field: false
+      }],
+    }
+  );
+}
+
+#[test]
+fn from_stdin() {
+  let script = script::Builder::new()
+    .push_opcode(opcodes::OP_FALSE)
+    .push_opcode(opcodes::all::OP_IF)
+    .push_slice(b"ord")
+    .push_slice([1])
+    .push_slice(b"text/plain;charset=utf-8")
+    .push_slice([])
+    .push_slice([0, 1, 2, 3])
+    .push_opcode(opcodes::all::OP_ENDIF)
+    .into_script();
+
+  let mut witness = Witness::new();
+
+  witness.push(script);
+  witness.push([]);
+
+  let transaction = Transaction {
+    version: 0,
+    lock_time: LockTime::ZERO,
+    input: vec![TxIn {
+      previous_output: OutPoint::null(),
+      script_sig: ScriptBuf::new(),
+      sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+      witness,
+    }],
+    output: Vec::new(),
+  };
+
+  let mut buffer = Vec::new();
+
+  transaction.consensus_encode(&mut buffer).unwrap();
+
+  assert_eq!(
+    CommandBuilder::new("decode")
+      .stdin(buffer)
       .run_and_deserialize_output::<Output>(),
     Output {
       inscriptions: vec![Inscription {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -92,6 +92,7 @@ mod expected;
 mod test_server;
 
 mod core;
+mod decode;
 mod epochs;
 mod find;
 mod index;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -23,6 +23,7 @@ use {
   serde::de::DeserializeOwned,
   std::{
     fs,
+    io::Write,
     net::TcpListener,
     path::Path,
     process::{Child, Command, Stdio},


### PR DESCRIPTION
Decodes a transaction from a file, useful for debugging inscription parsing.