### PR TITLE
Create single-directory release archives

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -19,14 +19,14 @@ if [[ $OS == windows-latest ]]; then
 fi
 
 echo "Copying release files..."
-mkdir dist
+mkdir -p dist/ord-$VERSION
 cp \
   $EXECUTABLE \
   Cargo.lock \
   Cargo.toml \
   LICENSE \
   README.md \
-  $DIST
+  $DIST/ord-$VERSION
 
 cd $DIST
 echo "Creating release archive..."

--- a/install.sh
+++ b/install.sh
@@ -128,7 +128,7 @@ say_err "Destination: $dest"
 say_err "Archive:     $archive"
 
 td=$(mktemp -d || mktemp -d -t tmp)
-curl --proto =https --tlsv1.2 -sSfL $archive | tar -C $td -xz
+curl --proto =https --tlsv1.2 -sSfL $archive | tar --directory $td --strip-components 1 -xz
 
 for f in $(ls $td); do
   test -x $td/$f || continue


### PR DESCRIPTION
This puts the files in release archives inside a directory, so that when you extract them, they stay within a directory. This should be merged right before doing a release, so that the next release archive is compatible.