### PR TITLE
Remove paranthetical annotations

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -2059,7 +2059,7 @@ mod tests {
   <dt>id</dt>
   <dd class=monospace>{inscription_id}</dd>
   <dt>preview</dt>.*<dt>output</dt>
-  <dd><a class=monospace href=/output/0000000000000000000000000000000000000000000000000000000000000000:0>0000000000000000000000000000000000000000000000000000000000000000:0 \\(unbound\\)</a></dd>.*"
+  <dd><a class=monospace href=/output/0000000000000000000000000000000000000000000000000000000000000000:0>0000000000000000000000000000000000000000000000000000000000000000:0</a></dd>.*"
       ),
     );
   }
@@ -3315,7 +3315,7 @@ mod tests {
       "/inscription/-1",
       StatusCode::OK,
       format!(
-        ".*<h1>Inscription -1 \\(unstable\\)</h1>.*
+        ".*<h1>Inscription -1</h1>.*
 <dl>
   <dt>id</dt>
   <dd class=monospace>{cursed_inscription_id}</dd>.*"

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -276,14 +276,14 @@ mod tests {
         timestamp: timestamp(0),
       },
       "
-        <h1>Inscription -1 \\(unstable\\)</h1>
+        <h1>Inscription -1</h1>
         .*
         <dl>
           .*
           <dt>location</dt>
-          <dd class=monospace>0{64}:0:0 \\(unbound\\)</dd>
+          <dd class=monospace>0{64}:0:0</dd>
           <dt>output</dt>
-          <dd><a class=monospace href=/output/0{64}:0>0{64}:0 \\(unbound\\)</a></dd>
+          <dd><a class=monospace href=/output/0{64}:0>0{64}:0</a></dd>
           .*
         </dl>
       "

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -1,8 +1,4 @@
-%% if self.inscription_number >= 0 {
 <h1>Inscription {{ self.inscription_number }}</h1>
-%% } else {
-<h1>Inscription {{ self.inscription_number }} (unstable)</h1>
-%% }
 <div class=inscription>
 %% if let Some(previous) = self.previous {
 <a class=prev href=/inscription/{{previous}}>❮</a>
@@ -66,15 +62,9 @@
   <dt>genesis transaction</dt>
   <dd><a class=monospace href=/tx/{{ self.inscription_id.txid }}>{{ self.inscription_id.txid }}</a></dd>
   <dt>location</dt>
-%% if self.satpoint.outpoint == unbound_outpoint() {
-  <dd class=monospace>{{ self.satpoint }} (unbound)</dd>
-  <dt>output</dt>
-  <dd><a class=monospace href=/output/{{ self.satpoint.outpoint }}>{{ self.satpoint.outpoint }} (unbound)</a></dd>
-%% } else {
   <dd class=monospace>{{ self.satpoint }}</dd>
   <dt>output</dt>
   <dd><a class=monospace href=/output/{{ self.satpoint.outpoint }}>{{ self.satpoint.outpoint }}</a></dd>
-%% }
   <dt>offset</dt>
   <dd>{{ self.satpoint.offset }}</dd>
 %% if !self.children.is_empty() {


### PR DESCRIPTION
I think the `(unbound)` and `(unstable)` annotations are unattractive, so I removed them. Practically speaking, I think having `(unstable)` in large letters the inscription title makes cursed inscriptions unnecessarily unattractive and undesirable. `(unbound)` is also kind of unattractive, so I removed that too.