### PR TITLE
VINDICATION

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -87,18 +87,18 @@ pub enum List {
 #[derive(Copy, Clone)]
 pub(crate) enum Statistic {
   Schema = 0,
-  BlessedInscriptions,
-  Commits,
-  CursedInscriptions,
-  IndexRunes,
-  IndexSats,
-  LostSats,
-  OutputsTraversed,
-  ReservedRunes,
-  Runes,
-  SatRanges,
-  UnboundInscriptions,
-  IndexTransactions,
+  BlessedInscriptions = 1,
+  Commits = 2,
+  CursedInscriptions = 3,
+  IndexRunes = 4,
+  IndexSats = 5,
+  LostSats = 6,
+  OutputsTraversed = 7,
+  ReservedRunes = 8,
+  Runes = 9,
+  SatRanges = 10,
+  UnboundInscriptions = 11,
+  IndexTransactions = 12,
 }
 
 impl Statistic {

--- a/src/index.rs
+++ b/src/index.rs
@@ -5663,7 +5663,10 @@ mod tests {
         .unwrap()
         .unwrap();
 
-      dbg!(Charm::charms(entry.charms));
+      assert!(Charm::charms(entry.charms)
+        .iter()
+        .find(|charm| **charm == Charm::Cursed)
+        .is_some());
 
       let sat = entry.sat;
 
@@ -5677,7 +5680,7 @@ mod tests {
         ..Default::default()
       });
 
-      let blocks = context.mine_blocks(1);
+      context.mine_blocks(1);
 
       let inscription_id = InscriptionId { txid, index: 0 };
 
@@ -5687,9 +5690,12 @@ mod tests {
         .unwrap()
         .unwrap();
 
-      dbg!(Charm::charms(entry.charms));
-
       assert_eq!(entry.inscription_number, 0);
+
+      assert!(Charm::charms(entry.charms)
+        .iter()
+        .find(|charm| **charm == Charm::Cursed)
+        .is_none());
 
       assert_eq!(sat, entry.sat);
     }
@@ -5726,7 +5732,15 @@ mod tests {
         .unwrap()
         .unwrap();
 
-      dbg!(Charm::charms(entry.charms));
+      assert!(Charm::charms(entry.charms)
+        .iter()
+        .find(|charm| **charm == Charm::Cursed)
+        .is_some());
+
+      assert!(Charm::charms(entry.charms)
+        .iter()
+        .find(|charm| **charm == Charm::Vindicated)
+        .is_none());
 
       let sat = entry.sat;
 
@@ -5742,7 +5756,7 @@ mod tests {
         ..Default::default()
       });
 
-      let blocks = context.mine_blocks(1);
+      context.mine_blocks(1);
 
       let inscription_id = InscriptionId { txid, index: 0 };
 
@@ -5752,9 +5766,15 @@ mod tests {
         .unwrap()
         .unwrap();
 
-      dbg!(Charm::charms(entry.charms));
+      assert!(Charm::charms(entry.charms)
+        .iter()
+        .find(|charm| **charm == Charm::Cursed)
+        .is_none());
 
-      assert!(!Charm::Vindicated.is_set(dbg!(entry.charms)));
+      assert!(Charm::charms(entry.charms)
+        .iter()
+        .find(|charm| **charm == Charm::Vindicated)
+        .is_none());
 
       assert_eq!(entry.inscription_number, 0);
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -5596,6 +5596,9 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
+      // Before the jubilee, an inscription on a sat using a pushnum opcode is
+      // cursed and not vindicated.
+
       let script = script::Builder::new()
         .push_opcode(opcodes::OP_FALSE)
         .push_opcode(opcodes::all::OP_IF)
@@ -5634,6 +5637,9 @@ mod tests {
 
       assert_eq!(entry.inscription_number, -1);
 
+      // Before the jubilee, reinscription on the same sat is not cursed and
+      // not vindicated.
+
       let inscription = Inscription::default();
 
       let txid = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -5662,6 +5668,9 @@ mod tests {
         .any(|charm| *charm == Charm::Vindicated));
 
       assert_eq!(sat, entry.sat);
+
+      // Before the jubilee, a third reinscription on the same sat is cursed
+      // and not vindicated.
 
       let inscription = Inscription::default();
 
@@ -5698,6 +5707,8 @@ mod tests {
   fn post_jubilee_first_reinscription_after_vindicated_inscription_not_vindicated() {
     for context in Context::configurations() {
       context.mine_blocks(110);
+      // After the jubilee, an inscription on a sat using a pushnum opcode is
+      // vindicated and not cursed.
 
       let script = script::Builder::new()
         .push_opcode(opcodes::OP_FALSE)
@@ -5737,6 +5748,9 @@ mod tests {
 
       assert_eq!(entry.inscription_number, 0);
 
+      // After the jubilee, a reinscription on the same is not cursed and not
+      // vindicated.
+
       let inscription = Inscription::default();
 
       let txid = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -5765,6 +5779,9 @@ mod tests {
       assert_eq!(entry.inscription_number, 1);
 
       assert_eq!(sat, entry.sat);
+
+      // After the jubilee, a third reinscription on the same is vindicated and
+      // not cursed.
 
       let inscription = Inscription::default();
 

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -175,10 +175,10 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
                 .value(),
             );
 
-            let initial_inscription_is_cursed =
+            let initial_inscription_was_cursed_or_vindicated =
               entry.inscription_number < 0 || Charm::Vindicated.is_set(entry.charms);
 
-            if initial_inscription_is_cursed {
+            if initial_inscription_was_cursed_or_vindicated {
               None
             } else {
               Some(Curse::Reinscription)

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -188,8 +188,6 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           None
         };
 
-        let vindicated = jubilant && curse.is_some();
-
         let unbound = current_input_value == 0
           || curse == Some(Curse::UnrecognizedEvenField)
           || inscription.payload.unrecognized_even_field;
@@ -211,7 +209,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
             pointer: inscription.payload.pointer(),
             reinscription: inscribed_offsets.get(&offset).is_some(),
             unbound,
-            vindicated,
+            vindicated: curse.is_some() && jubilant,
           },
         });
 

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -167,15 +167,16 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
             let initial_inscription_sequence_number =
               self.id_to_sequence_number.get(id.store())?.unwrap().value();
 
-            let initial_inscription_is_cursed = InscriptionEntry::load(
+            let entry = InscriptionEntry::load(
               self
                 .sequence_number_to_entry
                 .get(initial_inscription_sequence_number)?
                 .unwrap()
                 .value(),
-            )
-            .inscription_number
-              < 0;
+            );
+
+            let initial_inscription_is_cursed =
+              entry.inscription_number < 0 || Charm::Vindicated.is_set(entry.charms);
 
             if initial_inscription_is_cursed {
               None

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -30,6 +30,7 @@ enum Origin {
     pointer: Option<u64>,
     reinscription: bool,
     unbound: bool,
+    vindicated: bool,
   },
   Old {
     old_satpoint: SatPoint,
@@ -76,6 +77,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     let mut floating_inscriptions = Vec::new();
     let mut id_counter = 0;
     let mut inscribed_offsets = BTreeMap::new();
+    let jubilant = self.height >= self.chain.jubilee_height();
     let mut total_input_value = 0;
     let total_output_value = tx.output.iter().map(|txout| txout.value).sum::<u64>();
 
@@ -142,9 +144,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           index: id_counter,
         };
 
-        let curse = if self.height >= self.chain.jubilee_height() {
-          None
-        } else if inscription.payload.unrecognized_even_field {
+        let curse = if inscription.payload.unrecognized_even_field {
           Some(Curse::UnrecognizedEvenField)
         } else if inscription.payload.duplicate_field {
           Some(Curse::DuplicateField)
@@ -187,6 +187,8 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           None
         };
 
+        let vindicated = jubilant && curse.is_some();
+
         let unbound = current_input_value == 0
           || curse == Some(Curse::UnrecognizedEvenField)
           || inscription.payload.unrecognized_even_field;
@@ -201,13 +203,14 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           inscription_id,
           offset,
           origin: Origin::New {
-            reinscription: inscribed_offsets.get(&offset).is_some(),
-            cursed: curse.is_some(),
+            cursed: curse.is_some() && !jubilant,
             fee: 0,
             hidden: inscription.payload.hidden(),
             parent: inscription.payload.parent(),
             pointer: inscription.payload.pointer(),
+            reinscription: inscribed_offsets.get(&offset).is_some(),
             unbound,
+            vindicated,
           },
         });
 
@@ -404,6 +407,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
         pointer: _,
         reinscription,
         unbound,
+        vindicated,
       } => {
         let inscription_number = if cursed {
           let number: i32 = self.cursed_inscription_count.try_into().unwrap();
@@ -465,6 +469,10 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
 
         if unbound {
           Charm::Unbound.set(&mut charms);
+        }
+
+        if vindicated {
+          Charm::Vindicated.set(&mut charms);
         }
 
         if let Some(Sat(n)) = sat {

--- a/src/inscriptions/charm.rs
+++ b/src/inscriptions/charm.rs
@@ -1,19 +1,20 @@
 #[derive(Copy, Clone)]
 pub(crate) enum Charm {
-  Coin,
-  Cursed,
-  Epic,
-  Legendary,
-  Lost,
-  Nineball,
-  Rare,
-  Reinscription,
-  Unbound,
-  Uncommon,
+  Coin = 0,
+  Cursed = 1,
+  Epic = 2,
+  Legendary = 3,
+  Lost = 4,
+  Nineball = 5,
+  Rare = 6,
+  Reinscription = 7,
+  Unbound = 8,
+  Uncommon = 9,
+  Vindicated = 10,
 }
 
 impl Charm {
-  pub(crate) const ALL: [Charm; 10] = [
+  pub(crate) const ALL: [Charm; 11] = [
     Self::Coin,
     Self::Uncommon,
     Self::Rare,
@@ -24,6 +25,7 @@ impl Charm {
     Self::Cursed,
     Self::Unbound,
     Self::Lost,
+    Self::Vindicated,
   ];
 
   fn flag(self) -> u16 {
@@ -50,6 +52,7 @@ impl Charm {
       Self::Reinscription => "♻️",
       Self::Unbound => "🔓",
       Self::Uncommon => "🌱",
+      Self::Vindicated => "❤️‍🔥",
     }
   }
 
@@ -65,6 +68,7 @@ impl Charm {
       Self::Reinscription => "reinscription",
       Self::Unbound => "unbound",
       Self::Uncommon => "uncommon",
+      Self::Vindicated => "vindicated",
     }
   }
 }

--- a/src/inscriptions/charm.rs
+++ b/src/inscriptions/charm.rs
@@ -71,4 +71,13 @@ impl Charm {
       Self::Vindicated => "vindicated",
     }
   }
+
+  #[cfg(test)]
+  pub(crate) fn charms(charms: u16) -> Vec<&'static str> {
+    Self::ALL
+      .iter()
+      .filter(|charm| charm.is_set(charms))
+      .map(|charm| charm.title())
+      .collect()
+  }
 }

--- a/src/inscriptions/charm.rs
+++ b/src/inscriptions/charm.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum Charm {
   Coin = 0,
   Cursed = 1,
@@ -73,11 +73,11 @@ impl Charm {
   }
 
   #[cfg(test)]
-  pub(crate) fn charms(charms: u16) -> Vec<&'static str> {
+  pub(crate) fn charms(charms: u16) -> Vec<Charm> {
     Self::ALL
       .iter()
       .filter(|charm| charm.is_set(charms))
-      .map(|charm| charm.title())
+      .cloned()
       .collect()
   }
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1219,6 +1219,11 @@ impl Server {
     Ok(if accept_json {
       Json(InscriptionJson {
         inscription_id: info.entry.id,
+        charms: Charm::ALL
+          .iter()
+          .filter(|charm| charm.is_set(info.charms))
+          .map(|charm| charm.title().into())
+          .collect(),
         children: info.children,
         inscription_number: info.entry.inscription_number,
         genesis_height: info.entry.height,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -4326,7 +4326,7 @@ next
   }
 
   #[test]
-  fn charm_cursed() {
+  fn charm_cursed_present_before_jubilee() {
     let server = TestServer::new_with_regtest();
 
     server.mine_blocks(2);
@@ -4355,6 +4355,45 @@ next
   <dt>charms</dt>
   <dd>
     <span title=cursed>👹</span>
+  </dd>
+  .*
+</dl>
+.*
+"
+      ),
+    );
+  }
+
+  #[test]
+  fn charm_vindicated() {
+    let server = TestServer::new_with_regtest();
+
+    server.mine_blocks(110);
+
+    let txid = server.bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[
+        (1, 0, 0, Witness::default()),
+        (2, 0, 0, inscription("text/plain", "cursed").to_witness()),
+      ],
+      outputs: 2,
+      ..Default::default()
+    });
+
+    let id = InscriptionId { txid, index: 0 };
+
+    server.mine_blocks(1);
+
+    server.assert_response_regex(
+      format!("/inscription/{id}"),
+      StatusCode::OK,
+      format!(
+        ".*<h1>Inscription 0</h1>.*
+<dl>
+  <dt>id</dt>
+  <dd class=monospace>{id}</dd>
+  <dt>charms</dt>
+  <dd>
+    <span title=vindicated>❤️‍🔥</span>
   </dd>
   .*
 </dl>

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -4346,7 +4346,7 @@ next
   }
 
   #[test]
-  fn charm_cursed_present_before_jubilee() {
+  fn charm_cursed() {
     let server = TestServer::new_with_regtest();
 
     server.mine_blocks(2);

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -23,6 +23,7 @@ pub(crate) struct InscriptionHtml {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct InscriptionJson {
   pub address: Option<String>,
+  pub charms: Vec<String>,
   pub children: Vec<InscriptionId>,
   pub content_length: Option<usize>,
   pub content_type: Option<String>,

--- a/tests/json_api.rs
+++ b/tests/json_api.rs
@@ -147,22 +147,23 @@ fn get_inscription() {
   pretty_assert_eq!(
     inscription_json,
     InscriptionJson {
-      parent: None,
+      address: None,
+      charms: vec!["coin".into(), "uncommon".into()],
       children: Vec::new(),
+      content_length: Some(3),
+      content_type: Some("text/plain;charset=utf-8".to_string()),
+      genesis_fee: 138,
+      genesis_height: 2,
       inscription_id,
       inscription_number: 0,
-      genesis_height: 2,
-      genesis_fee: 138,
+      next: None,
       output_value: Some(10000),
-      address: None,
+      parent: None,
+      previous: None,
+      rune: None,
       sat: Some(ord::Sat(50 * COIN_VALUE)),
       satpoint: SatPoint::from_str(&format!("{}:{}:{}", reveal, 0, 0)).unwrap(),
-      content_type: Some("text/plain;charset=utf-8".to_string()),
-      content_length: Some(3),
       timestamp: 2,
-      previous: None,
-      next: None,
-      rune: None,
     }
   )
 }


### PR DESCRIPTION
This PR adds a ❤️‍🔥 charm, named "vindicated". The intent is to demonstrate that, with only a small change to ord, we can support BRC-20 indexers that wish to update to a new version of `ord` at a later date, by letting them skip inscriptions with the vindicated charm until then.

This needs tests before being merged. We should also consider whether or not we want to make this charm visible to end users. Users may prefer not to have an additional charm on their inscriptions.