### PR TITLE
Update redb to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "der-parser"
@@ -2398,8 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "1.3.0"
-source = "git+https://github.com/cberner/redb.git?rev=c29eed6f866d50a2c79042fe55cf898a5aba1579#c29eed6f866d50a2c79042fe55cf898a5aba1579"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08837f9a129bde83c51953b8c96cbb3422b940166b730caa954836106eb1dfd2"
 dependencies = [
  "libc",
 ]
@@ -2787,18 +2788,18 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ mime_guess = "2.0.4"
 miniscript = "10.0.0"
 mp4 = "0.14.0"
 ord-bitcoincore-rpc = "0.17.1"
-redb = { git = "https://github.com/cberner/redb.git", rev = "c29eed6f866d50a2c79042fe55cf898a5aba1579" }
+redb = "1.4.0"
 regex = "1.6.0"
 rss = "2.0.1"
 rust-embed = "8.0.0"

--- a/src/index.rs
+++ b/src/index.rs
@@ -35,7 +35,7 @@ mod updater;
 #[cfg(test)]
 pub(crate) mod testing;
 
-const SCHEMA_VERSION: u64 = 12;
+const SCHEMA_VERSION: u64 = 13;
 
 macro_rules! define_table {
   ($name:ident, $key:ty, $value:ty) => {

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -45,7 +45,7 @@ pub(super) type RuneEntryValue = (
   u64,          // number
   u128,         // rune
   u128,         // supply
-  Option<u32>,  // symbol
+  Option<char>, // symbol
   u32,          // timestamp
 );
 
@@ -90,7 +90,7 @@ impl Entry for RuneEntry {
       number,
       rune: Rune(rune),
       supply,
-      symbol: symbol.map(|symbol| char::from_u32(symbol).unwrap()),
+      symbol,
       timestamp,
     }
   }
@@ -117,7 +117,7 @@ impl Entry for RuneEntry {
       self.number,
       self.rune.0,
       self.supply,
-      self.symbol.map(u32::from),
+      self.symbol,
       self.timestamp,
     )
   }
@@ -417,7 +417,7 @@ mod tests {
       5,
       6,
       7,
-      Some(u32::from('a')),
+      Some('a'),
       6,
     );
 


### PR DESCRIPTION
Also, `redb` now supports `char` index keys and values, so we no longer need to store it as a u32. Increments the schema version, since u32 -> char is a breaking change.