### PR TITLE
Remove default for `ord index export --tsv`

### DIFF
--- a/src/subcommand/index/export.rs
+++ b/src/subcommand/index/export.rs
@@ -2,11 +2,7 @@ use super::*;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Export {
-  #[arg(
-    long,
-    default_value = "inscription_number_to_id.tsv",
-    help = "<TSV> file to write to"
-  )]
+  #[arg(long, help = "<TSV> file to write to")]
   tsv: String,
   #[arg(long, help = "Whether to include addresses in export")]
   include_addresses: bool,

--- a/src/subcommand/index/export.rs
+++ b/src/subcommand/index/export.rs
@@ -2,10 +2,10 @@ use super::*;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Export {
-  #[arg(long, help = "<TSV> file to write to")]
-  tsv: String,
-  #[arg(long, help = "Whether to include addresses in export")]
+  #[arg(long, help = "Include addresses in export")]
   include_addresses: bool,
+  #[arg(long, help = "Write export to <TSV>")]
+  tsv: String,
 }
 
 impl Export {


### PR DESCRIPTION
I think it's better not to have defaults for things like this. If we wanted it to work with `--tsv`, writing to stdout is the best option.