### PR TITLE
Use new RPC client in Reorg::get_block_with_retries

### DIFF
--- a/src/index/fetcher.rs
+++ b/src/index/fetcher.rs
@@ -1,10 +1,7 @@
 use {
-  crate::Options,
-  anyhow::{anyhow, Result},
+  super::*,
   base64::Engine,
-  bitcoin::{Transaction, Txid},
   hyper::{client::HttpConnector, Body, Client, Method, Request, Uri},
-  serde::Deserialize,
   serde_json::{json, Value},
 };
 

--- a/src/index/reorg.rs
+++ b/src/index/reorg.rs
@@ -85,7 +85,8 @@ impl Reorg {
 
     if (height < SAVEPOINT_INTERVAL || height % SAVEPOINT_INTERVAL == 0)
       && index
-        .client
+        .options
+        .bitcoin_rpc_client()?
         .get_blockchain_info()?
         .headers
         .saturating_sub(height)


### PR DESCRIPTION
This client was timing out when commits took longer than 90 seconds, so just get a new client. This fixes #2455.