### PR TITLE
HTML endpoint /inscriptions/block/<height>/<page> returns nothing after page 0

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1453,13 +1453,13 @@ impl Server {
       .take(page_size.saturating_add(1))
       .collect::<Vec<InscriptionId>>();
 
-    let more = inscriptions.len() > page_size;
-
-    if more {
-      inscriptions.pop();
-    }
-
     Ok(if accept_json.0 {
+      let more = inscriptions.len() > page_size;
+
+      if more {
+        inscriptions.pop();
+      }
+
       Json(InscriptionsJson {
         inscriptions,
         page_index,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -4782,13 +4782,13 @@ next
     server.assert_response_regex(
       "/inscriptions/block/102",
       StatusCode::OK,
-      format!(".*(<a href=/inscription/[[:xdigit:]]{{64}}i0>.*</a>.*\n.*){{100}}.*"),
+      ".*(<a href=/inscription/[[:xdigit:]]{{64}}i0>.*</a>.*\n.*){{100}}.*",
     );
 
     server.assert_response_regex(
       "/inscriptions/block/102/1",
       StatusCode::OK,
-      format!(".*<a href=/inscription/[[:xdigit:]]{{64}}i0>.*</a>.*"),
+      ".*<a href=/inscription/[[:xdigit:]]{{64}}i0>.*</a>.*",
     );
   }
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -4782,7 +4782,7 @@ next
     server.assert_response_regex(
       "/inscriptions/block/102",
       StatusCode::OK,
-      r".*(<a href=/inscription/[[:xdigit:]]{64}i0>.*</a>.*){100}.*".to_string(),
+      r".*(<a href=/inscription/[[:xdigit:]]{64}i0>.*</a>.*){100}.*",
     );
 
     server.assert_response_regex(

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1453,13 +1453,13 @@ impl Server {
       .take(page_size.saturating_add(1))
       .collect::<Vec<InscriptionId>>();
 
+    let more = inscriptions.len() > page_size;
+
+    if more {
+      inscriptions.pop();
+    }
+
     Ok(if accept_json.0 {
-      let more = inscriptions.len() > page_size;
-
-      if more {
-        inscriptions.pop();
-      }
-
       Json(InscriptionsJson {
         inscriptions,
         page_index,
@@ -1471,6 +1471,7 @@ impl Server {
         block_height,
         index.block_height()?.unwrap_or(Height(0)).n(),
         inscriptions,
+        more,
         page_index,
       )?
       .page(page_config)

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -4782,13 +4782,13 @@ next
     server.assert_response_regex(
       "/inscriptions/block/102",
       StatusCode::OK,
-      ".*(<a href=/inscription/[[:xdigit:]]{{64}}i0>.*</a>.*\n.*){{100}}.*",
+      r".*(<a href=/inscription/[[:xdigit:]]{64}i0>.*</a>.*){100}.*".to_string(),
     );
 
     server.assert_response_regex(
       "/inscriptions/block/102/1",
       StatusCode::OK,
-      ".*<a href=/inscription/[[:xdigit:]]{{64}}i0>.*</a>.*",
+      r".*<a href=/inscription/[[:xdigit:]]{64}i0>.*</a>.*",
     );
   }
 }

--- a/src/templates/inscriptions_block.rs
+++ b/src/templates/inscriptions_block.rs
@@ -15,16 +15,12 @@ impl InscriptionsBlockHtml {
     block: u32,
     current_blockheight: u32,
     inscriptions: Vec<InscriptionId>,
+    more_inscriptions: bool,
     page_index: usize,
   ) -> Result<Self> {
-    let num_inscriptions = inscriptions.len();
-
-    let end = usize::min(100, num_inscriptions);
-
     if inscriptions.is_empty() {
       return Err(anyhow!("page index {page_index} exceeds inscription count"));
     }
-    let inscriptions = inscriptions[..end].to_vec();
 
     Ok(Self {
       block,
@@ -35,12 +31,8 @@ impl InscriptionsBlockHtml {
       } else {
         None
       },
-      prev_page: if page_index > 0 {
-        Some(page_index - 1)
-      } else {
-        None
-      },
-      next_page: if num_inscriptions > 100 {
+      prev_page: page_index.checked_sub(1),
+      next_page: if more_inscriptions {
         Some(page_index + 1)
       } else {
         None

--- a/src/templates/inscriptions_block.rs
+++ b/src/templates/inscriptions_block.rs
@@ -19,13 +19,12 @@ impl InscriptionsBlockHtml {
   ) -> Result<Self> {
     let num_inscriptions = inscriptions.len();
 
-    let start = page_index * 100;
-    let end = usize::min(start + 100, num_inscriptions);
+    let end = usize::min(100, num_inscriptions);
 
-    if start > num_inscriptions || start > end {
+    if inscriptions.is_empty() {
       return Err(anyhow!("page index {page_index} exceeds inscription count"));
     }
-    let inscriptions = inscriptions[start..end].to_vec();
+    let inscriptions = inscriptions[..end].to_vec();
 
     Ok(Self {
       block,
@@ -41,7 +40,7 @@ impl InscriptionsBlockHtml {
       } else {
         None
       },
-      next_page: if (page_index + 1) * 100 <= num_inscriptions {
+      next_page: if num_inscriptions > 100 {
         Some(page_index + 1)
       } else {
         None


### PR DESCRIPTION
* go to https://ordinals.com/block/800000
* it correctly shows "2914 Inscriptions"
* click "more" -> https://ordinals.com/inscriptions/block/800000
* it correctly shows the first 100 inscriptions
* click "next" -> https://ordinals.com/inscriptions/block/800000/1
* it incorrectly shows no inscriptions

Both `Server::inscriptions_in_block_paginated()` and `InscriptionsBlockHtml::new()` are removing the first `page_index * page_size` inscriptions. Only one of them should do it. 

This commit fixes the issue. 