### PR TITLE
Keep inscriptions with unrecognized even fields unbound after jubilee

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -3252,6 +3252,51 @@ mod tests {
   }
 
   #[test]
+  fn unrecognized_even_field_inscriptions_are_unbound_after_jubilee() {
+    for context in Context::configurations() {
+      context.mine_blocks(109);
+
+      let witness = envelope(&[
+        b"ord",
+        &[1],
+        b"text/plain;charset=utf-8",
+        &[2],
+        b"bar",
+        &[4],
+        b"ord",
+      ]);
+
+      let txid = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0, witness)],
+        ..Default::default()
+      });
+
+      let inscription_id = InscriptionId { txid, index: 0 };
+
+      context.mine_blocks(1);
+
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: unbound_outpoint(),
+          offset: 0,
+        },
+        None,
+      );
+
+      assert_eq!(
+        context
+          .index
+          .get_inscription_entry(inscription_id)
+          .unwrap()
+          .unwrap()
+          .inscription_number,
+        0
+      );
+    }
+  }
+
+  #[test]
   fn inscriptions_are_uncursed_after_jubilee() {
     for context in Context::configurations() {
       context.mine_blocks(108);

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -180,7 +180,9 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           None
         };
 
-        let unbound = current_input_value == 0 || curse == Some(Curse::UnrecognizedEvenField);
+        let unbound = current_input_value == 0
+          || curse == Some(Curse::UnrecognizedEvenField)
+          || inscription.payload.unrecognized_even_field;
 
         let offset = inscription
           .payload


### PR DESCRIPTION
Fixes #2845.