### PR TITLE
Add rune fuzz targets

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -57,6 +57,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,17 +381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,16 +574,16 @@ dependencies = [
 
 [[package]]
 name = "boilerplate"
-version = "0.2.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e7294fa817b2deee8867b77bc4d378523240b5dddecdd9f11fd08187503048"
+checksum = "1906889b1f805a715eac02b2dea416e25c5cfa00f099530fa9d137a3cff93113"
 dependencies = [
- "darling",
+ "darling 0.20.3",
  "mime",
  "new_mime_guess",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -619,43 +656,77 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "3.2.25"
+name = "ciborium"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+dependencies = [
+ "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
- "once_cell",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
@@ -778,8 +849,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -797,14 +878,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.27",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -853,7 +959,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1243,6 +1349,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,15 +1396,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1501,7 +1604,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1512,7 +1615,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
@@ -1680,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "mp4"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509348cba250e7b852a875100a2ddce7a36ee3abf881a681c756670c1774264d"
+checksum = "c9ef834d5ed55e494a2ae350220314dc4aacd1c43a9498b00e320e0ea352a5c3"
 dependencies = [
  "byteorder",
  "bytes",
@@ -1788,7 +1891,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1830,9 +1933,10 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ord"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "axum-server",
  "base64 0.21.2",
@@ -1841,6 +1945,7 @@ dependencies = [
  "bitcoin",
  "boilerplate",
  "chrono",
+ "ciborium",
  "clap",
  "ctrlc",
  "derive_more",
@@ -1879,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "ord-bitcoincore-rpc"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece3c1158d3391127ddd7615868792a602745cf4f9fbea259c4449c9ed89814a"
+checksum = "3d57a4297d466506cde088e020b33819f9a496d50272b14d7890e6fde5595a3e"
 dependencies = [
  "bitcoin-private",
  "jsonrpc",
@@ -1893,21 +1998,15 @@ dependencies = [
 
 [[package]]
 name = "ord-bitcoincore-rpc-json"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f46eb509cc95759461d3cb483ba51b2adbea0e31747cb1e3f388e71e13a321"
+checksum = "5bb35088f918c775bc27fa79e372d034892b216fb7900aeedd6e06654879ad33"
 dependencies = [
  "bitcoin",
  "bitcoin-private",
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "parking"
@@ -1989,30 +2088,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -2266,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "6.8.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
+checksum = "b1e7d90385b59f0a6bf3d3b757f3ca4ece2048265d70db20a2016043d4509a40"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -2277,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "6.8.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
+checksum = "3c3d8c6fd84090ae348e63a84336b112b5c3918b3bf0493a581f7bd8ee623c29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2290,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "7.8.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
+checksum = "873feff8cb7bf86fdf0a71bb21c95159f4e4a37dd7a4bd1855a940909b583ada"
 dependencies = [
  "sha2",
  "walkdir",
@@ -2511,6 +2586,7 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",
@@ -2748,12 +2824,6 @@ checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -3040,6 +3110,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "value-bag"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,25 @@ libfuzzer-sys = "0.4"
 ord = { path = ".." }
 
 [[bin]]
+name = "runestone-decipher"
+path = "fuzz_targets/runestone_decipher.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "transaction-builder"
 path = "fuzz_targets/transaction_builder.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "varint-encode"
+path = "fuzz_targets/varint_encode.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "varint-decode"
+path = "fuzz_targets/varint_decode.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/runestone_decipher.rs
+++ b/fuzz/fuzz_targets/runestone_decipher.rs
@@ -1,0 +1,36 @@
+#![no_main]
+
+use {
+  bitcoin::{
+    locktime, opcodes,
+    script::{self, PushBytes},
+    Transaction, TxOut,
+  },
+  libfuzzer_sys::fuzz_target,
+  ord::runes::Runestone,
+};
+
+fuzz_target!(|input: Vec<Vec<u8>>| {
+  let mut builder = script::Builder::new()
+    .push_opcode(opcodes::all::OP_RETURN)
+    .push_slice(b"RUNE_TEST");
+
+  for slice in input {
+    let Ok(push): Result<&PushBytes, _> = slice.as_slice().try_into() else {
+      continue;
+    };
+    builder = builder.push_slice(push);
+  }
+
+  let tx = Transaction {
+    input: Vec::new(),
+    lock_time: locktime::absolute::LockTime::ZERO,
+    output: vec![TxOut {
+      script_pubkey: builder.into_script(),
+      value: 0,
+    }],
+    version: 0,
+  };
+
+  Runestone::from_transaction(&tx);
+});

--- a/fuzz/fuzz_targets/transaction_builder.rs
+++ b/fuzz/fuzz_targets/transaction_builder.rs
@@ -7,7 +7,7 @@ use {
     Amount, OutPoint,
   },
   libfuzzer_sys::fuzz_target,
-  ord::{FeeRate, SatPoint, TransactionBuilder},
+  ord::{FeeRate, SatPoint, Target, TransactionBuilder},
   std::collections::BTreeMap,
 };
 
@@ -62,29 +62,34 @@ fuzz_target!(|input: Input| {
       .assume_checked(),
   ];
 
-  let Ok(fee_rate) = FeeRate::try_from(input.fee_rate) else { return; };
+  let Ok(fee_rate) = FeeRate::try_from(input.fee_rate) else {
+    return;
+  };
 
   match input.output_value {
     Some(output_value) => {
-      let _ = TransactionBuilder::build_transaction_with_value(
+      let _ = TransactionBuilder::new(
         satpoint,
         inscriptions,
         amounts,
         recipient,
         change,
         fee_rate,
-        Amount::from_sat(output_value),
-      );
+        Target::Value(Amount::from_sat(output_value)),
+      )
+      .build_transaction();
     }
     None => {
-      let _ = TransactionBuilder::build_transaction_with_postage(
+      let _ = TransactionBuilder::new(
         satpoint,
         inscriptions,
         amounts,
         recipient,
         change,
         fee_rate,
-      );
+        Target::Postage,
+      )
+      .build_transaction();
     }
   }
 });

--- a/fuzz/fuzz_targets/varint_decode.rs
+++ b/fuzz/fuzz_targets/varint_decode.rs
@@ -1,0 +1,17 @@
+#![no_main]
+
+use {libfuzzer_sys::fuzz_target, ord::runes::varint};
+
+fuzz_target!(|input: &[u8]| {
+  let mut i = 0;
+
+  while i < input.len() {
+    let Ok((decoded, length)) = varint::decode(&input[i..]) else {
+      break;
+    };
+    let mut encoded = Vec::new();
+    varint::encode_to_vec(decoded, &mut encoded);
+    assert_eq!(encoded, &input[i..i + length]);
+    i += length;
+  }
+});

--- a/fuzz/fuzz_targets/varint_encode.rs
+++ b/fuzz/fuzz_targets/varint_encode.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use {libfuzzer_sys::fuzz_target, ord::runes::varint};
+
+fuzz_target!(|input: u128| {
+  let mut encoded = Vec::new();
+  varint::encode_to_vec(input, &mut encoded);
+  let (decoded, length) = varint::decode(&encoded).unwrap();
+  assert_eq!(length, encoded.len());
+  assert_eq!(decoded, input);
+});

--- a/justfile
+++ b/justfile
@@ -68,7 +68,16 @@ profile-tests:
     | tee test-times.txt
 
 fuzz:
-  cd fuzz && cargo +nightly fuzz run transaction-builder
+  #!/usr/bin/env bash
+  set -euxo pipefail
+
+  cd fuzz
+
+  while true; do
+    cargo +nightly fuzz run runestone-decipher -- -max_total_time=60
+    cargo +nightly fuzz run varint-decode -- -max_total_time=60
+    cargo +nightly fuzz run varint-encode -- -max_total_time=60
+  done
 
 open:
   open http://localhost

--- a/justfile
+++ b/justfile
@@ -74,6 +74,7 @@ fuzz:
   cd fuzz
 
   while true; do
+    cargo +nightly fuzz run transaction-builder -- -max_total_time=60
     cargo +nightly fuzz run runestone-decipher -- -max_total_time=60
     cargo +nightly fuzz run varint-decode -- -max_total_time=60
     cargo +nightly fuzz run varint-encode -- -max_total_time=60

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,13 @@ use {
 };
 
 pub use crate::{
-  fee_rate::FeeRate, inscription::Inscription, object::Object, rarity::Rarity, sat::Sat,
-  sat_point::SatPoint, subcommand::wallet::transaction_builder::TransactionBuilder,
+  fee_rate::FeeRate,
+  inscription::Inscription,
+  object::Object,
+  rarity::Rarity,
+  sat::Sat,
+  sat_point::SatPoint,
+  subcommand::wallet::transaction_builder::{Target, TransactionBuilder},
 };
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ mod outgoing;
 mod page_config;
 pub mod rarity;
 mod representation;
-mod runes;
+pub mod runes;
 pub mod sat;
 mod sat_point;
 pub mod subcommand;

--- a/src/runes.rs
+++ b/src/runes.rs
@@ -1,8 +1,8 @@
 use {self::error::Error, super::*};
 
-pub(crate) use {
-  edict::Edict, etching::Etching, pile::Pile, rune::Rune, rune_id::RuneId, runestone::Runestone,
-};
+pub use runestone::Runestone;
+
+pub(crate) use {edict::Edict, etching::Etching, pile::Pile, rune::Rune, rune_id::RuneId};
 
 const MAX_DIVISIBILITY: u8 = 38;
 
@@ -13,7 +13,7 @@ mod pile;
 mod rune;
 mod rune_id;
 mod runestone;
-pub(crate) mod varint;
+pub mod varint;
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/src/subcommand/wallet/transaction_builder.rs
+++ b/src/subcommand/wallet/transaction_builder.rs
@@ -121,7 +121,7 @@ impl TransactionBuilder {
   pub(crate) const TARGET_POSTAGE: Amount = Amount::from_sat(10_000);
   pub(crate) const MAX_POSTAGE: Amount = Amount::from_sat(2 * 10_000);
 
-  pub(crate) fn new(
+  pub fn new(
     outgoing: SatPoint,
     inscriptions: BTreeMap<SatPoint, InscriptionId>,
     amounts: BTreeMap<OutPoint, Amount>,
@@ -145,7 +145,7 @@ impl TransactionBuilder {
     }
   }
 
-  pub(crate) fn build_transaction(self) -> Result<Transaction> {
+  pub fn build_transaction(self) -> Result<Transaction> {
     if self.change_addresses.len() < 2 {
       return Err(Error::DuplicateAddress(
         self.change_addresses.first().unwrap().clone(),


### PR DESCRIPTION
The `transaction-builder` fuzz target is broken, so I removed it from the recipe. I changed the fuzz testing recipe to run all the fuzz targets for a minute at a time. This allows splitting time evenly between targets.