### PR TITLE
fix  issue with `--satpoint` when offset > 0. (Fix #2465)

### DIFF
--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -187,9 +187,11 @@ impl Inscribe {
 
     let commit = client.send_raw_transaction(&signed_commit_tx)?;
 
-    let reveal = client
-      .send_raw_transaction(&signed_reveal_tx)
-      .context("Failed to send reveal transaction")?;
+    let reveal = match client
+      .send_raw_transaction(&signed_reveal_tx) {
+        Ok(txid) => txid,
+        Err(err) => return Err(anyhow!("Failed to send reveal transaction: {err}\nCommit tx {commit} will be recovered once mined"))
+      };
 
     Ok(Box::new(Output {
       commit,

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -368,7 +368,7 @@ impl Inscribe {
       bail!("commit transaction output would be dust");
     }
 
-    let mut prevouts = vec![unsigned_commit_tx.output[0].clone()];
+    let mut prevouts = vec![unsigned_commit_tx.output[vout].clone()];
 
     if let Some(parent_info) = parent_info {
       prevouts.insert(0, parent_info.tx_out);

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -187,11 +187,14 @@ impl Inscribe {
 
     let commit = client.send_raw_transaction(&signed_commit_tx)?;
 
-    let reveal = match client
-      .send_raw_transaction(&signed_reveal_tx) {
-        Ok(txid) => txid,
-        Err(err) => return Err(anyhow!("Failed to send reveal transaction: {err}\nCommit tx {commit} will be recovered once mined"))
-      };
+    let reveal = match client.send_raw_transaction(&signed_reveal_tx) {
+      Ok(txid) => txid,
+      Err(err) => {
+        return Err(anyhow!(
+        "Failed to send reveal transaction: {err}\nCommit tx {commit} will be recovered once mined"
+      ))
+      }
+    };
 
     Ok(Box::new(Output {
       commit,


### PR DESCRIPTION
the prevouts being used to construct the reveal signature is:
```rust
let mut prevouts = vec![unsigned_commit_tx.output[0].clone()];

if let Some(parent_info) = parent_info {
  prevouts.insert(0, parent_info.tx_out);
}
```
but using `unsigned_commit_tx.output[0]` as one of its elements is a wrong assumption since a inscribe run can be called using `--satpoint` with offset > 0, which would make the first output of the commit transaction to be a change (part not used of the satpoint), and not the output encoding the taproot spending condition.

Example of a inscribe using `--satpoint=cad80aa153050fa300fc539e35fbb2046f4c99d3e09b27437db2232bfec43f71:2:1000`
![image](https://github.com/ordinals/ord/assets/37600416/d884819b-8b70-448a-ad2b-319ef30c1df5)
(example produced building ord with the code from this pr. https://mempool.space/pt/testnet/tx/aab6b689ec23b60e0943adf6357eb3a2cdb8c50ebfaf10cb972f96155a239f4b#flow=&vout=1)
In this case, `unsigned_commit_tx.output[0]` is the first output with `1000sat` value

---

this pr fix #2465