### PR TITLE
Allow passing satpoint when batch inscribing

### DIFF
--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -55,7 +55,7 @@ pub(crate) struct Inscribe {
     long,
     help = "Inscribe a multiple inscriptions defines in a yaml <BATCH_FILE>.",
     conflicts_with_all = &[
-      "file", "destination", "cbor_metadata", "json_metadata", "satpoint", "reinscribe", "metaprotocol", "parent"
+      "file", "destination", "cbor_metadata", "json_metadata", "reinscribe", "metaprotocol", "parent"
     ]
   )]
   pub(crate) batch: Option<PathBuf>,
@@ -1258,10 +1258,6 @@ inscriptions:
       ),
       ("--cbor-metadata", Some("foo")),
       ("--json-metadata", Some("foo")),
-      (
-        "--satpoint",
-        Some("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0:0"),
-      ),
       ("--reinscribe", None),
       ("--metaprotocol", Some("foo")),
       (

--- a/src/subcommand/wallet/inscribe/batch.rs
+++ b/src/subcommand/wallet/inscribe/batch.rs
@@ -186,14 +186,6 @@ impl Batch {
         .all(|inscription| inscription.parent().unwrap() == parent_info.id))
     }
 
-    if self.satpoint.is_some() {
-      assert_eq!(
-        self.inscriptions.len(),
-        1,
-        "invariant: satpoint may only be specified when making a single inscription",
-      );
-    }
-
     match self.mode {
       Mode::SeparateOutputs => assert_eq!(
         self.destinations.len(),


### PR DESCRIPTION
I am most likely missing something here as I imagine there's a reason why this is being prevented in the first place. But this change would be useful when you want to batch inscribe on a specific UTXO.