### PR TITLE
Fee spent inscription numbering

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -736,6 +736,15 @@ impl Index {
       .unwrap_or_default()
   }
 
+  #[cfg(test)]
+  pub(crate) fn inscription_number(&self, inscription_id: InscriptionId) -> i32 {
+    self
+      .get_inscription_entry(inscription_id)
+      .unwrap()
+      .unwrap()
+      .inscription_number
+  }
+
   pub(crate) fn block_count(&self) -> Result<u32> {
     self.begin_read()?.block_count()
   }
@@ -3397,15 +3406,7 @@ mod tests {
         None,
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(inscription_id), -1);
     }
   }
 
@@ -3442,15 +3443,7 @@ mod tests {
         None,
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        0
-      );
+      assert_eq!(context.index.inscription_number(inscription_id), 0);
     }
   }
 
@@ -3478,15 +3471,7 @@ mod tests {
 
       assert_eq!(context.rpc_server.height(), 109);
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(inscription_id), -1);
 
       let txid = context.rpc_server.broadcast_tx(TransactionTemplate {
         inputs: &[(2, 0, 0, witness)],
@@ -3499,15 +3484,7 @@ mod tests {
 
       assert_eq!(context.rpc_server.height(), 110);
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        0
-      );
+      assert_eq!(context.index.inscription_number(inscription_id), 0);
     }
   }
 
@@ -3533,15 +3510,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(inscription_id), -1);
     }
   }
 
@@ -3561,15 +3530,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(inscription_id), -1);
     }
   }
 
@@ -3598,15 +3559,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(inscription_id), -1);
     }
   }
 
@@ -3636,15 +3589,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(inscription_id), -1);
     }
   }
 
@@ -3680,15 +3625,7 @@ mod tests {
         None,
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        0
-      );
+      assert_eq!(context.index.inscription_number(inscription_id), 0);
     }
   }
 
@@ -3726,15 +3663,7 @@ mod tests {
         None,
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(second_inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(second_inscription_id), -1);
     }
   }
 
@@ -3789,35 +3718,9 @@ mod tests {
         Some(150 * COIN_VALUE),
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(first)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        0
-      );
-
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(second)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
-
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(third)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -2
-      );
+      assert_eq!(context.index.inscription_number(first), 0);
+      assert_eq!(context.index.inscription_number(second), -1);
+      assert_eq!(context.index.inscription_number(third), -2);
     }
   }
 
@@ -3903,25 +3806,9 @@ mod tests {
         0
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(second)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
-
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(third)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -2
-      );
+      assert_eq!(context.index.inscription_number(first), 0);
+      assert_eq!(context.index.inscription_number(second), -1);
+      assert_eq!(context.index.inscription_number(third), -2);
     }
   }
 
@@ -4013,15 +3900,7 @@ mod tests {
         Some(150 * COIN_VALUE),
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(first)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        0
-      );
+      assert_eq!(context.index.inscription_number(first), 0);
 
       assert_eq!(
         context
@@ -4032,25 +3911,9 @@ mod tests {
         fourth
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(fourth)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -3
-      );
+      assert_eq!(context.index.inscription_number(fourth), -3);
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(ninth)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -8
-      );
+      assert_eq!(context.index.inscription_number(ninth), -8);
     }
   }
 
@@ -4154,15 +4017,7 @@ mod tests {
         Some(100 * COIN_VALUE),
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(cursed)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(cursed), -1);
 
       let witness = envelope(&[
         b"ord",
@@ -4190,15 +4045,7 @@ mod tests {
         Some(100 * COIN_VALUE),
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(reinscription_on_cursed)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        1
-      );
+      assert_eq!(context.index.inscription_number(reinscription_on_cursed), 1);
     }
   }
 
@@ -4235,15 +4082,7 @@ mod tests {
         Some(100 * COIN_VALUE),
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(cursed)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(cursed), -1);
 
       let witness = envelope(&[
         b"ord",
@@ -4271,15 +4110,7 @@ mod tests {
         Some(100 * COIN_VALUE),
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(reinscription_on_cursed)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        1
-      );
+      assert_eq!(context.index.inscription_number(reinscription_on_cursed), 1);
 
       let witness = envelope(&[
         b"ord",
@@ -4310,10 +4141,7 @@ mod tests {
       assert_eq!(
         context
           .index
-          .get_inscription_entry(second_reinscription_on_cursed)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
+          .inscription_number(second_reinscription_on_cursed),
         -2
       );
 
@@ -5041,15 +4869,7 @@ mod tests {
         Some(50 * COIN_VALUE),
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(inscription_id), -1);
     }
   }
 
@@ -5105,15 +4925,7 @@ mod tests {
         Some(50 * COIN_VALUE),
       );
 
-      assert_eq!(
-        context
-          .index
-          .get_inscription_entry(child_inscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
-        -1
-      );
+      assert_eq!(context.index.inscription_number(child_inscription_id), -1);
 
       assert_eq!(
         context
@@ -5468,13 +5280,10 @@ mod tests {
         0
       );
 
+      assert_eq!(context.index.inscription_number(inscription_id), 0);
+
       assert_eq!(
-        context
-          .index
-          .get_inscription_entry(cursed_reinscription_id)
-          .unwrap()
-          .unwrap()
-          .inscription_number,
+        context.index.inscription_number(cursed_reinscription_id),
         -1
       );
     }
@@ -5946,5 +5755,32 @@ mod tests {
         vout: 0,
       })
       .unwrap());
+  }
+
+  #[test]
+  fn fee_spent_inscriptions_are_numbered_in_order() {
+    for context in Context::configurations() {
+      context.mine_blocks(2);
+
+      let txid = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+        fee: 50 * COIN_VALUE,
+        ..Default::default()
+      });
+
+      let a = InscriptionId { txid, index: 0 };
+
+      let txid = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(2, 0, 0, inscription("text/plain", "hello").to_witness())],
+        ..Default::default()
+      });
+
+      let b = InscriptionId { txid, index: 0 };
+
+      context.mine_blocks(1);
+
+      assert_eq!(context.index.inscription_number(a), 0);
+      assert_eq!(context.index.inscription_number(b), 1);
+    }
   }
 }


### PR DESCRIPTION
This PR fixes #2967. The issue identified in #2967 is that when an inscription is created but immediately fee-spent, it is numbered as if it was the last inscription in the block. I don't think we can merge this, because it would change the numbers of over 7 million inscriptions, so this is just just there for reference. This PR does have some good refactors and tests, so those should make it in.