### PR TITLE
Always create rune, even if none were allocated

### DIFF
--- a/src/index/updater/rune_updater.rs
+++ b/src/index/updater/rune_updater.rs
@@ -136,28 +136,24 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
       {
         // Calculate the allocated supply
         let supply = u128::max_value() - balance;
-
-        // If no runes were allocated, ignore this issuance
-        if supply > 0 {
-          let id = RuneId::try_from(id).unwrap();
-          self.rune_to_id.insert(rune.0, id.store())?;
-          self.id_to_entry.insert(
-            id.store(),
-            RuneEntry {
-              burned: 0,
-              divisibility,
-              etching: txid,
-              rarity: if self.count == 0 {
-                self.rarity
-              } else {
-                Rarity::Common
-              },
-              rune,
-              supply,
-            }
-            .store(),
-          )?;
-        }
+        let id = RuneId::try_from(id).unwrap();
+        self.rune_to_id.insert(rune.0, id.store())?;
+        self.id_to_entry.insert(
+          id.store(),
+          RuneEntry {
+            burned: 0,
+            divisibility,
+            etching: txid,
+            rarity: if self.count == 0 {
+              self.rarity
+            } else {
+              Rarity::Common
+            },
+            rune,
+            supply,
+          }
+          .store(),
+        )?;
         self.count += 1;
       }
     }

--- a/src/runes.rs
+++ b/src/runes.rs
@@ -77,14 +77,14 @@ mod tests {
   }
 
   #[test]
-  fn etching_with_no_edicts_does_not_create_rune() {
+  fn etching_with_no_edicts_creates_rune() {
     let context = Context::builder()
       .arg("--index-runes-pre-alpha-i-agree-to-get-rekt")
       .build();
 
     context.mine_blocks(1);
 
-    context.rpc_server.broadcast_tx(TransactionTemplate {
+    let txid = context.rpc_server.broadcast_tx(TransactionTemplate {
       inputs: &[(1, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -101,7 +101,26 @@ mod tests {
 
     context.mine_blocks(1);
 
-    assert_eq!(context.index.runes().unwrap().unwrap(), []);
+    let id = RuneId {
+      height: 2,
+      index: 1,
+    };
+
+    assert_eq!(
+      context.index.runes().unwrap().unwrap(),
+      [(
+        id,
+        RuneEntry {
+          burned: 0,
+          divisibility: 0,
+          etching: txid,
+          rarity: Rarity::Uncommon,
+          rune: Rune(RUNE),
+          supply: 0,
+        }
+      )]
+    );
+
     assert_eq!(context.index.rune_balances(), []);
   }
 


### PR DESCRIPTION
Since it's so critical that we don't miss runes, it seems like a good idea to remove this special case. It also makes @rot13maxi's sophon a little bit cheaper to run, since he won't need to include an edict in the etchings.