### PR TITLE
set csp origin in deploy script

### DIFF
--- a/deploy/ord.service
+++ b/deploy/ord.service
@@ -16,6 +16,7 @@ ExecStart=/usr/local/bin/ord \
   --index-sats \
   server \
   --acme-contact mailto:casey@rodarmor.com \
+  --csp-origin https://ordinals.com \
   --http \
   --https
 Group=ord


### PR DESCRIPTION
looks like ordinals.com is still using the wildcard content-security policy, meaning recursive inscriptions don't render properly on safari. I assume that ordinals.com is deployed through the scripts in `deploy/`, so this PR attempts to set the csp origin.