### PR TITLE
Decode transactions from core with `ord decode --txid`

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -27,11 +27,11 @@ pub(crate) type ParsedEnvelope = Envelope<Inscription>;
 
 #[derive(Default, PartialEq, Clone, Serialize, Deserialize, Debug, Eq)]
 pub struct Envelope<T> {
-  pub(crate) input: u32,
-  pub(crate) offset: u32,
-  pub(crate) payload: T,
-  pub(crate) pushnum: bool,
-  pub(crate) stutter: bool,
+  pub input: u32,
+  pub offset: u32,
+  pub payload: T,
+  pub pushnum: bool,
+  pub stutter: bool,
 }
 
 fn remove_field(fields: &mut BTreeMap<&[u8], Vec<&[u8]>>, field: &[u8]) -> Option<Vec<u8>> {

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -25,8 +25,8 @@ type Result<T> = std::result::Result<T, script::Error>;
 type RawEnvelope = Envelope<Vec<Vec<u8>>>;
 pub(crate) type ParsedEnvelope = Envelope<Inscription>;
 
-#[derive(Debug, Default, PartialEq, Clone)]
-pub(crate) struct Envelope<T> {
+#[derive(Default, PartialEq, Clone, Serialize, Deserialize, Debug, Eq)]
+pub struct Envelope<T> {
   pub(crate) input: u32,
   pub(crate) offset: u32,
   pub(crate) payload: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ use {
 };
 
 pub use self::{
+  envelope::Envelope,
   fee_rate::FeeRate,
   inscription::Inscription,
   object::Object,

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -54,7 +54,7 @@ impl Subcommand {
   pub(crate) fn run(self, options: Options) -> SubcommandResult {
     match self {
       Self::Balances => balances::run(options),
-      Self::Decode(decode) => decode.run(),
+      Self::Decode(decode) => decode.run(options),
       Self::Epochs => epochs::run(),
       Self::Find(find) => find.run(options),
       Self::Index(index) => index.run(options),

--- a/src/subcommand/decode.rs
+++ b/src/subcommand/decode.rs
@@ -75,10 +75,10 @@ pub(crate) struct Decode {
 
 impl Decode {
   pub(crate) fn run(self, options: Options) -> SubcommandResult {
-    let client = options.bitcoin_rpc_client()?;
-
     let transaction = if let Some(txid) = self.txid {
-      client.get_raw_transaction(&txid, None)?
+      options
+        .bitcoin_rpc_client()?
+        .get_raw_transaction(&txid, None)?
     } else if let Some(file) = self.file {
       Transaction::consensus_decode(&mut File::open(file)?)?
     } else {

--- a/src/subcommand/decode.rs
+++ b/src/subcommand/decode.rs
@@ -12,25 +12,25 @@ pub struct RawOutput {
 
 #[derive(Serialize, Eq, PartialEq, Deserialize, Debug)]
 pub struct CompactInscription {
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub body: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub content_encoding: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub content_type: Option<String>,
-  #[serde(skip_serializing_if = "std::ops::Not::not")]
+  #[serde(default, skip_serializing_if = "std::ops::Not::not")]
   pub duplicate_field: bool,
-  #[serde(skip_serializing_if = "std::ops::Not::not")]
+  #[serde(default, skip_serializing_if = "std::ops::Not::not")]
   pub incomplete_field: bool,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub metadata: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub metaprotocol: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub parent: Option<InscriptionId>,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub pointer: Option<u64>,
-  #[serde(skip_serializing_if = "std::ops::Not::not")]
+  #[serde(default, skip_serializing_if = "std::ops::Not::not")]
   pub unrecognized_even_field: bool,
 }
 

--- a/src/subcommand/decode.rs
+++ b/src/subcommand/decode.rs
@@ -1,8 +1,59 @@
 use super::*;
 
 #[derive(Serialize, Eq, PartialEq, Deserialize, Debug)]
-pub struct Output {
-  pub inscriptions: Vec<Inscription>,
+pub struct CompactOutput {
+  pub inscriptions: Vec<CompactInscription>,
+}
+
+#[derive(Serialize, Eq, PartialEq, Deserialize, Debug)]
+pub struct RawOutput {
+  pub inscriptions: Vec<ParsedEnvelope>,
+}
+
+#[derive(Serialize, Eq, PartialEq, Deserialize, Debug)]
+pub struct CompactInscription {
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub body: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub content_encoding: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub content_type: Option<String>,
+  #[serde(skip_serializing_if = "std::ops::Not::not")]
+  pub duplicate_field: bool,
+  #[serde(skip_serializing_if = "std::ops::Not::not")]
+  pub incomplete_field: bool,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub metadata: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub metaprotocol: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub parent: Option<InscriptionId>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub pointer: Option<u64>,
+  #[serde(skip_serializing_if = "std::ops::Not::not")]
+  pub unrecognized_even_field: bool,
+}
+
+impl TryFrom<Inscription> for CompactInscription {
+  type Error = Error;
+
+  fn try_from(inscription: Inscription) -> Result<Self> {
+    Ok(Self {
+      content_encoding: inscription
+        .content_encoding()
+        .map(|header_value| header_value.to_str().map(str::to_string))
+        .transpose()?,
+      content_type: inscription.content_type().map(str::to_string),
+      metaprotocol: inscription.metaprotocol().map(str::to_string),
+      parent: inscription.parent(),
+      pointer: inscription.pointer(),
+      body: inscription.body.map(hex::encode),
+      duplicate_field: inscription.duplicate_field,
+      incomplete_field: inscription.incomplete_field,
+      metadata: inscription.metadata.map(hex::encode),
+      unrecognized_even_field: inscription.unrecognized_even_field,
+    })
+  }
 }
 
 #[derive(Debug, Parser)]
@@ -15,6 +66,11 @@ pub(crate) struct Decode {
   txid: Option<Txid>,
   #[arg(long, conflicts_with = "txid", help = "Load transaction from <FILE>.")]
   file: Option<PathBuf>,
+  #[arg(
+    long,
+    help = "Serialize inscriptions in a compact, human-readable format."
+  )]
+  compact: bool,
 }
 
 impl Decode {
@@ -31,11 +87,16 @@ impl Decode {
 
     let inscriptions = ParsedEnvelope::from_transaction(&transaction);
 
-    Ok(Box::new(Output {
-      inscriptions: inscriptions
-        .into_iter()
-        .map(|inscription| inscription.payload)
-        .collect(),
-    }))
+    if self.compact {
+      Ok(Box::new(CompactOutput {
+        inscriptions: inscriptions
+          .clone()
+          .into_iter()
+          .map(|inscription| inscription.payload.try_into())
+          .collect::<Result<Vec<CompactInscription>>>()?,
+      }))
+    } else {
+      Ok(Box::new(RawOutput { inscriptions }))
+    }
   }
 }

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -4,7 +4,10 @@ use {
     absolute::LockTime, consensus::Encodable, opcodes, script, ScriptBuf, Sequence, Transaction,
     TxIn, Witness,
   },
-  ord::{subcommand::decode::RawOutput, Envelope, Inscription},
+  ord::{
+    subcommand::decode::{CompactInscription, CompactOutput, RawOutput},
+    Envelope, Inscription,
+  },
 };
 
 fn transaction() -> Vec<u8> {
@@ -110,6 +113,29 @@ fn from_core() {
         offset: 0,
         pushnum: false,
         stutter: false,
+      }],
+    },
+  );
+}
+
+#[test]
+fn compact() {
+  assert_eq!(
+    CommandBuilder::new("decode --compact --file transaction.bin")
+      .write("transaction.bin", transaction())
+      .run_and_deserialize_output::<CompactOutput>(),
+    CompactOutput {
+      inscriptions: vec![CompactInscription {
+        body: Some("00010203".into()),
+        content_encoding: None,
+        content_type: Some("text/plain;charset=utf-8".into()),
+        duplicate_field: false,
+        incomplete_field: false,
+        metadata: None,
+        metaprotocol: None,
+        parent: None,
+        pointer: None,
+        unrecognized_even_field: false,
       }],
     },
   );

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -4,7 +4,7 @@ use {
     absolute::LockTime, consensus::Encodable, opcodes, script, ScriptBuf, Sequence, Transaction,
     TxIn, Witness,
   },
-  ord::{subcommand::decode::Output, Inscription},
+  ord::{subcommand::decode::RawOutput, Envelope, Inscription},
 };
 
 fn transaction() -> Vec<u8> {
@@ -48,14 +48,20 @@ fn from_file() {
   assert_eq!(
     CommandBuilder::new("decode --file transaction.bin")
       .write("transaction.bin", transaction())
-      .run_and_deserialize_output::<Output>(),
-    Output {
-      inscriptions: vec![Inscription {
-        body: Some(vec![0, 1, 2, 3]),
-        content_type: Some(b"text/plain;charset=utf-8".into()),
-        ..Default::default()
+      .run_and_deserialize_output::<RawOutput>(),
+    RawOutput {
+      inscriptions: vec![Envelope {
+        payload: Inscription {
+          body: Some(vec![0, 1, 2, 3]),
+          content_type: Some(b"text/plain;charset=utf-8".into()),
+          ..Default::default()
+        },
+        input: 0,
+        offset: 0,
+        pushnum: false,
+        stutter: false,
       }],
-    }
+    },
   );
 }
 
@@ -64,14 +70,20 @@ fn from_stdin() {
   assert_eq!(
     CommandBuilder::new("decode")
       .stdin(transaction())
-      .run_and_deserialize_output::<Output>(),
-    Output {
-      inscriptions: vec![Inscription {
-        body: Some(vec![0, 1, 2, 3]),
-        content_type: Some(b"text/plain;charset=utf-8".into()),
-        ..Default::default()
+      .run_and_deserialize_output::<RawOutput>(),
+    RawOutput {
+      inscriptions: vec![Envelope {
+        payload: Inscription {
+          body: Some(vec![0, 1, 2, 3]),
+          content_type: Some(b"text/plain;charset=utf-8".into()),
+          ..Default::default()
+        },
+        input: 0,
+        offset: 0,
+        pushnum: false,
+        stutter: false,
       }],
-    }
+    },
   );
 }
 
@@ -86,13 +98,19 @@ fn from_core() {
   assert_eq!(
     CommandBuilder::new(format!("decode --txid {reveal}"))
       .rpc_server(&rpc_server)
-      .run_and_deserialize_output::<Output>(),
-    Output {
-      inscriptions: vec![Inscription {
-        body: Some(b"FOO".into()),
-        content_type: Some(b"text/plain;charset=utf-8".into()),
-        ..Default::default()
+      .run_and_deserialize_output::<RawOutput>(),
+    RawOutput {
+      inscriptions: vec![Envelope {
+        payload: Inscription {
+          body: Some(b"FOO".into()),
+          content_type: Some(b"text/plain;charset=utf-8".into()),
+          ..Default::default()
+        },
+        input: 0,
+        offset: 0,
+        pushnum: false,
+        stutter: false,
       }],
-    }
+    },
   );
 }


### PR DESCRIPTION
Also add an optional compact output format which is less horrible to read