### PR TITLE
Avoid caching error responses

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -3094,12 +3094,13 @@ mod tests {
   #[test]
   fn error_content_responses_have_max_age_zero_cache_control_headers() {
     let server = TestServer::new_with_regtest();
-    let response = server.get("/content/foo");
+    let response =
+      server.get("/content/6ac5cacb768794f4fd7a78bf00f2074891fce68bd65c4ff36e77177237aacacai0");
 
-    assert_eq!(response.status(), 400);
+    assert_eq!(response.status(), 404);
     assert_eq!(
       response.headers().get(header::CACHE_CONTROL).unwrap(),
-      "max-age=31536000, immutable"
+      "no-store"
     );
   }
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -244,7 +244,7 @@ impl Server {
           header::CONTENT_SECURITY_POLICY,
           HeaderValue::from_static("default-src 'self'"),
         ))
-        .layer(SetResponseHeaderLayer::if_not_present(
+        .layer(SetResponseHeaderLayer::overriding(
           header::STRICT_TRANSPORT_SECURITY,
           HeaderValue::from_static("max-age=31536000; includeSubDomains; preload"),
         ))

--- a/src/subcommand/server/error.rs
+++ b/src/subcommand/server/error.rs
@@ -23,19 +23,13 @@ impl IntoResponse for ServerError {
       }
       Self::NotFound(message) => (
         StatusCode::NOT_FOUND,
-        [(
-          header::STRICT_TRANSPORT_SECURITY,
-          HeaderValue::from_static("max-age=0; includeSubDomains; preload"),
-        )],
+        [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
         message,
       )
         .into_response(),
       Self::BadRequest(message) => (
         StatusCode::BAD_REQUEST,
-        [(
-          header::STRICT_TRANSPORT_SECURITY,
-          HeaderValue::from_static("max-age=0; includeSubDomains; preload"),
-        )],
+        [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
         message,
       )
         .into_response(),

--- a/src/subcommand/server/error.rs
+++ b/src/subcommand/server/error.rs
@@ -21,8 +21,24 @@ impl IntoResponse for ServerError {
         )
           .into_response()
       }
-      Self::NotFound(message) => (StatusCode::NOT_FOUND, message).into_response(),
-      Self::BadRequest(message) => (StatusCode::BAD_REQUEST, message).into_response(),
+      Self::NotFound(message) => (
+        StatusCode::NOT_FOUND,
+        [(
+          header::STRICT_TRANSPORT_SECURITY,
+          HeaderValue::from_static("max-age=0; includeSubDomains; preload"),
+        )],
+        message,
+      )
+        .into_response(),
+      Self::BadRequest(message) => (
+        StatusCode::BAD_REQUEST,
+        [(
+          header::STRICT_TRANSPORT_SECURITY,
+          HeaderValue::from_static("max-age=0; includeSubDomains; preload"),
+        )],
+        message,
+      )
+        .into_response(),
     }
   }
 }

--- a/src/subcommand/server/error.rs
+++ b/src/subcommand/server/error.rs
@@ -11,6 +11,7 @@ pub(super) type ServerResult<T> = Result<T, ServerError>;
 impl IntoResponse for ServerError {
   fn into_response(self) -> Response {
     match self {
+      Self::BadRequest(message) => (StatusCode::BAD_REQUEST, message).into_response(),
       Self::Internal(error) => {
         eprintln!("error serving request: {error}");
         (
@@ -23,12 +24,6 @@ impl IntoResponse for ServerError {
       }
       Self::NotFound(message) => (
         StatusCode::NOT_FOUND,
-        [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
-        message,
-      )
-        .into_response(),
-      Self::BadRequest(message) => (
-        StatusCode::BAD_REQUEST,
         [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
         message,
       )


### PR DESCRIPTION
Error responses are currently cached by cloudflare, which is an attack vector. Someone could just watch mempool and make /content requests before the tx confirmation.

@raphjaph I am not able to get the tests to pass. Can you please point me in the right direction re: how to do this?