### PR TITLE
Revert "Fixes release tarbomb (#2473)"

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -19,14 +19,14 @@ if [[ $OS == windows-latest ]]; then
 fi
 
 echo "Copying release files..."
-mkdir -p dist/ord-$VERSION
+mkdir dist
 cp \
   $EXECUTABLE \
   Cargo.lock \
   Cargo.toml \
   LICENSE \
   README.md \
-  $DIST/ord-$VERSION
+  $DIST
 
 cd $DIST
 echo "Creating release archive..."


### PR DESCRIPTION
This reverts commit fba065684f3a42ff3f447f2a7c6a8790da46a9bb. This was a good change, but requires coordination between the bin/package and install.sh. I'll open a new PR which contains the reverted change, along with the accompanying change to install.sh.