### PR TITLE
Add coverage recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -222,3 +222,6 @@ update-mdbook-theme:
 
 audit-cache:
   cargo run --package audit-cache
+
+coverage:
+  cargo llvm-cov


### PR DESCRIPTION
Add a recipe for generating a code coverage report. Doesn't do much, but gives contributors a clue for how to do it. Our code coverage looks pretty good. I ran it, and our tests exercise 96% of our codebase by line.