### PR TITLE
Cache less aggressively

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1140,7 +1140,7 @@ impl Server {
 
     headers.insert(
       header::CACHE_CONTROL,
-      HeaderValue::from_static("public, max-age=31536000, immutable"),
+      HeaderValue::from_static("public, max-age=1209600, immutable"),
     );
 
     headers.insert(
@@ -3921,7 +3921,7 @@ mod tests {
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
       response.headers().get(header::CACHE_CONTROL).unwrap(),
-      "public, max-age=31536000, immutable"
+      "public, max-age=1209600, immutable"
     );
   }
 


### PR DESCRIPTION
This sets the max-age for cached responses to two weeks, instead of a year. It's probably better if these expire sooner, and we have to serve marginally more data, if weird responses eventually expire.