### PR TITLE
Refactor index checks

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -673,10 +673,6 @@ impl Index {
     &self,
     outpoint: OutPoint,
   ) -> Result<Vec<(Rune, Pile)>> {
-    if !self.has_rune_index()? {
-      return Ok(Vec::new());
-    }
-
     let rtx = &self.database.begin_read()?;
 
     let outpoint_to_balances = rtx.open_table(OUTPOINT_TO_RUNE_BALANCES)?;

--- a/src/index.rs
+++ b/src/index.rs
@@ -35,7 +35,7 @@ mod updater;
 #[cfg(test)]
 pub(crate) mod testing;
 
-const SCHEMA_VERSION: u64 = 8;
+const SCHEMA_VERSION: u64 = 9;
 
 macro_rules! define_table {
   ($name:ident, $key:ty, $value:ty) => {
@@ -75,16 +75,17 @@ pub enum List {
 }
 
 #[derive(Copy, Clone)]
-#[repr(u64)]
 pub(crate) enum Statistic {
-  Schema = 0,
-  Commits = 1,
-  LostSats = 2,
-  OutputsTraversed = 3,
-  SatRanges = 4,
-  UnboundInscriptions = 5,
-  CursedInscriptions = 6,
-  BlessedInscriptions = 7,
+  BlessedInscriptions,
+  Commits,
+  CursedInscriptions,
+  IndexRunes,
+  IndexSats,
+  LostSats,
+  OutputsTraversed,
+  SatRanges,
+  Schema,
+  UnboundInscriptions,
 }
 
 impl Statistic {
@@ -154,6 +155,8 @@ pub(crate) struct Index {
   genesis_block_coinbase_transaction: Transaction,
   genesis_block_coinbase_txid: Txid,
   height_limit: Option<u64>,
+  index_runes: bool,
+  index_sats: bool,
   options: Options,
   path: PathBuf,
   unrecoverably_reorged: AtomicBool,
@@ -207,19 +210,23 @@ impl Index {
       redb::Durability::Immediate
     };
 
+    let index_runes;
+    let index_sats;
+
     let database = match Database::builder()
       .set_cache_size(db_cache_size)
       .open(&path)
     {
       Ok(database) => {
-        let schema_version = database
-          .begin_read()?
-          .open_table(STATISTIC_TO_COUNT)?
-          .get(&Statistic::Schema.key())?
-          .map(|x| x.value())
-          .unwrap_or(0);
+        {
+          let tx = database.begin_read()?;
+          let schema_version = tx
+            .open_table(STATISTIC_TO_COUNT)?
+            .get(&Statistic::Schema.key())?
+            .map(|x| x.value())
+            .unwrap_or(0);
 
-        match schema_version.cmp(&SCHEMA_VERSION) {
+          match schema_version.cmp(&SCHEMA_VERSION) {
           cmp::Ordering::Less =>
             bail!(
               "index at `{}` appears to have been built with an older, incompatible version of ord, consider deleting and rebuilding the index: index schema {schema_version}, ord schema {SCHEMA_VERSION}",
@@ -232,6 +239,20 @@ impl Index {
             ),
           cmp::Ordering::Equal => {
           }
+        }
+
+          let statistics = tx.open_table(STATISTIC_TO_COUNT)?;
+
+          index_runes = statistics
+            .get(&Statistic::IndexRunes.key())?
+            .unwrap()
+            .value()
+            != 0;
+          index_sats = statistics
+            .get(&Statistic::IndexSats.key())?
+            .unwrap()
+            .value()
+            != 0;
         }
 
         database
@@ -253,23 +274,31 @@ impl Index {
         tx.open_table(INSCRIPTION_ID_TO_INSCRIPTION_ENTRY)?;
         tx.open_table(INSCRIPTION_ID_TO_SATPOINT)?;
         tx.open_table(INSCRIPTION_NUMBER_TO_INSCRIPTION_ID)?;
+        tx.open_table(OUTPOINT_TO_RUNE_BALANCES)?;
         tx.open_table(OUTPOINT_TO_VALUE)?;
+        tx.open_table(RUNE_ID_TO_RUNE_ENTRY)?;
+        tx.open_table(RUNE_TO_RUNE_ID)?;
         tx.open_table(SAT_TO_SATPOINT)?;
         tx.open_table(SEQUENCE_NUMBER_TO_INSCRIPTION_ID)?;
         tx.open_table(WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP)?;
 
-        tx.open_table(STATISTIC_TO_COUNT)?
-          .insert(&Statistic::Schema.key(), &SCHEMA_VERSION)?;
+        {
+          let mut outpoint_to_sat_ranges = tx.open_table(OUTPOINT_TO_SAT_RANGES)?;
+          let mut statistics = tx.open_table(STATISTIC_TO_COUNT)?;
 
-        if options.index_runes() {
-          tx.open_table(OUTPOINT_TO_RUNE_BALANCES)?;
-          tx.open_table(RUNE_ID_TO_RUNE_ENTRY)?;
-          tx.open_table(RUNE_TO_RUNE_ID)?;
-        }
+          if options.index_sats {
+            outpoint_to_sat_ranges.insert(&OutPoint::null().store(), [].as_slice())?;
+          }
 
-        if options.index_sats {
-          tx.open_table(OUTPOINT_TO_SAT_RANGES)?
-            .insert(&OutPoint::null().store(), [].as_slice())?;
+          index_runes = options.index_runes();
+          index_sats = options.index_sats;
+
+          statistics.insert(
+            &Statistic::IndexRunes.key(),
+            &u64::from(options.index_runes()),
+          )?;
+          statistics.insert(&Statistic::IndexSats.key(), &u64::from(options.index_sats))?;
+          statistics.insert(&Statistic::Schema.key(), &SCHEMA_VERSION)?;
         }
 
         tx.commit()?;
@@ -290,6 +319,8 @@ impl Index {
       genesis_block_coinbase_transaction,
       height_limit: options.height_limit,
       options: options.clone(),
+      index_runes,
+      index_sats,
       path,
       unrecoverably_reorged: AtomicBool::new(false),
     })
@@ -358,28 +389,8 @@ impl Index {
       .collect()
   }
 
-  pub(crate) fn has_rune_index(&self) -> Result<bool> {
-    match self.begin_read()?.0.open_table(RUNE_ID_TO_RUNE_ENTRY) {
-      Ok(_) => Ok(true),
-      Err(redb::TableError::TableDoesNotExist(_)) => Ok(false),
-      Err(err) => Err(err.into()),
-    }
-  }
-
-  pub(crate) fn has_sat_index(&self) -> Result<bool> {
-    match self.begin_read()?.0.open_table(OUTPOINT_TO_SAT_RANGES) {
-      Ok(_) => Ok(true),
-      Err(redb::TableError::TableDoesNotExist(_)) => Ok(false),
-      Err(err) => Err(err.into()),
-    }
-  }
-
-  fn require_sat_index(&self, feature: &str) -> Result {
-    if !self.has_sat_index()? {
-      bail!("{feature} requires index created with `--index-sats` flag")
-    }
-
-    Ok(())
+  pub(crate) fn has_sat_index(&self) -> bool {
+    self.index_sats
   }
 
   pub(crate) fn info(&self) -> Result<Info> {
@@ -602,76 +613,60 @@ impl Index {
     Ok(blocks)
   }
 
-  pub(crate) fn rare_sat_satpoints(&self) -> Result<Option<Vec<(Sat, SatPoint)>>> {
-    if self.has_sat_index()? {
-      let rtx = self.database.begin_read()?;
+  pub(crate) fn rare_sat_satpoints(&self) -> Result<Vec<(Sat, SatPoint)>> {
+    let rtx = self.database.begin_read()?;
 
-      let sat_to_satpoint = rtx.open_table(SAT_TO_SATPOINT)?;
+    let sat_to_satpoint = rtx.open_table(SAT_TO_SATPOINT)?;
 
-      let mut result = Vec::with_capacity(sat_to_satpoint.len()?.try_into().unwrap());
+    let mut result = Vec::with_capacity(sat_to_satpoint.len()?.try_into().unwrap());
 
-      for range in sat_to_satpoint.range(0..)? {
-        let (sat, satpoint) = range?;
-        result.push((Sat(sat.value()), Entry::load(*satpoint.value())));
-      }
-
-      Ok(Some(result))
-    } else {
-      Ok(None)
+    for range in sat_to_satpoint.range(0..)? {
+      let (sat, satpoint) = range?;
+      result.push((Sat(sat.value()), Entry::load(*satpoint.value())));
     }
+
+    Ok(result)
   }
 
   pub(crate) fn rare_sat_satpoint(&self, sat: Sat) -> Result<Option<SatPoint>> {
-    if self.has_sat_index()? {
-      Ok(
-        self
-          .database
-          .begin_read()?
-          .open_table(SAT_TO_SATPOINT)?
-          .get(&sat.n())?
-          .map(|satpoint| Entry::load(*satpoint.value())),
-      )
-    } else {
-      Ok(None)
-    }
+    Ok(
+      self
+        .database
+        .begin_read()?
+        .open_table(SAT_TO_SATPOINT)?
+        .get(&sat.n())?
+        .map(|satpoint| Entry::load(*satpoint.value())),
+    )
   }
 
   pub(crate) fn rune(&self, rune: Rune) -> Result<Option<(RuneId, RuneEntry)>> {
-    if self.has_rune_index()? {
-      let rtx = self.database.begin_read()?;
+    let rtx = self.database.begin_read()?;
 
-      let entry = match rtx.open_table(RUNE_TO_RUNE_ID)?.get(rune.0)? {
-        Some(id) => rtx
-          .open_table(RUNE_ID_TO_RUNE_ENTRY)?
-          .get(id.value())?
-          .map(|entry| (RuneId::load(id.value()), RuneEntry::load(entry.value()))),
-        None => None,
-      };
+    let entry = match rtx.open_table(RUNE_TO_RUNE_ID)?.get(rune.0)? {
+      Some(id) => rtx
+        .open_table(RUNE_ID_TO_RUNE_ENTRY)?
+        .get(id.value())?
+        .map(|entry| (RuneId::load(id.value()), RuneEntry::load(entry.value()))),
+      None => None,
+    };
 
-      Ok(entry)
-    } else {
-      Ok(None)
-    }
+    Ok(entry)
   }
 
-  pub(crate) fn runes(&self) -> Result<Option<Vec<(RuneId, RuneEntry)>>> {
-    if self.has_rune_index()? {
-      let mut entries = Vec::new();
+  pub(crate) fn runes(&self) -> Result<Vec<(RuneId, RuneEntry)>> {
+    let mut entries = Vec::new();
 
-      for result in self
-        .database
-        .begin_read()?
-        .open_table(RUNE_ID_TO_RUNE_ENTRY)?
-        .iter()?
-      {
-        let (id, entry) = result?;
-        entries.push((RuneId::load(id.value()), RuneEntry::load(entry.value())));
-      }
-
-      Ok(Some(entries))
-    } else {
-      Ok(None)
+    for result in self
+      .database
+      .begin_read()?
+      .open_table(RUNE_ID_TO_RUNE_ENTRY)?
+      .iter()?
+    {
+      let (id, entry) = result?;
+      entries.push((RuneId::load(id.value()), RuneEntry::load(entry.value())));
     }
+
+    Ok(entries)
   }
 
   #[cfg(test)]
@@ -919,8 +914,6 @@ impl Index {
   }
 
   pub(crate) fn find(&self, sat: u64) -> Result<Option<SatPoint>> {
-    self.require_sat_index("find")?;
-
     let rtx = self.begin_read()?;
 
     if rtx.block_count()? <= Sat(sat).height().n() {
@@ -952,8 +945,6 @@ impl Index {
     range_start: u64,
     range_end: u64,
   ) -> Result<Option<Vec<FindRangeOutput>>> {
-    self.require_sat_index("find")?;
-
     let rtx = self.begin_read()?;
 
     if rtx.block_count()? < Sat(range_end - 1).height().n() + 1 {
@@ -1012,7 +1003,9 @@ impl Index {
   }
 
   pub(crate) fn list(&self, outpoint: OutPoint) -> Result<Option<List>> {
-    self.require_sat_index("list")?;
+    if !self.index_sats {
+      return Ok(None);
+    }
 
     let array = outpoint.store();
 
@@ -1256,7 +1249,7 @@ impl Index {
 
     match sat {
       Some(sat) => {
-        if self.has_sat_index().unwrap() {
+        if self.index_sats {
           // unbound inscriptions should not be assigned to a sat
           assert!(satpoint.outpoint != unbound_outpoint());
           assert!(rtx
@@ -1284,7 +1277,7 @@ impl Index {
         }
       }
       None => {
-        if self.has_sat_index().unwrap() {
+        if self.index_sats {
           assert!(satpoint.outpoint == unbound_outpoint())
         }
       }
@@ -1333,19 +1326,17 @@ impl Index {
       }
     }
 
-    if self.has_sat_index().unwrap() {
-      for range in rtx
-        .open_multimap_table(SAT_TO_INSCRIPTION_ID)
-        .unwrap()
-        .iter()
-        .into_iter()
-      {
-        for entry in range.into_iter() {
-          let (_sat, ids) = entry.unwrap();
-          assert!(!ids
-            .into_iter()
-            .any(|id| InscriptionId::load(*id.unwrap().value()) == inscription_id))
-        }
+    for range in rtx
+      .open_multimap_table(SAT_TO_INSCRIPTION_ID)
+      .unwrap()
+      .iter()
+      .into_iter()
+    {
+      for entry in range.into_iter() {
+        let (_sat, ids) = entry.unwrap();
+        assert!(!ids
+          .into_iter()
+          .any(|id| InscriptionId::load(*id.unwrap().value()) == inscription_id))
       }
     }
   }

--- a/src/index/testing.rs
+++ b/src/index/testing.rs
@@ -53,11 +53,6 @@ impl ContextBuilder {
     self
   }
 
-  pub(crate) fn chain(mut self, chain: Chain) -> Self {
-    self.chain = chain;
-    self
-  }
-
   pub(crate) fn tempdir(mut self, tempdir: TempDir) -> Self {
     self.tempdir = Some(tempdir);
     self

--- a/src/page_config.rs
+++ b/src/page_config.rs
@@ -4,4 +4,5 @@ use super::*;
 pub(crate) struct PageConfig {
   pub(crate) chain: Chain,
   pub(crate) domain: Option<String>,
+  pub(crate) index_sats: bool,
 }

--- a/src/runes.rs
+++ b/src/runes.rs
@@ -24,29 +24,43 @@ mod tests {
   const RUNE: u128 = (21_000_000 * COIN_VALUE) as u128;
 
   #[test]
-  fn index_only_indexes_runes_if_flag_is_passed_and_on_mainnet() {
-    assert!(!Context::builder().build().index.has_rune_index().unwrap());
-    assert!(!Context::builder()
-      .arg("--index-runes-pre-alpha-i-agree-to-get-rekt")
-      .chain(Chain::Mainnet)
-      .build()
-      .index
-      .has_rune_index()
-      .unwrap());
-    assert!(Context::builder()
-      .arg("--index-runes-pre-alpha-i-agree-to-get-rekt")
-      .build()
-      .index
-      .has_rune_index()
-      .unwrap());
-  }
-
-  #[test]
   fn index_starts_with_no_runes() {
     let context = Context::builder()
       .arg("--index-runes-pre-alpha-i-agree-to-get-rekt")
       .build();
-    assert_eq!(context.index.runes().unwrap().unwrap(), []);
+    assert_eq!(context.index.runes().unwrap(), []);
+    assert_eq!(context.index.rune_balances(), []);
+  }
+
+  #[test]
+  fn default_index_does_not_index_runes() {
+    let context = Context::builder().build();
+
+    context.mine_blocks(1);
+
+    context.rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(1, 0, 0, Witness::new())],
+      op_return: Some(
+        Runestone {
+          edicts: vec![Edict {
+            id: 0,
+            amount: u128::max_value(),
+            output: 0,
+          }],
+          etching: Some(Etching {
+            divisibility: 0,
+            rune: Rune(RUNE),
+          }),
+        }
+        .encipher(),
+      ),
+      ..Default::default()
+    });
+
+    context.mine_blocks(1);
+
+    assert_eq!(context.index.runes().unwrap(), []);
+
     assert_eq!(context.index.rune_balances(), []);
   }
 
@@ -72,7 +86,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    assert_eq!(context.index.runes().unwrap().unwrap(), []);
+    assert_eq!(context.index.runes().unwrap(), []);
     assert_eq!(context.index.rune_balances(), []);
   }
 
@@ -101,7 +115,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    assert_eq!(context.index.runes().unwrap().unwrap(), []);
+    assert_eq!(context.index.runes().unwrap(), []);
     assert_eq!(context.index.rune_balances(), []);
   }
 
@@ -140,7 +154,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -190,7 +204,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      assert_eq!(context.index.runes().unwrap().unwrap(), []);
+      assert_eq!(context.index.runes().unwrap(), []);
 
       assert_eq!(context.index.rune_balances(), []);
     }
@@ -229,7 +243,7 @@ mod tests {
       };
 
       assert_eq!(
-        context.index.runes().unwrap().unwrap(),
+        context.index.runes().unwrap(),
         [(
           id,
           RuneEntry {
@@ -285,7 +299,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -347,7 +361,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -409,7 +423,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -464,7 +478,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -526,7 +540,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -591,7 +605,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -646,7 +660,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -690,7 +704,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -751,7 +765,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -791,7 +805,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -853,7 +867,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -887,7 +901,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -948,7 +962,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -989,7 +1003,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -1044,7 +1058,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id0,
         RuneEntry {
@@ -1096,7 +1110,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [
         (
           id0,
@@ -1151,7 +1165,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [
         (
           id0,
@@ -1225,7 +1239,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id0,
         RuneEntry {
@@ -1277,7 +1291,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [
         (
           id0,
@@ -1332,7 +1346,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [
         (
           id0,
@@ -1397,7 +1411,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [
         (
           id0,
@@ -1483,7 +1497,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id0,
         RuneEntry {
@@ -1535,7 +1549,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [
         (
           id0,
@@ -1608,7 +1622,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [
         (
           id0,
@@ -1683,7 +1697,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -1722,7 +1736,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -1801,7 +1815,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [
         (
           id0,
@@ -1884,7 +1898,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -1935,7 +1949,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -1996,7 +2010,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id0,
         RuneEntry {
@@ -2048,7 +2062,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [
         (
           id0,
@@ -2121,7 +2135,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [
         (
           id0,
@@ -2204,7 +2218,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -2248,7 +2262,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -2309,7 +2323,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -2365,7 +2379,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -2428,7 +2442,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {

--- a/src/runes.rs
+++ b/src/runes.rs
@@ -99,9 +99,8 @@ mod tests {
       op_return: Some(
         Runestone {
           etching: Some(Etching {
-            divisibility: 0,
             rune: Rune(RUNE),
-            symbol: None,
+            ..Default::default()
           }),
           ..Default::default()
         }
@@ -122,17 +121,13 @@ mod tests {
       [(
         id,
         RuneEntry {
-          burned: 0,
-          divisibility: 0,
           etching: txid,
           rune: Rune(RUNE),
-          supply: 0,
-          symbol: None,
+          ..Default::default()
         }
       )]
     );
 
-    assert_eq!(context.index.runes().unwrap(), []);
     assert_eq!(context.index.get_rune_balances(), []);
   }
 

--- a/src/runes.rs
+++ b/src/runes.rs
@@ -28,7 +28,7 @@ mod tests {
     let context = Context::builder()
       .arg("--index-runes-pre-alpha-i-agree-to-get-rekt")
       .build();
-    assert_eq!(context.index.runes().unwrap().unwrap(), []);
+    assert_eq!(context.index.runes().unwrap(), []);
     assert_eq!(context.index.get_rune_balances(), []);
   }
 
@@ -50,6 +50,7 @@ mod tests {
           etching: Some(Etching {
             divisibility: 0,
             rune: Rune(RUNE),
+            symbol: None,
           }),
         }
         .encipher(),
@@ -86,7 +87,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    assert_eq!(context.index.runes().unwrap().unwrap(), []);
+    assert_eq!(context.index.runes().unwrap(), []);
     assert_eq!(context.index.get_rune_balances(), []);
   }
 
@@ -2499,7 +2500,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -2555,7 +2556,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -2611,7 +2612,7 @@ mod tests {
     };
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {
@@ -2656,7 +2657,7 @@ mod tests {
     context.mine_blocks(1);
 
     assert_eq!(
-      context.index.runes().unwrap().unwrap(),
+      context.index.runes().unwrap(),
       [(
         id,
         RuneEntry {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -20,8 +20,6 @@ pub(crate) enum Subcommand {
   Decode(decode::Decode),
   #[command(about = "List the first satoshis of each reward epoch")]
   Epochs,
-  #[command(about = "Run an explorer server populated with inscriptions")]
-  Preview(preview::Preview),
   #[command(about = "Find a satoshi's current location")]
   Find(find::Find),
   #[command(subcommand, about = "Index commands")]
@@ -32,10 +30,12 @@ pub(crate) enum Subcommand {
   List(list::List),
   #[command(about = "Parse a satoshi from ordinal notation")]
   Parse(parse::Parse),
-  #[command(about = "Display information about a block's subsidy")]
-  Subsidy(subsidy::Subsidy),
+  #[command(about = "Run an explorer server populated with inscriptions")]
+  Preview(preview::Preview),
   #[command(about = "Run the explorer server")]
   Server(server::Server),
+  #[command(about = "Display information about a block's subsidy")]
+  Subsidy(subsidy::Subsidy),
   #[command(about = "Display Bitcoin supply information")]
   Supply,
   #[command(about = "Display satoshi traits")]
@@ -49,19 +49,19 @@ impl Subcommand {
     match self {
       Self::Decode(decode) => decode.run(),
       Self::Epochs => epochs::run(),
-      Self::Preview(preview) => preview.run(),
       Self::Find(find) => find.run(options),
       Self::Index(index) => index.run(options),
       Self::Info(info) => info.run(options),
       Self::List(list) => list.run(options),
       Self::Parse(parse) => parse.run(),
-      Self::Subsidy(subsidy) => subsidy.run(),
+      Self::Preview(preview) => preview.run(),
       Self::Server(server) => {
         let index = Arc::new(Index::open(&options)?);
         let handle = axum_server::Handle::new();
         LISTENERS.lock().unwrap().push(handle.clone());
         server.run(options, index, handle)
       }
+      Self::Subsidy(subsidy) => subsidy.run(),
       Self::Supply => supply::run(),
       Self::Traits(traits) => traits.run(),
       Self::Wallet(wallet) => wallet.run(options),

--- a/src/subcommand/find.rs
+++ b/src/subcommand/find.rs
@@ -24,6 +24,10 @@ impl Find {
   pub(crate) fn run(self, options: Options) -> SubcommandResult {
     let index = Index::open(&options)?;
 
+    if !index.has_sat_index() {
+      bail!("find requires index created with `--index-sats` flag");
+    }
+
     index.update()?;
 
     match self.end {

--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -21,6 +21,10 @@ impl List {
   pub(crate) fn run(self, options: Options) -> SubcommandResult {
     let index = Index::open(&options)?;
 
+    if !index.has_sat_index() {
+      bail!("list requires index created with `--index-sats` flag");
+    }
+
     index.update()?;
 
     match index.list(self.outpoint)? {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -2255,7 +2255,7 @@ mod tests {
   }
 
   #[test]
-  fn rare_with_index() {
+  fn rare_with_sat_index() {
     TestServer::new_with_sat_index().assert_response(
       "/rare.txt",
       StatusCode::OK,
@@ -2266,8 +2266,8 @@ mod tests {
   }
 
   #[test]
-  fn rare_without_index() {
-    TestServer::new_with_sat_index().assert_response(
+  fn rare_without_sat_index() {
+    TestServer::new().assert_response(
       "/rare.txt",
       StatusCode::OK,
       "sat\tsatpoint

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -2266,6 +2266,16 @@ mod tests {
   }
 
   #[test]
+  fn rare_without_index() {
+    TestServer::new_with_sat_index().assert_response(
+      "/rare.txt",
+      StatusCode::OK,
+      "sat\tsatpoint
+",
+    );
+  }
+
+  #[test]
   fn show_rare_txt_in_header_with_sat_index() {
     TestServer::new_with_sat_index().assert_response_regex(
       "/",
@@ -3353,7 +3363,7 @@ mod tests {
     };
 
     assert_eq!(
-      server.index.runes().unwrap().unwrap(),
+      server.index.runes().unwrap(),
       [(
         id,
         RuneEntry {

--- a/src/subcommand/wallet/sats.rs
+++ b/src/subcommand/wallet/sats.rs
@@ -26,6 +26,11 @@ pub struct OutputRare {
 impl Sats {
   pub(crate) fn run(&self, options: Options) -> SubcommandResult {
     let index = Index::open(&options)?;
+
+    if !index.has_sat_index() {
+      bail!("sats requires index created with `--index-sats` flag");
+    }
+
     index.update()?;
 
     let utxos = index.get_unspent_output_ranges(Wallet::load(&options)?)?;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -45,24 +45,19 @@ mod transaction;
 #[derive(Boilerplate)]
 pub(crate) struct PageHtml<T: PageContent> {
   content: T,
-  has_sat_index: bool,
-  page_config: Arc<PageConfig>,
+  config: Arc<PageConfig>,
 }
 
 impl<T> PageHtml<T>
 where
   T: PageContent,
 {
-  pub(crate) fn new(content: T, page_config: Arc<PageConfig>, has_sat_index: bool) -> Self {
-    Self {
-      content,
-      has_sat_index,
-      page_config,
-    }
+  pub(crate) fn new(content: T, config: Arc<PageConfig>) -> Self {
+    Self { content, config }
   }
 
   fn og_image(&self) -> String {
-    if let Some(domain) = &self.page_config.domain {
+    if let Some(domain) = &self.config.domain {
       format!("https://{domain}/static/favicon.png")
     } else {
       "https://ordinals.com/static/favicon.png".into()
@@ -70,10 +65,10 @@ where
   }
 
   fn superscript(&self) -> String {
-    if self.page_config.chain == Chain::Mainnet {
+    if self.config.chain == Chain::Mainnet {
       "alpha".into()
     } else {
-      self.page_config.chain.to_string()
+      self.config.chain.to_string()
     }
   }
 }
@@ -81,11 +76,11 @@ where
 pub(crate) trait PageContent: Display + 'static {
   fn title(&self) -> String;
 
-  fn page(self, page_config: Arc<PageConfig>, has_sat_index: bool) -> PageHtml<Self>
+  fn page(self, page_config: Arc<PageConfig>) -> PageHtml<Self>
   where
     Self: Sized,
   {
-    PageHtml::new(self, page_config, has_sat_index)
+    PageHtml::new(self, page_config)
   }
 
   fn preview_image_url(&self) -> Option<Trusted<String>> {
@@ -114,13 +109,11 @@ mod tests {
   #[test]
   fn page() {
     assert_regex_match!(
-      Foo.page(
-        Arc::new(PageConfig {
-          chain: Chain::Mainnet,
-          domain: Some("signet.ordinals.com".into())
-        }),
-        true
-      ),
+      Foo.page(Arc::new(PageConfig {
+        chain: Chain::Mainnet,
+        domain: Some("signet.ordinals.com".into()),
+        index_sats: true,
+      }),),
       r"<!doctype html>
 <html lang=en>
   <head>
@@ -161,13 +154,11 @@ mod tests {
   #[test]
   fn page_mainnet() {
     assert_regex_match!(
-      Foo.page(
-        Arc::new(PageConfig {
-          chain: Chain::Mainnet,
-          domain: None
-        }),
-        true
-      ),
+      Foo.page(Arc::new(PageConfig {
+        chain: Chain::Mainnet,
+        domain: None,
+        index_sats: true,
+      }),),
       r".*<nav>\s*<a href=/>Ordinals<sup>alpha</sup></a>.*"
     );
   }
@@ -175,13 +166,11 @@ mod tests {
   #[test]
   fn page_no_sat_index() {
     assert_regex_match!(
-      Foo.page(
-        Arc::new(PageConfig {
-          chain: Chain::Mainnet,
-          domain: None
-        }),
-        false
-      ),
+      Foo.page(Arc::new(PageConfig {
+        chain: Chain::Mainnet,
+        domain: None,
+        index_sats: false,
+      }),),
       r".*<nav>\s*<a href=/>Ordinals<sup>alpha</sup></a>.*<a href=/clock>Clock</a>\s*<form action=/search.*",
     );
   }
@@ -189,13 +178,11 @@ mod tests {
   #[test]
   fn page_signet() {
     assert_regex_match!(
-      Foo.page(
-        Arc::new(PageConfig {
-          chain: Chain::Signet,
-          domain: None
-        }),
-        true
-      ),
+      Foo.page(Arc::new(PageConfig {
+        chain: Chain::Signet,
+        domain: None,
+        index_sats: true,
+      }),),
       r".*<nav>\s*<a href=/>Ordinals<sup>signet</sup></a>.*"
     );
   }

--- a/templates/page.html
+++ b/templates/page.html
@@ -20,7 +20,7 @@
       <a href=https://docs.ordinals.com/>Handbook</a>
       <a href=https://github.com/ordinals/ord>Wallet</a>
       <a href=/clock>Clock</a>
-%% if self.has_sat_index {
+%% if self.config.index_sats {
       <a href=/rare.txt>rare.txt</a>
 %% }
       <form action=/search method=get>

--- a/tests/wallet/sats.rs
+++ b/tests/wallet/sats.rs
@@ -4,6 +4,18 @@ use {
 };
 
 #[test]
+fn requires_sat_index() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  create_wallet(&rpc_server);
+
+  CommandBuilder::new("wallet sats")
+    .rpc_server(&rpc_server)
+    .expected_exit_code(1)
+    .expected_stderr("error: sats requires index created with `--index-sats` flag\n")
+    .run_and_extract_stdout();
+}
+
+#[test]
 fn sats() {
   let rpc_server = test_bitcoincore_rpc::spawn();
   create_wallet(&rpc_server);
@@ -37,7 +49,7 @@ fn sats_from_tsv_parse_error() {
   let rpc_server = test_bitcoincore_rpc::spawn();
   create_wallet(&rpc_server);
 
-  CommandBuilder::new("wallet sats --tsv foo.tsv")
+  CommandBuilder::new("--index-sats wallet sats --tsv foo.tsv")
     .write("foo.tsv", "===")
     .rpc_server(&rpc_server)
     .expected_exit_code(1)
@@ -51,7 +63,7 @@ fn sats_from_tsv_parse_error() {
 fn sats_from_tsv_file_not_found() {
   let rpc_server = test_bitcoincore_rpc::spawn();
   create_wallet(&rpc_server);
-  CommandBuilder::new("wallet sats --tsv foo.tsv")
+  CommandBuilder::new("--index-sats wallet sats --tsv foo.tsv")
     .rpc_server(&rpc_server)
     .expected_exit_code(1)
     .stderr_regex("error: I/O error reading `.*`\nbecause: .*\n")


### PR DESCRIPTION
- Remove index checks in server, just return empty responses.
- Create all tables when index is created, so all index functions can be called, and will just return empty responses when the index doesn't exist.
- Add explicit checks to those command which don't make sense without an index.

This just cleans up the code a bunch.