### PR TITLE
Guilt by association

### DIFF
--- a/deploy/ord.service
+++ b/deploy/ord.service
@@ -13,7 +13,7 @@ ExecStart=/usr/local/bin/ord \
   --data-dir /var/lib/ord \
   --config-dir /var/lib/ord \
   --chain ${CHAIN} \
-  --index-sats \
+#  --index-sats \
   server \
   --acme-contact mailto:casey@rodarmor.com \
   --http \

--- a/justfile
+++ b/justfile
@@ -70,15 +70,16 @@ profile-tests:
 fuzz:
   #!/usr/bin/env bash
   set -euxo pipefail
-
   cd fuzz
-
   while true; do
     cargo +nightly fuzz run transaction-builder -- -max_total_time=60
     cargo +nightly fuzz run runestone-decipher -- -max_total_time=60
     cargo +nightly fuzz run varint-decode -- -max_total_time=60
     cargo +nightly fuzz run varint-encode -- -max_total_time=60
   done
+
+decode txid:
+  bitcoin-cli getrawtransaction {{txid}} | xxd -r -p - | cargo run decode
 
 open:
   open http://localhost

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -110,7 +110,15 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     txid: Txid,
     input_sat_ranges: Option<&VecDeque<(u64, u64)>>,
   ) -> Result {
-    let mut envelopes = ParsedEnvelope::from_transaction(tx).into_iter().peekable();
+    let envelopes = ParsedEnvelope::from_transaction(tx);
+
+    let guilt_by_association = envelopes.iter().any(|envelope| {
+      envelope.payload.unrecognized_even_field
+        || envelope.payload.duplicate_field
+        || envelope.payload.incomplete_field
+    });
+
+    let mut envelopes = envelopes.into_iter().peekable();
     let mut floating_inscriptions = Vec::new();
     let mut inscribed_offsets = BTreeMap::new();
     let mut total_input_value = 0;
@@ -197,6 +205,8 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           log::info!("processing reinscription {inscription_id} on sat {:?}: sequence number {seq_num}, inscribed offsets {:?}", sat, inscribed_offsets);
 
           Some(Curse::Reinscription)
+        } else if guilt_by_association {
+          Some(Curse::GuiltByAssociation)
         } else {
           None
         };

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -14,6 +14,7 @@ use {
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) enum Curse {
   DuplicateField,
+  GuiltByAssociation,
   IncompleteField,
   NotAtOffsetZero,
   NotInFirstInput,


### PR DESCRIPTION
Attempt to fix #2569. In the old, pre 0.9.0 parser, if an inscription was followed by an inscription that caused an error, earlier inscriptions would not be processed. The things that would trigger this were unrecognized even fields, duplicate fields, and incomplete fields. This adds a new curse, GuiltByAssociation, which which causes an inscription which is valid, but is followed by an inscription which triggers one of the errors to be cursed. I'd be mad but honestly this is kind of hilarious at this point.