### PR TITLE
Use install to copy binary in deploy script

### DIFF
--- a/deploy/setup
+++ b/deploy/setup
@@ -98,7 +98,7 @@ source ~/.cargo/env
 rustup update stable
 
 cargo build --release
-cp target/release/ord /usr/local/bin/ord
+install --backup target/release/ord /usr/local/bin/ord
 
 id --user bitcoin || useradd --system bitcoin
 id --user ord || useradd --system ord


### PR DESCRIPTION
Our deploy script currently doesn't work, because if you try to overwrite /usr/lib/bin/ord, it errors out since the file is being used. This uses `install` to move it into place, which also keeps one backup, which it names `/usr/local/bin/ord~`.