### PR TITLE
chore: also forbid `entry.destination` in `same-sat` mode

### DIFF
--- a/src/wallet/inscribe/batch_file.rs
+++ b/src/wallet/inscribe/batch_file.rs
@@ -35,10 +35,10 @@ impl Batchfile {
       .inscriptions
       .iter()
       .any(|entry| entry.destination.is_some())
-      && self.mode == Mode::SharedOutput
+      && (self.mode == Mode::SharedOutput || self.mode == Mode::SameSat)
     {
       return Err(anyhow!(
-        "individual inscription destinations cannot be set in shared-output mode"
+        "individual inscription destinations cannot be set in shared-output or same-sat mode"
       ));
     }
 

--- a/tests/wallet/inscribe.rs
+++ b/tests/wallet/inscribe.rs
@@ -1517,7 +1517,7 @@ fn batch_inscribe_fails_with_shared_output_and_destination_set() {
     .bitcoin_rpc_server(&bitcoin_rpc_server)
     .ord_rpc_server(&ord_rpc_server)
     .expected_exit_code(1)
-    .stderr_regex("error: individual inscription destinations cannot be set in shared-output mode\n")
+    .stderr_regex("error: individual inscription destinations cannot be set in shared-output or same-sat mode\n")
     .run_and_extract_stdout();
 }
 


### PR DESCRIPTION
Since in `same-sat` mode, the `destination` is also calculated by `get_change_address` as per [here](https://github.com/ordinals/ord/blob/4b95ff655aa051578d26d755ba1532819b1a9da5/src/subcommand/wallet/inscribe/batch.rs#L646), it's more correct to forbid `entry.destination` in `same-sat` mode.