### PR TITLE
Add total bytes and proportion to database info

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -122,6 +122,7 @@ pub(crate) struct Info {
   sat_ranges: u64,
   stored_bytes: u64,
   tables: BTreeMap<String, TableInfo>,
+  total_bytes: u64,
   pub(crate) transactions: Vec<TransactionInfo>,
   tree_height: u32,
   utxos_indexed: u64,
@@ -133,7 +134,9 @@ pub(crate) struct TableInfo {
   fragmented_bytes: u64,
   leaf_pages: u64,
   metadata_bytes: u64,
+  proportion: f64,
   stored_bytes: u64,
+  total_bytes: u64,
   tree_height: u32,
 }
 
@@ -437,18 +440,27 @@ impl Index {
     fn insert_table_info<K: RedbKey + 'static, V: RedbValue + 'static>(
       tables: &mut BTreeMap<String, TableInfo>,
       wtx: &WriteTransaction,
+      database_total_bytes: u64,
       definition: TableDefinition<K, V>,
     ) {
       let stats = wtx.open_table(definition).unwrap().stats().unwrap();
+
+      let fragmented_bytes = stats.fragmented_bytes();
+      let metadata_bytes = stats.metadata_bytes();
+      let stored_bytes = stats.stored_bytes();
+      let total_bytes = stored_bytes + metadata_bytes + fragmented_bytes;
+
       tables.insert(
         definition.name().into(),
         TableInfo {
-          tree_height: stats.tree_height(),
-          leaf_pages: stats.leaf_pages(),
           branch_pages: stats.branch_pages(),
-          stored_bytes: stats.stored_bytes(),
-          metadata_bytes: stats.metadata_bytes(),
-          fragmented_bytes: stats.fragmented_bytes(),
+          fragmented_bytes,
+          leaf_pages: stats.leaf_pages(),
+          metadata_bytes,
+          proportion: total_bytes as f64 / database_total_bytes as f64,
+          stored_bytes,
+          total_bytes,
+          tree_height: stats.tree_height(),
         },
       );
     }
@@ -456,6 +468,7 @@ impl Index {
     fn insert_multimap_table_info<K: RedbKey + 'static, V: RedbValue + RedbKey + 'static>(
       tables: &mut BTreeMap<String, TableInfo>,
       wtx: &WriteTransaction,
+      database_total_bytes: u64,
       definition: MultimapTableDefinition<K, V>,
     ) {
       let stats = wtx
@@ -463,15 +476,23 @@ impl Index {
         .unwrap()
         .stats()
         .unwrap();
+
+      let fragmented_bytes = stats.fragmented_bytes();
+      let metadata_bytes = stats.metadata_bytes();
+      let stored_bytes = stats.stored_bytes();
+      let total_bytes = stored_bytes + metadata_bytes + fragmented_bytes;
+
       tables.insert(
         definition.name().into(),
         TableInfo {
-          tree_height: stats.tree_height(),
-          leaf_pages: stats.leaf_pages(),
           branch_pages: stats.branch_pages(),
-          stored_bytes: stats.stored_bytes(),
-          metadata_bytes: stats.metadata_bytes(),
-          fragmented_bytes: stats.fragmented_bytes(),
+          fragmented_bytes,
+          leaf_pages: stats.leaf_pages(),
+          metadata_bytes,
+          proportion: total_bytes as f64 / database_total_bytes as f64,
+          stored_bytes,
+          total_bytes,
+          tree_height: stats.tree_height(),
         },
       );
     }
@@ -480,31 +501,57 @@ impl Index {
 
     let stats = wtx.stats()?;
 
+    let fragmented_bytes = stats.fragmented_bytes();
+    let metadata_bytes = stats.metadata_bytes();
+    let stored_bytes = stats.stored_bytes();
+    let total_bytes = fragmented_bytes + metadata_bytes + stored_bytes;
+
     let mut tables: BTreeMap<String, TableInfo> = BTreeMap::new();
 
-    insert_multimap_table_info(&mut tables, &wtx, SATPOINT_TO_SEQUENCE_NUMBER);
-    insert_multimap_table_info(&mut tables, &wtx, SAT_TO_SEQUENCE_NUMBER);
-    insert_multimap_table_info(&mut tables, &wtx, SEQUENCE_NUMBER_TO_CHILDREN);
-    insert_table_info(&mut tables, &wtx, HEIGHT_TO_BLOCK_HASH);
-    insert_table_info(&mut tables, &wtx, HEIGHT_TO_BLOCK_HASH);
-    insert_table_info(&mut tables, &wtx, HEIGHT_TO_LAST_SEQUENCE_NUMBER);
-    insert_table_info(&mut tables, &wtx, HOME_INSCRIPTIONS);
-    insert_table_info(&mut tables, &wtx, INSCRIPTION_ID_TO_SEQUENCE_NUMBER);
-    insert_table_info(&mut tables, &wtx, INSCRIPTION_NUMBER_TO_SEQUENCE_NUMBER);
-    insert_table_info(&mut tables, &wtx, OUTPOINT_TO_RUNE_BALANCES);
-    insert_table_info(&mut tables, &wtx, OUTPOINT_TO_SAT_RANGES);
-    insert_table_info(&mut tables, &wtx, OUTPOINT_TO_VALUE);
-    insert_table_info(&mut tables, &wtx, RUNE_ID_TO_RUNE_ENTRY);
-    insert_table_info(&mut tables, &wtx, RUNE_TO_RUNE_ID);
-    insert_table_info(&mut tables, &wtx, SAT_TO_SATPOINT);
-    insert_table_info(&mut tables, &wtx, SEQUENCE_NUMBER_TO_INSCRIPTION_ENTRY);
-    insert_table_info(&mut tables, &wtx, SEQUENCE_NUMBER_TO_RUNE);
-    insert_table_info(&mut tables, &wtx, SEQUENCE_NUMBER_TO_SATPOINT);
-    insert_table_info(&mut tables, &wtx, STATISTIC_TO_COUNT);
-    insert_table_info(&mut tables, &wtx, TRANSACTION_ID_TO_RUNE);
+    insert_multimap_table_info(&mut tables, &wtx, total_bytes, SATPOINT_TO_SEQUENCE_NUMBER);
+    insert_multimap_table_info(&mut tables, &wtx, total_bytes, SAT_TO_SEQUENCE_NUMBER);
+    insert_multimap_table_info(&mut tables, &wtx, total_bytes, SEQUENCE_NUMBER_TO_CHILDREN);
+    insert_table_info(&mut tables, &wtx, total_bytes, HEIGHT_TO_BLOCK_HASH);
+    insert_table_info(&mut tables, &wtx, total_bytes, HEIGHT_TO_BLOCK_HASH);
     insert_table_info(
       &mut tables,
       &wtx,
+      total_bytes,
+      HEIGHT_TO_LAST_SEQUENCE_NUMBER,
+    );
+    insert_table_info(&mut tables, &wtx, total_bytes, HOME_INSCRIPTIONS);
+    insert_table_info(
+      &mut tables,
+      &wtx,
+      total_bytes,
+      INSCRIPTION_ID_TO_SEQUENCE_NUMBER,
+    );
+    insert_table_info(
+      &mut tables,
+      &wtx,
+      total_bytes,
+      INSCRIPTION_NUMBER_TO_SEQUENCE_NUMBER,
+    );
+    insert_table_info(&mut tables, &wtx, total_bytes, OUTPOINT_TO_RUNE_BALANCES);
+    insert_table_info(&mut tables, &wtx, total_bytes, OUTPOINT_TO_SAT_RANGES);
+    insert_table_info(&mut tables, &wtx, total_bytes, OUTPOINT_TO_VALUE);
+    insert_table_info(&mut tables, &wtx, total_bytes, RUNE_ID_TO_RUNE_ENTRY);
+    insert_table_info(&mut tables, &wtx, total_bytes, RUNE_TO_RUNE_ID);
+    insert_table_info(&mut tables, &wtx, total_bytes, SAT_TO_SATPOINT);
+    insert_table_info(
+      &mut tables,
+      &wtx,
+      total_bytes,
+      SEQUENCE_NUMBER_TO_INSCRIPTION_ENTRY,
+    );
+    insert_table_info(&mut tables, &wtx, total_bytes, SEQUENCE_NUMBER_TO_RUNE);
+    insert_table_info(&mut tables, &wtx, total_bytes, SEQUENCE_NUMBER_TO_SATPOINT);
+    insert_table_info(&mut tables, &wtx, total_bytes, STATISTIC_TO_COUNT);
+    insert_table_info(&mut tables, &wtx, total_bytes, TRANSACTION_ID_TO_RUNE);
+    insert_table_info(
+      &mut tables,
+      &wtx,
+      total_bytes,
       WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP,
     );
 
@@ -527,7 +574,6 @@ impl Index {
         .map(|x| x.value())
         .unwrap_or(0);
       Info {
-        index_path: self.path.clone(),
         blocks_indexed: wtx
           .open_table(HEIGHT_TO_BLOCK_HASH)?
           .range(0..)?
@@ -536,15 +582,17 @@ impl Index {
           .map(|(height, _hash)| height.value() + 1)
           .unwrap_or(0),
         branch_pages: stats.branch_pages(),
-        fragmented_bytes: stats.fragmented_bytes(),
+        fragmented_bytes,
         index_file_size: fs::metadata(&self.path)?.len(),
+        index_path: self.path.clone(),
         leaf_pages: stats.leaf_pages(),
-        metadata_bytes: stats.metadata_bytes(),
-        sat_ranges,
+        metadata_bytes,
         outputs_traversed,
         page_size: stats.page_size(),
-        stored_bytes: stats.stored_bytes(),
+        sat_ranges,
+        stored_bytes,
         tables,
+        total_bytes,
         transactions: wtx
           .open_table(WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP)?
           .range(0..)?

--- a/tests/info.rs
+++ b/tests/info.rs
@@ -19,6 +19,7 @@ fn json_with_satoshi_index() {
   "sat_ranges": 1,
   "stored_bytes": \d+,
   "tables": .*,
+  "total_bytes": \d+,
   "transactions": \[
     \{
       "starting_block_count": 0,
@@ -52,6 +53,7 @@ fn json_without_satoshi_index() {
   "sat_ranges": 0,
   "stored_bytes": \d+,
   "tables": .*,
+  "total_bytes": \d+,
   "transactions": \[
     \{
       "starting_block_count": 0,


### PR DESCRIPTION
Sum fragmented, metadata, and stored bytes for database and tables, and output from info command. Also, include an f64 proportion for each table, which is the proportion of the database that that table uses.