### PR TITLE
Rune balance and issuance CLI

### DIFF
--- a/src/runes/runestone.rs
+++ b/src/runes/runestone.rs
@@ -93,7 +93,7 @@ impl Runestone {
     }))
   }
 
-  #[cfg(test)]
+  //#[cfg(test)]
   pub(crate) fn encipher(&self) -> ScriptBuf {
     let mut payload = Vec::new();
 

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -8,6 +8,7 @@ pub mod info;
 pub mod list;
 pub mod parse;
 mod preview;
+pub mod runes;
 mod server;
 pub mod subsidy;
 pub mod supply;
@@ -45,6 +46,8 @@ pub(crate) enum Subcommand {
   Traits(traits::Traits),
   #[command(subcommand, about = "Wallet commands")]
   Wallet(wallet::Wallet),
+  #[command(subcommand, about = "Rune commands")]
+  Runes(runes::RunesSubcommand),
 }
 
 impl Subcommand {
@@ -69,6 +72,7 @@ impl Subcommand {
       Self::Teleburn(teleburn) => teleburn.run(),
       Self::Traits(traits) => traits.run(),
       Self::Wallet(wallet) => wallet.run(options),
+      Self::Runes(runes) => runes.run(options),
     }
   }
 }

--- a/src/subcommand/runes.rs
+++ b/src/subcommand/runes.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+pub mod balance;
+pub mod issue;
+
+#[derive(Debug, Parser)]
+pub(crate) enum RunesSubcommand {
+  #[command(about = "Issue a rune")]
+  Issue(issue::Issue),
+  #[command(about = "Issue a rune")]
+  Balance(balance::Balance),
+}
+
+impl RunesSubcommand {
+  pub(crate) fn run(self, options: Options) -> SubcommandResult {
+    match self {
+      Self::Issue(issue) => issue.run(options),
+      Self::Balance(balance) => balance.run(options),
+    }
+  }
+}

--- a/src/subcommand/runes.rs
+++ b/src/subcommand/runes.rs
@@ -7,7 +7,7 @@ pub mod issue;
 pub(crate) enum RunesSubcommand {
   #[command(about = "Issue a rune")]
   Issue(issue::Issue),
-  #[command(about = "Issue a rune")]
+  #[command(about = "Get rune balance")]
   Balance(balance::Balance),
 }
 

--- a/src/subcommand/runes/balance.rs
+++ b/src/subcommand/runes/balance.rs
@@ -1,0 +1,36 @@
+use super::*;
+use crate::wallet::Wallet;
+
+#[derive(Debug, Parser)]
+pub(crate) struct Balance {}
+
+#[derive(Serialize, Deserialize)]
+pub struct Output {
+  pub name: String,
+  pub amount: String,
+}
+
+impl Balance {
+  pub(crate) fn run(self, options: Options) -> SubcommandResult {
+    let index = Index::open(&options)?;
+    index.update()?;
+    let utxos = index.get_unspent_outputs(Wallet::load(&options)?)?;
+
+    let balance = utxos
+      .iter()
+      .filter_map(
+        |e| match index.get_rune_balances_for_outpoint(e.0.clone()) {
+          Ok(v) => Some(v),
+          Err(_) => None,
+        },
+      )
+      .flatten()
+      .map(|e| Output {
+        name: format!("{}", e.0),
+        amount: format!("{}", e.1),
+      })
+      .collect::<Vec<_>>();
+
+    Ok(Box::new(balance))
+  }
+}

--- a/src/subcommand/runes/issue.rs
+++ b/src/subcommand/runes/issue.rs
@@ -1,0 +1,106 @@
+use super::*;
+use crate::{runes::*, subcommand::wallet::get_change_address, wallet::Wallet};
+use bitcoin::blockdata::locktime::absolute::LockTime;
+
+#[derive(Debug, Parser)]
+pub(crate) struct Issue {
+  #[arg(long, help = "Amount to cast")]
+  pub amount: u128,
+  #[arg(long, help = "Rune name")]
+  pub name: String,
+  #[arg(long, help = "Divisibility")]
+  pub divisibility: u8,
+}
+
+impl Issue {
+  pub(crate) fn run(self, options: Options) -> SubcommandResult {
+    if options.chain_argument == chain::Chain::Mainnet {
+      return Ok(Box::new(
+        "Runes are not yet available on mainnet, try running ord with '--chain signet'",
+      ));
+    }
+
+    let runestone = Runestone {
+      edicts: vec![Edict {
+        id: 0,
+        amount: self.amount,
+        output: 1,
+      }],
+      etching: Some(Etching {
+        divisibility: self.divisibility,
+        rune: crate::runes::Rune::from_str(&self.name)?,
+        symbol: None,
+      }),
+      burn: false,
+    };
+
+    let index = Index::open(&options)?;
+    index.update()?;
+
+    let utxos = index.get_unspent_outputs(Wallet::load(&options)?)?;
+    let inscriptions = index.get_inscriptions(&utxos)?;
+
+    let inscribed_utxos = inscriptions
+      .keys()
+      .map(|satpoint| satpoint.outpoint)
+      .collect::<std::collections::BTreeSet<OutPoint>>();
+
+    let chain = options.chain();
+
+    let client = options.bitcoin_rpc_client_for_wallet_command(false)?;
+
+    let cardinal_utxos = utxos
+      .iter()
+      .filter_map(|e| match inscribed_utxos.get(e.0) {
+        Some(_) => None,
+        None => Some(e.clone()),
+      })
+      .filter_map(
+        |e| match index.get_rune_balances_for_outpoint(e.0.clone()) {
+          Ok(v) => {
+            if v.len() > 0 {
+              return None;
+            }
+
+            Some(e.clone())
+          }
+          Err(_) => None,
+        },
+      )
+      .collect::<Vec<_>>();
+
+    let utxo = &cardinal_utxos[0];
+
+    let tx = Transaction {
+      version: 1,
+      lock_time: LockTime::ZERO,
+      input: vec![TxIn {
+        previous_output: utxo.0.clone(),
+        script_sig: ScriptBuf::new(),
+        sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        witness: bitcoin::blockdata::witness::Witness::new(),
+      }],
+      output: vec![
+        TxOut {
+          value: 0,
+          script_pubkey: runestone.encipher(),
+        },
+        TxOut {
+          value: 546,
+          script_pubkey: get_change_address(&client, chain)?.script_pubkey(),
+        },
+        TxOut {
+          value: utxo.1.to_sat() - 1000,
+          script_pubkey: get_change_address(&client, chain)?.script_pubkey(),
+        },
+      ],
+    };
+
+    let signed_tx = client
+      .sign_raw_transaction_with_wallet(&tx, None, None)?
+      .hex;
+    let txid = client.send_raw_transaction(&signed_tx)?;
+
+    Ok(Box::new(txid))
+  }
+}

--- a/src/subcommand/wallet.rs
+++ b/src/subcommand/wallet.rs
@@ -71,7 +71,7 @@ impl Wallet {
   }
 }
 
-fn get_change_address(client: &Client, chain: Chain) -> Result<Address> {
+pub fn get_change_address(client: &Client, chain: Chain) -> Result<Address> {
   Ok(
     client
       .call::<Address<NetworkUnchecked>>("getrawchangeaddress", &["bech32m".into()])


### PR DESCRIPTION
<img width="284" alt="Screen Shot 1402-08-03 at 14 57 22" src="https://github.com/ordinals/ord/assets/8557965/6763a27b-0c04-45fc-9d04-26d03aa37104">

This PR adds a new subcommand `ord runes`. I used the cli to create a couple of runes on signet to start experimenting with the indexer. The transaction creation is very basic and should not be used on mainnet. I ran into problems using the transaction builder as it did not support arbitrary op_return scripts in the tx_out, so i kept it simple to avoid modifying any transaction building logic

command: `ord runes`
```
Usage: ord runes <COMMAND>

Commands:
  issue    Issue a rune
  balance  Get rune balance
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

command: `ord runes issue`
```
Issue a rune

Usage: ord runes issue --amount <AMOUNT> --name <NAME> --divisibility <DIVISIBILITY>

Options:
      --amount <AMOUNT>              Amount to cast
      --name <NAME>                  Rune name
      --divisibility <DIVISIBILITY>  Divisibility
  -h, --help                         Print help
```

command: `ord runes balance`
```
[
  {
    "name": "A",
    "amount": "69420"
  },
  {
    "name": "RUNE",
    "amount": "21000000"
  }
]
```


<img width="745" alt="Screen Shot 1402-08-03 at 14 57 30" src="https://github.com/ordinals/ord/assets/8557965/8dfb03fe-cc56-4832-af49-b0db65c0b6b1">
<img width="758" alt="Screen Shot 1402-08-03 at 14 57 26" src="https://github.com/ordinals/ord/assets/8557965/800b536c-bb0f-4084-93a9-43cc33166929">

