### PR TITLE
Fix FundRawTransaction visibility issue

### DIFF
--- a/test-bitcoincore-rpc/src/lib.rs
+++ b/test-bitcoincore-rpc/src/lib.rs
@@ -159,7 +159,7 @@ impl From<OutPoint> for JsonOutPoint {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct FundRawTransactionOptions {
+pub struct FundRawTransactionOptions {
   #[serde(with = "bitcoin::amount::serde::as_btc::opt")]
   fee_rate: Option<Amount>,
 }


### PR DESCRIPTION
This was reported in #2792. I don't understand why I'm not getting this error locally, but the fix is simple.