### PR TITLE
Emit location update events to optional channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 /target
 /test-times.txt
 /tmp
-.vscode
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /*.redb
 /.idea/
 /.vagrant
+/.vscode
 /docs/build
 /fuzz/artifacts
 /fuzz/corpus
@@ -10,4 +11,3 @@
 /target
 /test-times.txt
 /tmp
-/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /target
 /test-times.txt
 /tmp
+.vscode

--- a/src/index.rs
+++ b/src/index.rs
@@ -5706,11 +5706,11 @@ mod tests {
       let mut index = context.index;
       let (sender, _) = tokio::sync::mpsc::channel::<LocationUpdateEvent>(1);
 
-      assert_eq!(index.event_sender.is_none(), true);
+      assert!(index.event_sender.is_none());
 
       index.with_event_sender(sender);
 
-      assert_eq!(index.event_sender.is_some(), true);
+      assert!(index.event_sender.is_some());
     }
   }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -4,6 +4,7 @@ use {
       Entry, HeaderValue, InscriptionEntry, InscriptionEntryValue, InscriptionIdValue,
       OutPointValue, RuneEntryValue, RuneIdValue, SatPointValue, SatRange, TxidValue,
     },
+    event::Event,
     reorg::*,
     runes::{Rune, RuneId},
     updater::Updater,
@@ -30,13 +31,10 @@ use {
   },
 };
 
-pub use {
-  self::{entry::RuneEntry, event::Event},
-  entry::MintEntry,
-};
+pub use {self::event::Event, entry::MintEntry};
 
 pub(crate) mod entry;
-mod event;
+pub mod event;
 mod fetcher;
 mod reorg;
 mod rtx;

--- a/src/index.rs
+++ b/src/index.rs
@@ -31,8 +31,7 @@ use {
   },
 };
 
-pub use self::entry::RuneEntry;
-pub use {self::event::Event, entry::MintEntry};
+pub use {self::entry::RuneEntry, entry::MintEntry};
 
 pub(crate) mod entry;
 pub mod event;
@@ -5722,7 +5721,7 @@ mod tests {
     let transfer_event = event_receiver.blocking_recv().unwrap();
     assert_eq!(
       transfer_event,
-      Event::InscriptionMoved {
+      Event::InscriptionTransferred {
         block_height: 3,
         inscription_id,
         new_location: SatPoint {

--- a/src/index.rs
+++ b/src/index.rs
@@ -31,6 +31,7 @@ use {
   },
 };
 
+pub use self::entry::RuneEntry;
 pub use {self::event::Event, entry::MintEntry};
 
 pub(crate) mod entry;
@@ -5665,16 +5666,44 @@ mod tests {
   }
 
   #[test]
-  fn set_event_sender() {
-    for context in Context::configurations() {
-      let mut index = context.index;
-      let (sender, _) = tokio::sync::mpsc::channel::<Event>(1);
+  fn event_sender_channel() {
+    for mut context in Context::configurations() {
+      let (sender, mut receiver) = tokio::sync::mpsc::channel::<Event>(1);
 
-      assert!(index.event_sender.is_none());
+      assert!(context.index.event_sender.is_none());
 
-      index.set_event_sender(sender);
+      context.index.set_event_sender(sender);
+      context.mine_blocks(1);
+      let inscription = Inscription::default();
+      let txid = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0, inscription.to_witness())],
+        fee: COIN_VALUE,
+        ..Default::default()
+      });
 
-      assert!(index.event_sender.is_some());
+      context.mine_blocks(1);
+
+      let inscription_id = InscriptionId { txid, index: 0 };
+
+      let event = receiver.blocking_recv().unwrap();
+      receiver.close();
+
+      let expected_charms = if context.index.index_sats { 513 } else { 0 };
+
+      assert_eq!(
+        event,
+        Event::InscriptionCreated {
+          id: inscription_id,
+          location: Some(SatPoint {
+            outpoint: OutPoint { txid, vout: 0 },
+            offset: 0
+          }),
+          sequence_number: 0,
+          block_height: 2,
+          charms: expected_charms,
+          parent_inscription_id: None
+        }
+      );
     }
   }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -30,9 +30,13 @@ use {
   },
 };
 
-pub use {self::entry::RuneEntry, entry::MintEntry};
+pub use {
+  self::{entry::RuneEntry, event::Event},
+  entry::MintEntry,
+};
 
 pub(crate) mod entry;
+mod event;
 mod fetcher;
 mod reorg;
 mod rtx;
@@ -195,29 +199,6 @@ impl<T> BitcoinCoreRpcResultExt<T> for Result<T, bitcoincore_rpc::Error> {
       Err(err) => Err(err.into()),
     }
   }
-}
-
-/// An event from indexing which can be optionally emitted by setting a
-/// channel sender using `set_event_sender`.
-#[derive(Debug, Clone)]
-pub enum Event {
-  /// Newly created inscriptions will include additional metadata including
-  /// rarity, cursed status, charms, etc.
-  InscriptionCreated {
-    id: InscriptionId,
-    location: Option<SatPoint>,
-    sequence_number: u32,
-    block_height: u32,
-    charms: u16,
-    parent_inscription_id: Option<InscriptionId>,
-  },
-  InscriptionMoved {
-    id: InscriptionId,
-    old_location: SatPoint,
-    new_location: SatPoint,
-    sequence_number: u32,
-    block_height: u32,
-  },
 }
 
 pub struct Index {

--- a/src/index/event.rs
+++ b/src/index/event.rs
@@ -1,24 +1,20 @@
 use crate::{InscriptionId, SatPoint};
 
-/// An event from indexing which can be optionally emitted by setting a
-/// channel sender using `set_event_sender`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Event {
-  /// Newly created inscriptions will include additional metadata including
-  /// rarity, cursed status, charms, etc.
   InscriptionCreated {
-    id: InscriptionId,
-    location: Option<SatPoint>,
-    sequence_number: u32,
     block_height: u32,
     charms: u16,
+    inscription_id: InscriptionId,
+    location: Option<SatPoint>,
     parent_inscription_id: Option<InscriptionId>,
+    sequence_number: u32,
   },
   InscriptionMoved {
-    id: InscriptionId,
-    old_location: SatPoint,
-    new_location: SatPoint,
-    sequence_number: u32,
     block_height: u32,
+    inscription_id: InscriptionId,
+    new_location: SatPoint,
+    old_location: SatPoint,
+    sequence_number: u32,
   },
 }

--- a/src/index/event.rs
+++ b/src/index/event.rs
@@ -2,7 +2,7 @@ use crate::{InscriptionId, SatPoint};
 
 /// An event from indexing which can be optionally emitted by setting a
 /// channel sender using `set_event_sender`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Event {
   /// Newly created inscriptions will include additional metadata including
   /// rarity, cursed status, charms, etc.

--- a/src/index/event.rs
+++ b/src/index/event.rs
@@ -1,0 +1,24 @@
+use crate::{InscriptionId, SatPoint};
+
+/// An event from indexing which can be optionally emitted by setting a
+/// channel sender using `set_event_sender`.
+#[derive(Debug, Clone)]
+pub enum Event {
+  /// Newly created inscriptions will include additional metadata including
+  /// rarity, cursed status, charms, etc.
+  InscriptionCreated {
+    id: InscriptionId,
+    location: Option<SatPoint>,
+    sequence_number: u32,
+    block_height: u32,
+    charms: u16,
+    parent_inscription_id: Option<InscriptionId>,
+  },
+  InscriptionMoved {
+    id: InscriptionId,
+    old_location: SatPoint,
+    new_location: SatPoint,
+    sequence_number: u32,
+    block_height: u32,
+  },
+}

--- a/src/index/event.rs
+++ b/src/index/event.rs
@@ -10,7 +10,7 @@ pub enum Event {
     parent_inscription_id: Option<InscriptionId>,
     sequence_number: u32,
   },
-  InscriptionMoved {
+  InscriptionTransferred {
     block_height: u32,
     inscription_id: InscriptionId,
     new_location: SatPoint,

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -446,7 +446,7 @@ impl<'index> Updater<'_> {
       unbound_inscriptions,
       value_cache,
       value_receiver,
-      event_sender: &self.index.event_sender.clone(),
+      event_sender: self.index.event_sender.as_ref(),
     };
 
     if self.index.index_sats {

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -38,7 +38,6 @@ pub(crate) struct Updater<'index> {
   outputs_cached: u64,
   outputs_inserted_since_flush: u64,
   outputs_traversed: u64,
-  event_sender: Option<tokio::sync::mpsc::Sender<LocationUpdateEvent>>,
 }
 
 impl<'index> Updater<'_> {
@@ -51,7 +50,6 @@ impl<'index> Updater<'_> {
       outputs_cached: 0,
       outputs_inserted_since_flush: 0,
       outputs_traversed: 0,
-      event_sender: index.event_sender.clone(),
     })
   }
 
@@ -448,7 +446,7 @@ impl<'index> Updater<'_> {
       unbound_inscriptions,
       value_cache,
       value_receiver,
-      event_sender: &self.event_sender.clone(),
+      event_sender: &self.index.event_sender.clone(),
     };
 
     if self.index.index_sats {

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -550,10 +550,7 @@ impl<'index> Updater<'_> {
       }
     } else if index_inscriptions {
       for (tx, txid) in block.txdata.iter().skip(1).chain(block.txdata.first()) {
-        inscription_updater.index_envelopes(
-          tx, *txid, None,
-          // self.location_update_sender.clone(),
-        )?;
+        inscription_updater.index_envelopes(tx, *txid, None)?;
       }
     }
 
@@ -658,12 +655,7 @@ impl<'index> Updater<'_> {
     index_inscriptions: bool,
   ) -> Result {
     if index_inscriptions {
-      inscription_updater.index_envelopes(
-        tx,
-        txid,
-        Some(input_sat_ranges),
-        // self.location_update_sender.clone(),
-      )?;
+      inscription_updater.index_envelopes(tx, txid, Some(input_sat_ranges))?;
     }
 
     for (vout, output) in tx.output.iter().enumerate() {

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -38,7 +38,7 @@ pub(crate) struct Updater<'index> {
   outputs_cached: u64,
   outputs_inserted_since_flush: u64,
   outputs_traversed: u64,
-  location_update_sender: Option<tokio::sync::mpsc::Sender<LocationUpdateEvent>>,
+  event_sender: Option<tokio::sync::mpsc::Sender<LocationUpdateEvent>>,
 }
 
 impl<'index> Updater<'_> {
@@ -51,7 +51,7 @@ impl<'index> Updater<'_> {
       outputs_cached: 0,
       outputs_inserted_since_flush: 0,
       outputs_traversed: 0,
-      location_update_sender: index.location_update_sender.clone(),
+      event_sender: index.event_sender.clone(),
     })
   }
 
@@ -448,6 +448,7 @@ impl<'index> Updater<'_> {
       unbound_inscriptions,
       value_cache,
       value_receiver,
+      event_sender: &self.event_sender.clone(),
     };
 
     if self.index.index_sats {
@@ -550,10 +551,8 @@ impl<'index> Updater<'_> {
     } else if index_inscriptions {
       for (tx, txid) in block.txdata.iter().skip(1).chain(block.txdata.first()) {
         inscription_updater.index_envelopes(
-          tx,
-          *txid,
-          None,
-          self.location_update_sender.clone(),
+          tx, *txid, None,
+          // self.location_update_sender.clone(),
         )?;
       }
     }
@@ -663,7 +662,7 @@ impl<'index> Updater<'_> {
         tx,
         txid,
         Some(input_sat_ranges),
-        self.location_update_sender.clone(),
+        // self.location_update_sender.clone(),
       )?;
     }
 

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -74,7 +74,6 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     tx: &Transaction,
     txid: Txid,
     input_sat_ranges: Option<&VecDeque<(u64, u64)>>,
-    // location_update_sender: Option<Sender<LocationUpdateEvent>>,
   ) -> Result {
     let mut floating_inscriptions = Vec::new();
     let mut id_counter = 0;
@@ -334,12 +333,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
         _ => new_satpoint,
       };
 
-      self.update_inscription_location(
-        input_sat_ranges,
-        flotsam,
-        new_satpoint,
-        // &location_update_sender,
-      )?;
+      self.update_inscription_location(input_sat_ranges, flotsam, new_satpoint)?;
     }
 
     if is_coinbase {
@@ -348,12 +342,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           outpoint: OutPoint::null(),
           offset: self.lost_sats + flotsam.offset - output_value,
         };
-        self.update_inscription_location(
-          input_sat_ranges,
-          flotsam,
-          new_satpoint,
-          // &location_update_sender,
-        )?;
+        self.update_inscription_location(input_sat_ranges, flotsam, new_satpoint)?;
       }
       self.lost_sats += self.reward - output_value;
       Ok(())
@@ -391,7 +380,6 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     input_sat_ranges: Option<&VecDeque<(u64, u64)>>,
     flotsam: Flotsam,
     new_satpoint: SatPoint,
-    // location_update_sender: &Option<Sender<LocationUpdateEvent>>,
   ) -> Result {
     let inscription_id = flotsam.inscription_id;
     let (unbound, sequence_number) = match flotsam.origin {

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -41,7 +41,7 @@ pub(super) struct InscriptionUpdater<'a, 'db, 'tx> {
   pub(super) blessed_inscription_count: u64,
   pub(super) chain: Chain,
   pub(super) cursed_inscription_count: u64,
-  pub(super) event_sender: &'a Option<Sender<Event>>,
+  pub(super) event_sender: Option<&'a Sender<Event>>,
   pub(super) flotsam: Vec<Flotsam>,
   pub(super) height: u32,
   pub(super) home_inscription_count: u64,
@@ -396,11 +396,11 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
 
         if let Some(sender) = self.event_sender {
           sender.blocking_send(Event::InscriptionMoved {
-            id: inscription_id,
-            old_location: old_satpoint,
-            new_location: new_satpoint,
-            sequence_number,
             block_height: self.height,
+            inscription_id,
+            new_location: new_satpoint,
+            old_location: old_satpoint,
+            sequence_number,
           })?;
         }
 
@@ -501,12 +501,12 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
 
         if let Some(sender) = self.event_sender {
           sender.blocking_send(Event::InscriptionCreated {
-            id: inscription_id,
-            location: (!unbound).then_some(new_satpoint),
-            charms,
-            sequence_number,
-            parent_inscription_id: parent,
             block_height: self.height,
+            charms,
+            inscription_id,
+            location: (!unbound).then_some(new_satpoint),
+            parent_inscription_id: parent,
+            sequence_number,
           })?;
         }
 

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -395,7 +395,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           .value();
 
         if let Some(sender) = self.event_sender {
-          sender.blocking_send(Event::InscriptionMoved {
+          sender.blocking_send(Event::InscriptionTransferred {
             block_height: self.height,
             inscription_id,
             new_location: new_satpoint,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ mod inscriptions;
 mod object;
 mod options;
 pub mod outgoing;
+pub mod rarity;
 mod representation;
 pub mod runes;
 mod server_config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,6 @@ mod inscriptions;
 mod object;
 mod options;
 pub mod outgoing;
-pub mod rarity;
 mod representation;
 pub mod runes;
 mod server_config;


### PR DESCRIPTION
Addresses #2789 

Introduces a way for `InscriptionUpdater` to emit location update events on an in-process channel. Example usage can be found here: https://github.com/mi-yu/ord-custom-indexer-example

cc @casey 