### PR TITLE
fix commented sat field on batch inscriptions guide

### DIFF
--- a/batch.yaml
+++ b/batch.yaml
@@ -13,7 +13,7 @@ parent: 6ac5cacb768794f4fd7a78bf00f2074891fce68bd65c4ff36e77177237aacacai0
 postage: 12345
 
 # sat to inscribe on, can only be used with `same-sat`:
-# sat: 5000000000
+sat: 5000000000
 
 # inscriptions to inscribe
 #


### PR DESCRIPTION
fixes issue #2948 , I believe the `#` commenting out the sat field is a mistake and makes the example a little confusing