### PR TITLE
Index runes on servers

### DIFF
--- a/deploy/ord.service
+++ b/deploy/ord.service
@@ -10,9 +10,10 @@ Environment=RUST_BACKTRACE=1
 Environment=RUST_LOG=info
 ExecStart=/usr/local/bin/ord \
   --bitcoin-data-dir /var/lib/bitcoind \
-  --data-dir /var/lib/ord \
-  --config-dir /var/lib/ord \
   --chain ${CHAIN} \
+  --config-dir /var/lib/ord \
+  --data-dir /var/lib/ord \
+  --index-runes \
   --index-sats \
   server \
   --acme-contact mailto:casey@rodarmor.com \


### PR DESCRIPTION
Add `--index-runes` to `ord.service`. Will only take effect on signet and testnet.