### PR TITLE
Don't print out status when deploying

### DIFF
--- a/deploy/setup
+++ b/deploy/setup
@@ -128,7 +128,7 @@ systemctl daemon-reload
 systemctl enable ord
 systemctl restart ord
 
-while ! curl --fail https://$DOMAIN/status; do
+while ! curl --fail https://$DOMAIN/status > /dev/null; do
   echo "Waiting for ord at https://$DOMAIN/status…"
   sleep 1
 done


### PR DESCRIPTION
The status page is long now, so we should pipe it to /dev/null so it doesn't spam the terminal.