### PR TITLE
Speed up indexing of re-inscriptions

### DIFF
--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -190,7 +190,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
         } else if inscription.pushnum {
           Some(Curse::Pushnum)
         } else if inscribed_offsets.contains_key(&offset) {
-          let seq_num = self.id_to_entry.len()?;
+          let seq_num = self.next_sequence_number;
 
           let sat = Self::calculate_sat(input_sat_ranges, offset);
 


### PR DESCRIPTION
When logging re-inscription info, use already calculated `next_sequence_number` rather than calling `id_to_entry.len()`

On my PC (5600x, 32GB) speeds up indexing by ~40s per re-inscription.