### PR TITLE
Draft: Allow UTXO selection for batch inscribe

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -1405,6 +1405,17 @@ impl Index {
     self.client.get_raw_transaction(&txid, None).into_option()
   }
 
+  pub(crate) fn get_tx_out(&self, satpoint: SatPoint) -> Result<TxOut> {
+    Ok(
+      self.get_transaction(satpoint.outpoint.txid)?
+          .expect("transaction not found in index")
+          .output
+          .into_iter()
+          .nth(satpoint.outpoint.vout.try_into().unwrap())
+          .expect("current transaction output")
+    )
+  }
+
   pub(crate) fn find(&self, sat: Sat) -> Result<Option<SatPoint>> {
     let sat = sat.0;
     let rtx = self.begin_read()?;

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -131,6 +131,7 @@ impl Inscribe {
     let postage;
     let destinations;
     let inscriptions;
+    let mut reveal_satpoints = Vec::new();
     let mode;
     let parent_info;
     let sat;
@@ -178,7 +179,7 @@ impl Inscribe {
           .map(Amount::from_sat)
           .unwrap_or(TARGET_POSTAGE);
 
-        (inscriptions, destinations) = batchfile.inscriptions(
+        (inscriptions, reveal_satpoints, destinations) = batchfile.inscriptions(
           &index,
           &client,
           chain,
@@ -199,7 +200,7 @@ impl Inscribe {
       _ => unreachable!(),
     }
 
-    let satpoint = if let Some(sat) = sat {
+    let commit_satpoint: Option<SatPoint> = if let Some(sat) = sat {
       if !index.has_sat_index() {
         return Err(anyhow!(
           "index must be built with `--index-sats` to use `--sat`"
@@ -225,7 +226,8 @@ impl Inscribe {
       postage,
       reinscribe: self.reinscribe,
       reveal_fee_rate: self.fee_rate,
-      satpoint,
+      commit_satpoint,
+      reveal_satpoints
     }
     .inscribe(chain, &index, &client, &locked_utxos, runic_utxos, &utxos)
   }

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -211,7 +211,11 @@ impl Inscribe {
         None => return Err(anyhow!(format!("could not find sat `{sat}`"))),
       }
     } else {
-      self.satpoint
+      if reveal_satpoints.len() > 0 {
+        Some(reveal_satpoints[0])
+      } else {
+        self.satpoint
+      }
     };
 
     Batch {
@@ -268,13 +272,7 @@ impl Inscribe {
           destination: get_change_address(client, chain)?,
           id: parent_id,
           location: satpoint,
-          tx_out: index
-            .get_transaction(satpoint.outpoint.txid)?
-            .expect("parent transaction not found in index")
-            .output
-            .into_iter()
-            .nth(satpoint.outpoint.vout.try_into().unwrap())
-            .expect("current transaction output"),
+          tx_out: index.get_tx_out(satpoint)?,
         }))
       } else {
         Err(anyhow!(format!("parent {parent_id} does not exist")))


### PR DESCRIPTION
Seeking feedback for further revisions! This is an early stage draft, aimed to address #3022

This PR allows a batch.yaml to be specified with a satpoint per inscription:
```
# example file
mode: separate-outputs

inscriptions:
- file: test1.txt
  destination: bcrt1pgwdddrmhfpwwcfqrphymdzqn5p9rkdlrykmkv66wchad2mpay4rsv60ncu
  satpoint: 4772fe41fb6a8423613bc92ec3383eaa381c5456ec2d72c9ed3939481c9b278f:0:0

- file: test2.txt
  destination: bcrt1pgwdddrmhfpwwcfqrphymdzqn5p9rkdlrykmkv66wchad2mpay4rsv60ncu
  satpoint: 4772fe41fb6a8423613bc92ec3383eaa381c5456ec2d72c9ed3939481c9b278f:1:0
```

And running this batch file with:
`ord wallet inscribe --fee-rate 1 --batch batch.yaml`

Results in `test1.txt` and `test2.txt` inscribed using the exact sats specified. Postage is matched to those UTXOs and any additional `postage` setting in `batch.yaml` is ignored.

There is [another branch](https://github.com/kiwidream/ord/tree/batch-satpoint-psbt) in my repo which includes the changes from #2925 to aid debugging.

Outstanding issues/considerations:
- Inscription order is reversed, i.e. test2.txt becomes the first output in the reveal tx. This is somewhat by design - the commit output is placed last in the reveal tx so that it can be used for fees.
- Needing automated tests. Haven't written any at this stage and there are likely edge cases to be caught.
- Regression testing - some logic is in close proximity to parent/child inscriptions.
- Bringing `index` into `create_batch_inscription_transactions` doesn't seem right, but works for now
- Handling conflicting settings in `batch.yaml` by throwing an error (e.g. do not specify postage)

🥝 
