### PR TITLE
Add api router to support OpenAPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,6 +1648,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -2206,6 +2207,7 @@ dependencies = [
  "tokio-util 0.7.10",
  "tower-http",
  "unindent",
+ "utoipa",
 ]
 
 [[package]]
@@ -2408,6 +2410,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
  "toml",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -3566,6 +3592,30 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "utoipa"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "272ebdfbc99111033031d2f10e018836056e4d2c8e2acda76450ec7974269fa7"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3c9f4d08338c1bfa70dde39412a040a884c6f318b3d09aaaf3437a1e52027fc"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ tokio = { version = "1.17.0", features = ["rt-multi-thread"] }
 tokio-stream = "0.1.9"
 tokio-util = {version = "0.7.3", features = ["compat"] }
 tower-http = { version = "0.4.0", features = ["compression-br", "compression-gzip", "cors", "set-header"] }
+utoipa = "4.1.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/subcommand/server/api.rs
+++ b/src/subcommand/server/api.rs
@@ -1,0 +1,20 @@
+use {
+  super::{api_response::ApiResult, *},
+  crate::templates::StatusHtml,
+  axum::Json,
+};
+
+/// Get the indexer status.
+#[utoipa::path(
+  get,
+  path = "/api/v1/status",
+  responses(
+    (status = 200, description = "Get the indexer status.", body = Status),
+    (status = 500, description = "Internal server error.", body = ApiError, example = json!(&ApiError::internal("internal error"))),
+  )
+)]
+pub(crate) async fn status(Extension(index): Extension<Arc<Index>>) -> ApiResult<StatusHtml> {
+  log::debug!("rpc: get status");
+
+  Ok(Json(ApiResponse::ok(index.status()?)))
+}

--- a/src/subcommand/server/api_response.rs
+++ b/src/subcommand/server/api_response.rs
@@ -1,0 +1,56 @@
+use {
+  super::*,
+  utoipa::{IntoParams, ToSchema},
+};
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[aliases()]
+pub(crate) struct ApiResponse<T: Serialize> {
+  pub code: i32,
+  #[schema(example = "ok")]
+  pub msg: String,
+  pub data: T,
+}
+
+impl<T> ApiResponse<T>
+where
+  T: Serialize,
+{
+  fn new(code: i32, msg: String, data: T) -> Self {
+    Self { code, msg, data }
+  }
+
+  pub fn ok(data: T) -> Self {
+    Self::new(0, "ok".to_string(), data)
+  }
+}
+
+#[derive(Deserialize, IntoParams)]
+pub struct Pagination {
+  /// Start index of the result.
+  pub start: Option<usize>,
+  /// Limit of the result.
+  pub limit: Option<usize>,
+}
+
+pub(crate) type ApiResult<T> = Result<axum::Json<ApiResponse<T>>, ApiError>;
+
+pub(super) trait ApiOptionExt<T> {
+  fn ok_or_api_err<F: FnOnce() -> ApiError>(self, f: F) -> Result<T, ApiError>;
+  fn ok_or_api_not_found<S: ToString>(self, s: S) -> Result<T, ApiError>;
+}
+
+impl<T> ApiOptionExt<T> for Option<T> {
+  fn ok_or_api_err<F: FnOnce() -> ApiError>(self, f: F) -> Result<T, ApiError> {
+    match self {
+      Some(value) => Ok(value),
+      None => Err(f()),
+    }
+  }
+  fn ok_or_api_not_found<S: ToString>(self, s: S) -> Result<T, ApiError> {
+    match self {
+      Some(value) => Ok(value),
+      None => Err(ApiError::not_found(s)),
+    }
+  }
+}

--- a/src/subcommand/server/api_response.rs
+++ b/src/subcommand/server/api_response.rs
@@ -1,10 +1,13 @@
 use {
   super::*,
+  crate::templates::StatusHtml,
   utoipa::{IntoParams, ToSchema},
 };
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[aliases()]
+#[aliases(
+  Status = ApiResponse<StatusHtml>
+)]
 pub(crate) struct ApiResponse<T: Serialize> {
   pub code: i32,
   #[schema(example = "ok")]

--- a/src/templates/status.rs
+++ b/src/templates/status.rs
@@ -1,6 +1,7 @@
 use super::*;
+use utoipa::ToSchema;
 
-#[derive(Boilerplate, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Boilerplate, Debug, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct StatusHtml {
   pub blessed_inscriptions: u64,
   pub cursed_inscriptions: u64,


### PR DESCRIPTION
## Summary

Introduce the crate [utoipa](https://crates.io/crates/utoipa) to auto-generate OpenAPI docs for the API.

## Example

The `status` function in the `src/subcommand/server/api.rs`.

## Test

* Run `ord` and connect with the bitcoin `testnet`: `ord -t server -j`
* Check the OpenAPI docs via the URL: http://localhost/api/v1/api-docs/openapi.json
* Access the REST API: http://localhost:8080/api/v1/status

Output
```json
{"code":0,"msg":"ok","data":{"blessed_inscriptions":0,"cursed_inscriptions":0,"chain":"testnet","height":2573099,"inscriptions":0,"lost_sats":0,"minimum_rune_for_next_block":"ZCUKDPQNT","rune_index":true,"runes":1858,"sat_index":false,"started":"2024-01-16T13:12:44.150040217Z","transaction_index":false,"unrecoverably_reorged":false,"uptime":{"secs":30,"nanos":888723119}}}
```