### PR TITLE
dependency purification

### DIFF
--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -63,7 +63,7 @@
 
         {{#if mathjax_support}}
         <!-- MathJax -->
-        <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script async src="/content/dfcddc2ef31d803379729a87912d9246091f83303584cea31786ec189e8dc234i0"></script>
         {{/if}}
     </head>
     <body>

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -976,7 +976,7 @@ impl Server {
         (
           [(
             header::CONTENT_SECURITY_POLICY,
-            "script-src-elem 'self' https://cdn.jsdelivr.net; href-src 'self' https://cdn.jsdelivr.net",
+            "script-src-elem 'self'; href-src 'self'",
           )],
           PreviewCodeHtml { inscription_id },
         )
@@ -1001,7 +1001,7 @@ impl Server {
         (
           [(
             header::CONTENT_SECURITY_POLICY,
-            "script-src-elem 'self' https://cdn.jsdelivr.net",
+            "script-src-elem 'self'",
           )],
           PreviewMarkdownHtml { inscription_id },
         )

--- a/static/preview-code.css
+++ b/static/preview-code.css
@@ -1,4 +1,4 @@
-@import url('https://cdn.jsdelivr.net/npm/highlight.js@11.8.0/styles/atom-one-dark.min.css');
+@import url('/content/969cf0610b1dc284d83b2c078f3042cd0e8eda44ab63b7f104c6014979e8eeabi0');
 
 html {
     color: #98a3ad;

--- a/static/preview-code.js
+++ b/static/preview-code.js
@@ -1,8 +1,8 @@
-import hljs from 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/es/highlight.min.js';
-import javascript from 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/es/languages/javascript.min.js';
-import yaml from 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/es/languages/yaml.min.js';
-import css from 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/es/languages/css.min.js';
-import json from 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/es/languages/json.min.js';
+import hljs from '/content/e26e96915acbaed1888fdeb72402e9eb21f83e533ee26fc7101e631b3f78eae6i0';
+import javascript from '/content/7a115d8cb6f6f9feeca922cdeed30368db49d97ccb607ce4bcd6f94a7917555fi0';
+import yaml from '/content/0430c866bc414f8e744bb23aabc668c23ab8b71071e533fb4ee6e0832fb5cc22i0';
+import css from '/content/ca08f3ab2402161e6efdc2f4031793c237061fb2c9f561a0830618acdf970d5fi0';
+import json from '/content/ea8e6708b2ba4fb5cc21ef21c330b6e650ca04ca01d02d3462ef7d250ec27eb4i0';
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('yaml', yaml);

--- a/static/preview-markdown.js
+++ b/static/preview-markdown.js
@@ -1,4 +1,4 @@
-import { marked } from 'https://cdn.jsdelivr.net/npm/marked@9/+esm'
+import { marked } from '/content/cf7ef67632861da5a59a716ad5ee398054f455c0011a7b6aa12c5985c1b8b0b8i0'
 
 const inscription = document.documentElement.dataset.inscription;
 const response = await fetch(`/content/${inscription}`);


### PR DESCRIPTION
this pr attempts to replace some of the CDN imports used by the explorer with links to inscribed libraries.

the inscribed code is an exact copy from the original CDN links for easy SHA256 checksum verification, except some just have extra comments added to the top for copyright/licensing/etc
