### PR TITLE
Fix deploy setup script

### DIFF
--- a/crates/audit-cache/src/main.rs
+++ b/crates/audit-cache/src/main.rs
@@ -4,48 +4,54 @@ use {
   std::process,
 };
 
-const ENDPOINTS: &[(&str, StatusCode, &str)] = &[
-  // PNG content is cached
+const ENDPOINTS: &[(&str, StatusCode, &str, &str)] = &[
+  // PNG content is cached for one year
   (
     "/content/6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0",
     StatusCode::OK,
     "HIT",
+    "public, max-age=31536000, immutable",
   ),
-  // HTML content is cached
+  // HTML content is cached for one year
   (
     "/content/114c5c87c4d0a7facb2b4bf515a4ad385182c076a5cfcc2982bf2df103ec0fffi0",
     StatusCode::OK,
     "HIT",
+    "public, max-age=31536000, immutable",
   ),
   // content respopnses that aren't found aren't cached
   (
     "/content/6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i1",
     StatusCode::NOT_FOUND,
     "BYPASS",
+    "no-store",
   ),
-  // HTML previews are cached
+  // HTML previews are cached for one year
   (
     "/preview/114c5c87c4d0a7facb2b4bf515a4ad385182c076a5cfcc2982bf2df103ec0fffi0",
     StatusCode::OK,
     "HIT",
+    "public, max-age=31536000, immutable",
   ),
-  // non-HTML previews are not cached
+  // non-HTML previews are cached for four hours
   (
     "/preview/6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0",
     StatusCode::OK,
-    "BYPASS",
+    "HIT",
+    "max-age=14400",
   ),
-  ("/static/index.css", StatusCode::OK, "HIT"),
-  ("/static/index.js", StatusCode::OK, "HIT"),
-  ("/sat/FOO", StatusCode::BAD_REQUEST, "HIT"),
-  ("/", StatusCode::OK, "BYPASS"),
-  ("/blockheight", StatusCode::OK, "BYPASS"),
+  ("/static/index.css", StatusCode::OK, "HIT", "max-age=14400"),
+  ("/static/index.js", StatusCode::OK, "HIT", "max-age=14400"),
+  ("/sat/FOO", StatusCode::BAD_REQUEST, "HIT", "max-age=14400"),
+  ("/", StatusCode::OK, "BYPASS", ""),
+  ("/blockheight", StatusCode::OK, "BYPASS", ""),
 ];
 
 fn main() {
   eprint!("Warming up the cache");
 
-  for (endpoint, expected_status_code, _expected_cache_status) in ENDPOINTS {
+  for (endpoint, expected_status_code, _expected_cache_status, _expected_cache_control) in ENDPOINTS
+  {
     let response = get(format!("https://ordinals.com{endpoint}")).unwrap();
 
     assert_eq!(response.status(), *expected_status_code);
@@ -57,7 +63,7 @@ fn main() {
 
   let mut failures = 0;
 
-  for (endpoint, expected_status_code, expected_cache_status) in ENDPOINTS {
+  for (endpoint, expected_status_code, expected_cache_status, expected_cache_control) in ENDPOINTS {
     eprint!("GET {endpoint}");
 
     let response = get(format!("https://ordinals.com{endpoint}")).unwrap();
@@ -68,14 +74,30 @@ fn main() {
 
     assert_eq!(response.status(), *expected_status_code);
 
-    let cache_status = response.headers().get("cf-cache-status").unwrap();
+    let headers = response.headers();
 
-    let pass = cache_status == expected_cache_status;
+    let mut pass = true;
 
-    if pass {
-      eprintln!(" {}", cache_status.to_str().unwrap().green());
+    let cache_status = headers
+      .get("cf-cache-status")
+      .map(|value| value.to_str().unwrap().to_string())
+      .unwrap_or_default();
+    if cache_status == *expected_cache_status {
+      eprint!(" {}", cache_status.green());
     } else {
-      eprintln!(" {}", cache_status.to_str().unwrap().red());
+      eprint!(" {}", cache_status.red());
+      pass = false;
+    }
+
+    let cache_control = headers
+      .get("cache-control")
+      .map(|value| value.to_str().unwrap().to_string())
+      .unwrap_or_default();
+    if cache_control == *expected_cache_control {
+      eprintln!(" {}", cache_control.green());
+    } else {
+      eprintln!(" {}", cache_control.red());
+      pass = false;
     }
 
     failures += u32::from(!pass);

--- a/deploy/checkout
+++ b/deploy/checkout
@@ -3,11 +3,12 @@
 set -euxo pipefail
 
 BRANCH=$1
-CHAIN=$2
-DOMAIN=$3
+REMOTE=$1
+CHAIN=$3
+DOMAIN=$4
 
 if [[ ! -d ord ]]; then
-  git clone https://github.com/ordinals/ord.git
+  git clone https://github.com/$REMOTE.git
 fi
 
 cd ord

--- a/deploy/checkout
+++ b/deploy/checkout
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 BRANCH=$1
-REMOTE=$1
+REMOTE=$2
 CHAIN=$3
 DOMAIN=$4
 

--- a/deploy/checkout
+++ b/deploy/checkout
@@ -7,11 +7,12 @@ REMOTE=$1
 CHAIN=$3
 DOMAIN=$4
 
-if [[ ! -d ord ]]; then
-  git clone https://github.com/$REMOTE.git
+if [[ ! -d $REMOTE ]]; then
+  mkdir -p $REMOTE
+  git clone https://github.com/$REMOTE.git $REMOTE
 fi
 
-cd ord
+cd $REMOTE
 
 git fetch origin
 git checkout -B $BRANCH

--- a/deploy/setup
+++ b/deploy/setup
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# This script is idempotent.
+
 set -euxo pipefail
 
 CHAIN=$1

--- a/deploy/setup
+++ b/deploy/setup
@@ -32,6 +32,7 @@ hostnamectl set-hostname $DOMAIN
 apt-get install --yes \
   acl \
   clang \
+  curl \
   libsqlite3-dev\
   libssl-dev \
   pkg-config \

--- a/deploy/setup
+++ b/deploy/setup
@@ -32,6 +32,7 @@ apt-get install --yes \
   curl \
   libsqlite3-dev\
   libssl-dev \
+  locales-all \
   pkg-config \
   ufw \
   vim

--- a/deploy/setup
+++ b/deploy/setup
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# This script is idempotent in the sense that running it more
-# than once will not change the state beyond the initial application
-
 set -euxo pipefail
 
 CHAIN=$1

--- a/justfile
+++ b/justfile
@@ -30,14 +30,15 @@ deploy branch remote chain domain:
 
 deploy-all: deploy-testnet deploy-signet deploy-mainnet
 
-deploy-mainnet branch="master" remote="ordinals/ord": (deploy branch remote "main" "ordinals.net")
+deploy-mainnet-balance branch="master" remote="ordinals/ord": (deploy branch "main" "balance.ordinals.net")
+
+deploy-mainnet-equilibrium branch="master" remote="ordinals/ord": (deploy branch "main" "equilibrium.ordinals.net")
+
+deploy-mainnet-stability branch="master" remote="ordinals/ord": (deploy branch "main" "stability.ordinals.net")
 
 deploy-signet branch="master" remote="ordinals/ord": (deploy branch remote "signet" "signet.ordinals.net")
 
 deploy-testnet branch="master" remote="ordinals/ord": (deploy branch remote "test" "testnet.ordinals.net")
-
-deploy-ord-dev branch="master" remote="ordinals/ord" chain="main" domain="ordinals-dev.com": \
-  (deploy branch remote chain domain)
 
 save-ord-dev-state domain="ordinals-dev.com":
   $EDITOR ./deploy/save-ord-dev-state

--- a/justfile
+++ b/justfile
@@ -20,23 +20,24 @@ clippy:
 lclippy:
   cargo lclippy --all --all-targets -- -D warnings
 
-deploy branch chain domain:
+deploy branch remote chain domain:
   ssh root@{{domain}} "mkdir -p deploy \
     && apt-get update --yes \
     && apt-get upgrade --yes \
     && apt-get install --yes git rsync"
   rsync -avz deploy/checkout root@{{domain}}:deploy/checkout
-  ssh root@{{domain}} 'cd deploy && ./checkout {{branch}} {{chain}} {{domain}}'
+  ssh root@{{domain}} 'cd deploy && ./checkout {{branch}} {{remote}} {{chain}} {{domain}}'
 
 deploy-all: deploy-testnet deploy-signet deploy-mainnet
 
-deploy-mainnet branch="master": (deploy branch "main" "ordinals.net")
+deploy-mainnet branch="master" remote="ordinals/ord": (deploy branch remote "main" "ordinals.net")
 
-deploy-signet branch="master": (deploy branch "signet" "signet.ordinals.net")
+deploy-signet branch="master" remote="ordinals/ord": (deploy branch remote "signet" "signet.ordinals.net")
 
-deploy-testnet branch="master": (deploy branch "test" "testnet.ordinals.net")
+deploy-testnet branch="master" remote="ordinals/ord": (deploy branch remote "test" "testnet.ordinals.net")
 
-deploy-ord-dev branch="master" chain="main" domain="ordinals-dev.com": (deploy branch chain domain)
+deploy-ord-dev branch="master" remote="ordinals/ord" chain="main" domain="ordinals-dev.com": \
+  (deploy branch remote chain domain)
 
 save-ord-dev-state domain="ordinals-dev.com":
   $EDITOR ./deploy/save-ord-dev-state

--- a/templates/page.html
+++ b/templates/page.html
@@ -7,7 +7,7 @@
     <meta property=og:title content='{{ self.content.title() }}'>
     <meta property=og:image content='{{ self.og_image() }}'>
     <meta property=twitter:card content=summary>
-    <title>TEST {{ self.content.title() }}</title>
+    <title>{{ self.content.title() }}</title>
     <link rel=alternate href=/feed.xml type=application/rss+xml title='Inscription RSS Feed'>
     <link rel=stylesheet href=/static/index.css>
     <link rel=stylesheet href=/static/modern-normalize.css>

--- a/templates/page.html
+++ b/templates/page.html
@@ -7,7 +7,7 @@
     <meta property=og:title content='{{ self.content.title() }}'>
     <meta property=og:image content='{{ self.og_image() }}'>
     <meta property=twitter:card content=summary>
-    <title>{{ self.content.title() }}</title>
+    <title>TEST {{ self.content.title() }}</title>
     <link rel=alternate href=/feed.xml type=application/rss+xml title='Inscription RSS Feed'>
     <link rel=stylesheet href=/static/index.css>
     <link rel=stylesheet href=/static/modern-normalize.css>


### PR DESCRIPTION
This started with me trying to fix HTTP/2, and ended with me redeploying testnet and signet.

Because we now might need to deploy from branches on `casey/ord` or `raphjaph/ord` while developing, I added a `remote` argument to the deploy recipes, which takes a github repo that defaults to `ordinals/ord`.

This also updates the deploy script to install `curl`, which wasn't present on the VPS, and `locales-all`, which gets rid of a missing locale warning.

`testnet.ordinals.net` and `signet.ordinals.net` are now up. 