### PR TITLE
Use jemalloc as global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "test-bitcoincore-rpc",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.10",
@@ -3090,6 +3091,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,11 +56,13 @@ serde_yaml = "0.9.17"
 sha3 = "0.10.8"
 sysinfo = "0.29.2"
 tempfile = "3.2.0"
-tikv-jemallocator = "0.5.4"
 tokio = { version = "1.17.0", features = ["rt-multi-thread"] }
 tokio-stream = "0.1.9"
 tokio-util = {version = "0.7.3", features = ["compat"] }
 tower-http = { version = "0.4.0", features = ["compression-br", "compression-gzip", "cors", "set-header"] }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5.4"
 
 [dev-dependencies]
 executable-path = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ serde_yaml = "0.9.17"
 sha3 = "0.10.8"
 sysinfo = "0.29.2"
 tempfile = "3.2.0"
+tikv-jemallocator = "0.5.4"
 tokio = { version = "1.17.0", features = ["rt-multi-thread"] }
 tokio-stream = "0.1.9"
 tokio-util = {version = "0.7.3", features = ["compat"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,6 @@ use {
   },
   sysinfo::{System, SystemExt},
   tempfile::TempDir,
-  tikv_jemallocator::Jemalloc,
   tokio::{runtime::Runtime, task},
 };
 
@@ -109,7 +108,7 @@ macro_rules! tprintln {
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod arguments;
 mod blocktime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ macro_rules! tprintln {
     };
 }
 
-#[cfg(not(windows))]
+#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ macro_rules! tprintln {
     };
 }
 
+#[cfg(not(windows))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ use {
   },
   sysinfo::{System, SystemExt},
   tempfile::TempDir,
+  tikv_jemallocator::Jemalloc,
   tokio::{runtime::Runtime, task},
 };
 
@@ -105,6 +106,9 @@ macro_rules! tprintln {
       }
     };
 }
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 mod arguments;
 mod blocktime;


### PR DESCRIPTION
jemalloc is generally faster. I want to make sure this builds on CI, and then actually benchmark it to see if it's a performance improvement.