### PR TITLE
Update audit-cache binary

### DIFF
--- a/crates/audit-cache/src/main.rs
+++ b/crates/audit-cache/src/main.rs
@@ -4,48 +4,54 @@ use {
   std::process,
 };
 
-const ENDPOINTS: &[(&str, StatusCode, &str)] = &[
-  // PNG content is cached
+const ENDPOINTS: &[(&str, StatusCode, &str, &str)] = &[
+  // PNG content is cached for one year
   (
     "/content/6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0",
     StatusCode::OK,
     "HIT",
+    "public, max-age=31536000, immutable",
   ),
-  // HTML content is cached
+  // HTML content is cached for one year
   (
     "/content/114c5c87c4d0a7facb2b4bf515a4ad385182c076a5cfcc2982bf2df103ec0fffi0",
     StatusCode::OK,
     "HIT",
+    "public, max-age=31536000, immutable",
   ),
   // content respopnses that aren't found aren't cached
   (
     "/content/6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i1",
     StatusCode::NOT_FOUND,
     "BYPASS",
+    "no-store",
   ),
-  // HTML previews are cached
+  // HTML previews are cached for one year
   (
     "/preview/114c5c87c4d0a7facb2b4bf515a4ad385182c076a5cfcc2982bf2df103ec0fffi0",
     StatusCode::OK,
     "HIT",
+    "public, max-age=31536000, immutable",
   ),
-  // non-HTML previews are not cached
+  // non-HTML previews are cached for four hours
   (
     "/preview/6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0",
     StatusCode::OK,
-    "BYPASS",
+    "HIT",
+    "max-age=14400",
   ),
-  ("/static/index.css", StatusCode::OK, "HIT"),
-  ("/static/index.js", StatusCode::OK, "HIT"),
-  ("/sat/FOO", StatusCode::BAD_REQUEST, "HIT"),
-  ("/", StatusCode::OK, "BYPASS"),
-  ("/blockheight", StatusCode::OK, "BYPASS"),
+  ("/static/index.css", StatusCode::OK, "HIT", "max-age=14400"),
+  ("/static/index.js", StatusCode::OK, "HIT", "max-age=14400"),
+  ("/sat/FOO", StatusCode::BAD_REQUEST, "HIT", "max-age=14400"),
+  ("/", StatusCode::OK, "BYPASS", ""),
+  ("/blockheight", StatusCode::OK, "BYPASS", ""),
 ];
 
 fn main() {
   eprint!("Warming up the cache");
 
-  for (endpoint, expected_status_code, _expected_cache_status) in ENDPOINTS {
+  for (endpoint, expected_status_code, _expected_cache_status, _expected_cache_control) in ENDPOINTS
+  {
     let response = get(format!("https://ordinals.com{endpoint}")).unwrap();
 
     assert_eq!(response.status(), *expected_status_code);
@@ -57,7 +63,7 @@ fn main() {
 
   let mut failures = 0;
 
-  for (endpoint, expected_status_code, expected_cache_status) in ENDPOINTS {
+  for (endpoint, expected_status_code, expected_cache_status, expected_cache_control) in ENDPOINTS {
     eprint!("GET {endpoint}");
 
     let response = get(format!("https://ordinals.com{endpoint}")).unwrap();
@@ -68,14 +74,30 @@ fn main() {
 
     assert_eq!(response.status(), *expected_status_code);
 
-    let cache_status = response.headers().get("cf-cache-status").unwrap();
+    let headers = response.headers();
 
-    let pass = cache_status == expected_cache_status;
+    let mut pass = true;
 
-    if pass {
-      eprintln!(" {}", cache_status.to_str().unwrap().green());
+    let cache_status = headers
+      .get("cf-cache-status")
+      .map(|value| value.to_str().unwrap().to_string())
+      .unwrap_or_default();
+    if cache_status == *expected_cache_status {
+      eprint!(" {}", cache_status.green());
     } else {
-      eprintln!(" {}", cache_status.to_str().unwrap().red());
+      eprint!(" {}", cache_status.red());
+      pass = false;
+    }
+
+    let cache_control = headers
+      .get("cache-control")
+      .map(|value| value.to_str().unwrap().to_string())
+      .unwrap_or_default();
+    if cache_control == *expected_cache_control {
+      eprintln!(" {}", cache_control.green());
+    } else {
+      eprintln!(" {}", cache_control.red());
+      pass = false;
     }
 
     failures += u32::from(!pass);


### PR DESCRIPTION
- Cache non-HTML previews for four hours
- Test expected cache-control header