### PR TITLE
add prompt for seed when restoring wallet

### DIFF
--- a/src/subcommand/wallet/restore.rs
+++ b/src/subcommand/wallet/restore.rs
@@ -31,7 +31,7 @@ impl Restore {
         wallet.initialize_from_descriptors(wallet_descriptors.descriptors)?;
       }
       Source::Mnemonic => {
-        let mnemonic = Mnemonic::parse_normalized(&buffer)?;
+        let mnemonic = Mnemonic::from_str(&buffer)?;
         wallet.initialize(mnemonic.to_seed(self.passphrase.unwrap_or_default()))?;
       }
     }

--- a/src/subcommand/wallet/restore.rs
+++ b/src/subcommand/wallet/restore.rs
@@ -1,20 +1,17 @@
 use super::*;
 
 #[derive(Debug, Parser)]
-#[clap(group(
-  ArgGroup::new("source").required(true).args(&["descriptor", "mnemonic"]))
-)]
 pub(crate) struct Restore {
-  #[arg(long, help = "Restore wallet from <DESCRIPTOR> from stdin.")]
-  descriptor: bool,
-  #[arg(long, help = "Restore wallet from <MNEMONIC> from stdin.")]
-  mnemonic: bool,
-  #[arg(
-    long,
-    requires = "mnemonic",
-    help = "Use <PASSPHRASE> when deriving wallet"
-  )]
+  #[clap(value_enum, long, help = "Restore wallet from <SOURCE> on stdin.")]
+  from: Source,
+  #[arg(long, help = "Use <PASSPHRASE> when deriving wallet")]
   pub(crate) passphrase: Option<String>,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone)]
+enum Source {
+  Descriptor,
+  Mnemonic,
 }
 
 impl Restore {
@@ -24,31 +21,21 @@ impl Restore {
     let mut buffer = String::new();
     io::stdin().read_to_string(&mut buffer)?;
 
-    if self.descriptor {
-      let wallet_descriptors: ListDescriptorsResult = serde_json::from_str(&buffer)?;
-      wallet.initialize_from_descriptors(wallet_descriptors.descriptors)?;
-    } else if self.mnemonic {
-      let mnemonic = Mnemonic::parse_normalized(&buffer)?;
-      wallet.initialize(mnemonic.to_seed(self.passphrase.unwrap_or_default()))?
-    } else {
-      unreachable!()
+    match self.from {
+      Source::Descriptor => {
+        ensure!(
+          self.passphrase.is_none(),
+          "descriptor does not take a passphrase"
+        );
+        let wallet_descriptors: ListDescriptorsResult = serde_json::from_str(&buffer)?;
+        wallet.initialize_from_descriptors(wallet_descriptors.descriptors)?;
+      }
+      Source::Mnemonic => {
+        let mnemonic = Mnemonic::parse_normalized(&buffer)?;
+        wallet.initialize(mnemonic.to_seed(self.passphrase.unwrap_or_default()))?;
+      }
     }
 
     Ok(None)
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn descriptor_and_mnemonic_conflict() {
-    assert_regex_match!(
-      Arguments::try_parse_from(["ord", "wallet", "restore", "--descriptor", "--mnemonic",])
-        .unwrap_err()
-        .to_string(),
-      ".*--descriptor.*cannot be used with.*--mnemonic.*"
-    );
   }
 }

--- a/src/subcommand/wallet/restore.rs
+++ b/src/subcommand/wallet/restore.rs
@@ -1,7 +1,4 @@
-use {
-  super::*,
-  std::{borrow::Cow, io, io::Write},
-};
+use super::*;
 
 #[derive(Debug, Parser)]
 #[clap(group(
@@ -10,8 +7,8 @@ use {
 pub(crate) struct Restore {
   #[arg(long, help = "Restore wallet from <DESCRIPTOR> from stdin.")]
   descriptor: bool,
-  #[arg(long, help = "Restore wallet from <MNEMONIC>.")]
-  mnemonic: Option<Option<Mnemonic>>,
+  #[arg(long, help = "Restore wallet from <MNEMONIC> from stdin.")]
+  mnemonic: bool,
   #[arg(
     long,
     requires = "mnemonic",
@@ -24,21 +21,14 @@ impl Restore {
   pub(crate) fn run(self, wallet: Wallet) -> SubcommandResult {
     ensure!(!wallet.exists()?, "wallet `{}` already exists", wallet.name);
 
+    let mut buffer = String::new();
+    io::stdin().read_to_string(&mut buffer)?;
+
     if self.descriptor {
-      let mut buffer = Vec::new();
-      io::stdin().read_to_end(&mut buffer)?;
-
-      let wallet_descriptors: ListDescriptorsResult = serde_json::from_slice(&buffer)?;
-
+      let wallet_descriptors: ListDescriptorsResult = serde_json::from_str(&buffer)?;
       wallet.initialize_from_descriptors(wallet_descriptors.descriptors)?;
-    } else if let Some(Some(mnemonic)) = self.mnemonic {
-      wallet.initialize(mnemonic.to_seed(self.passphrase.unwrap_or_default()))?;
-    } else if let Some(None) = self.mnemonic {
-      let mut buffer = String::new();
-      io::stdout().write_all(b"Please input your seed phrase:")?;
-      io::stdin().read_to_string(&mut buffer)?;
-      let buffer = Cow::<str>::Owned(buffer);
-      let mnemonic: Mnemonic = Mnemonic::parse(buffer)?;
+    } else if self.mnemonic {
+      let mnemonic = Mnemonic::parse_normalized(&buffer)?;
       wallet.initialize(mnemonic.to_seed(self.passphrase.unwrap_or_default()))?
     } else {
       unreachable!()
@@ -55,16 +45,9 @@ mod tests {
   #[test]
   fn descriptor_and_mnemonic_conflict() {
     assert_regex_match!(
-      Arguments::try_parse_from([
-        "ord",
-        "wallet",
-        "restore",
-        "--descriptor",
-        "--mnemonic",
-        "oil oil oil oil oil oil oil oil oil oil oil oil"
-      ])
-      .unwrap_err()
-      .to_string(),
+      Arguments::try_parse_from(["ord", "wallet", "restore", "--descriptor", "--mnemonic",])
+        .unwrap_err()
+        .to_string(),
       ".*--descriptor.*cannot be used with.*--mnemonic.*"
     );
   }

--- a/src/subcommand/wallet/restore.rs
+++ b/src/subcommand/wallet/restore.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::io;
 
 #[derive(Debug, Parser)]
 #[clap(group(
@@ -34,6 +35,17 @@ impl Restore {
       unreachable!();
     }
 
+    let seed = {
+      if self.mnemonic.is_none() {
+        let mut input = String::new();
+        println!("Please input your seed below:");
+        io::stdin().read_line(&mut input).expect("failed to read mnemonic");
+        let input = input.into_bytes();
+        assert_eq!(input.len(), 64);
+        input.try_into().unwrap()
+      } else {self.mnemonic.unwrap().to_seed(self.passphrase)}
+    };
+    wallet::initialize(seed)?;
     Ok(None)
   }
 }

--- a/tests/wallet/dump.rs
+++ b/tests/wallet/dump.rs
@@ -33,7 +33,7 @@ fn dumped_descriptors_restore() {
 
   let bitcoin_rpc_server = test_bitcoincore_rpc::spawn();
 
-  CommandBuilder::new("wallet restore --descriptor")
+  CommandBuilder::new("wallet restore --from descriptor")
     .stdin(serde_json::to_string(&output).unwrap().as_bytes().to_vec())
     .bitcoin_rpc_server(&bitcoin_rpc_server)
     .run_and_extract_stdout();
@@ -59,7 +59,7 @@ fn dump_and_restore_descriptors_with_minify() {
 
   let bitcoin_rpc_server = test_bitcoincore_rpc::spawn();
 
-  CommandBuilder::new("wallet restore --descriptor")
+  CommandBuilder::new("wallet restore --from descriptor")
     .stdin(serde_json::to_string(&output).unwrap().as_bytes().to_vec())
     .bitcoin_rpc_server(&bitcoin_rpc_server)
     .run_and_extract_stdout();

--- a/tests/wallet/restore.rs
+++ b/tests/wallet/restore.rs
@@ -14,7 +14,8 @@ fn restore_generates_same_descriptors() {
 
   let rpc_server = test_bitcoincore_rpc::spawn();
 
-  CommandBuilder::new(["wallet", "restore", "--mnemonic", &mnemonic.to_string()])
+  CommandBuilder::new(["wallet", "restore", "--mnemonic"])
+    .stdin(mnemonic.to_string().into())
     .bitcoin_rpc_server(&rpc_server)
     .run_and_extract_stdout();
 
@@ -43,8 +44,8 @@ fn restore_generates_same_descriptors_with_passphrase() {
     "--passphrase",
     passphrase,
     "--mnemonic",
-    &mnemonic.to_string(),
   ])
+  .stdin(mnemonic.to_string().into())
   .bitcoin_rpc_server(&rpc_server)
   .run_and_extract_stdout();
 
@@ -163,8 +164,7 @@ fn restore_with_blank_mnemonic_generates_same_descriptors() {
   let rpc_server = test_bitcoincore_rpc::spawn();
 
   CommandBuilder::new(["wallet", "restore", "--mnemonic"])
-    .stdout_regex("Please input your seed phrase:")
-    .stdin(mnemonic.to_string().into_bytes())
+    .stdin(mnemonic.to_string().into())
     .bitcoin_rpc_server(&rpc_server)
     .run_and_extract_stdout();
 

--- a/tests/wallet/restore.rs
+++ b/tests/wallet/restore.rs
@@ -14,7 +14,7 @@ fn restore_generates_same_descriptors() {
 
   let rpc_server = test_bitcoincore_rpc::spawn();
 
-  CommandBuilder::new(["wallet", "restore", "--mnemonic"])
+  CommandBuilder::new(["wallet", "restore", "--from", "mnemonic"])
     .stdin(mnemonic.to_string().into())
     .bitcoin_rpc_server(&rpc_server)
     .run_and_extract_stdout();
@@ -43,7 +43,8 @@ fn restore_generates_same_descriptors_with_passphrase() {
     "restore",
     "--passphrase",
     passphrase,
-    "--mnemonic",
+    "--from",
+    "mnemonic",
   ])
   .stdin(mnemonic.to_string().into())
   .bitcoin_rpc_server(&rpc_server)
@@ -66,7 +67,7 @@ fn restore_to_existing_wallet_fails() {
     .stderr_regex(".*")
     .run_and_deserialize_output::<ListDescriptorsResult>();
 
-  CommandBuilder::new("wallet restore --descriptor")
+  CommandBuilder::new("wallet restore --from descriptor")
     .stdin(serde_json::to_string(&output).unwrap().as_bytes().to_vec())
     .bitcoin_rpc_server(&bitcoin_rpc_server)
     .expected_exit_code(1)
@@ -87,7 +88,7 @@ fn restore_to_existing_wallet_fails() {
 fn restore_with_wrong_descriptors_fails() {
   let bitcoin_rpc_server = test_bitcoincore_rpc::spawn();
 
-  CommandBuilder::new("wallet --name foo restore --descriptor")
+  CommandBuilder::new("wallet --name foo restore --from descriptor")
       .stdin(r#"
 {
   "wallet_name": "bar",
@@ -142,7 +143,7 @@ fn restore_with_wrong_descriptors_fails() {
 fn restore_with_compact_works() {
   let bitcoin_rpc_server = test_bitcoincore_rpc::spawn();
 
-  CommandBuilder::new("wallet restore --descriptor")
+  CommandBuilder::new("wallet restore --from descriptor")
     .stdin(r#"{"wallet_name":"foo","descriptors":[{"desc":"rawtr(cVMYXp8uf1yFU9AAY6NJu1twA2uT94mHQBGkfgqCCzp6RqiTWCvP)#tah5crv7","timestamp":1706047934,"active":false,"internal":null,"range":null,"next":null},{"desc":"rawtr(cVdVu6VRwYXsTPMiptqVYLcp7EtQi5sjxLzbPTSNwW6CkCxBbEFs)#5afaht8d","timestamp":1706047934,"active":false,"internal":null,"range":null,"next":null},{"desc":"tr([c0b9536d/86'/1'/0']tprv8fXhtVjj3vb7kgxKuiWXzcUsur44gbLbbtwxL4HKmpzkBNoMrYqbQhMe7MWhrZjLFc9RBpTRYZZkrS8HH1Q3SmD5DkfpjKqtd97q1JWfqzr/0/*)#dweuu0ww","timestamp":1706047839,"active":true,"internal":false,"range":[0,1000],"next":1},{"desc":"tr([c0b9536d/86'/1'/0']tprv8fXhtVjj3vb7kgxKuiWXzcUsur44gbLbbtwxL4HKmpzkBNoMrYqbQhMe7MWhrZjLFc9RBpTRYZZkrS8HH1Q3SmD5DkfpjKqtd97q1JWfqzr/1/*)#u6uap67k","timestamp":1706047839,"active":true,"internal":true,"range":[0,1013],"next":14}]}"#.into())
     .bitcoin_rpc_server(&bitcoin_rpc_server)
     .expected_exit_code(0)
@@ -163,7 +164,7 @@ fn restore_with_blank_mnemonic_generates_same_descriptors() {
 
   let rpc_server = test_bitcoincore_rpc::spawn();
 
-  CommandBuilder::new(["wallet", "restore", "--mnemonic"])
+  CommandBuilder::new(["wallet", "restore", "--from", "mnemonic"])
     .stdin(mnemonic.to_string().into())
     .bitcoin_rpc_server(&rpc_server)
     .run_and_extract_stdout();

--- a/tests/wallet/restore.rs
+++ b/tests/wallet/restore.rs
@@ -171,3 +171,24 @@ fn restore_with_blank_mnemonic_generates_same_descriptors() {
 
   assert_eq!(rpc_server.descriptors(), descriptors);
 }
+
+#[test]
+fn passphrase_conflicts_with_descriptor() {
+  let bitcoin_rpc_server = test_bitcoincore_rpc::spawn();
+  let ord_rpc_server = TestServer::spawn(&bitcoin_rpc_server);
+
+  CommandBuilder::new([
+    "wallet",
+    "restore",
+    "--from",
+    "descriptor",
+    "--passphrase",
+    "supersecurepassword",
+  ])
+  .stdin("".into())
+  .bitcoin_rpc_server(&bitcoin_rpc_server)
+  .ord_rpc_server(&ord_rpc_server)
+  .expected_exit_code(1)
+  .expected_stderr("error: descriptor does not take a passphrase\n")
+  .run_and_extract_stdout();
+}

--- a/tests/wallet/restore.rs
+++ b/tests/wallet/restore.rs
@@ -163,7 +163,8 @@ fn restore_with_blank_mnemonic_generates_same_descriptors() {
   let rpc_server = test_bitcoincore_rpc::spawn();
 
   CommandBuilder::new(["wallet", "restore", "--mnemonic"])
-    .stdin(mnemonic.to_string().as_bytes().to_vec())
+    .stdout_regex("Please input your seed phrase:")
+    .stdin(mnemonic.to_string().into_bytes())
     .bitcoin_rpc_server(&rpc_server)
     .run_and_extract_stdout();
 

--- a/tests/wallet/restore.rs
+++ b/tests/wallet/restore.rs
@@ -147,3 +147,25 @@ fn restore_with_compact_works() {
     .expected_exit_code(0)
     .run_and_extract_stdout();
 }
+
+#[test]
+fn restore_with_blank_mnemonic_generates_same_descriptors() {
+  let (mnemonic, descriptors) = {
+    let rpc_server = test_bitcoincore_rpc::spawn();
+
+    let create::Output { mnemonic, .. } = CommandBuilder::new("wallet create")
+      .bitcoin_rpc_server(&rpc_server)
+      .run_and_deserialize_output();
+
+    (mnemonic, rpc_server.descriptors())
+  };
+
+  let rpc_server = test_bitcoincore_rpc::spawn();
+
+  CommandBuilder::new(["wallet", "restore", "--mnemonic"])
+    .stdin(mnemonic.to_string().as_bytes().to_vec())
+    .bitcoin_rpc_server(&rpc_server)
+    .run_and_extract_stdout();
+
+  assert_eq!(rpc_server.descriptors(), descriptors);
+}


### PR DESCRIPTION
Fixes issue #2990 by allowing a seed to be entered to stdin when restoring a wallet.  I'm not sure if I got the type coercion/checking exactly right here, so would appreciate any feedback/help.  Thanks!