### PR TITLE
chore: replace clamp with max

### DIFF
--- a/src/index/updater/rune_updater.rs
+++ b/src/index/updater/rune_updater.rs
@@ -134,7 +134,7 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
                 mint: etching.mint.map(|mint| MintEntry {
                   deadline: mint.deadline,
                   end: mint.term.map(|term| term + self.height),
-                  limit: mint.limit.map(|limit| limit.clamp(0, runes::MAX_LIMIT)),
+                  limit: mint.limit.map(|limit| limit.max(runes::MAX_LIMIT)),
                 }),
               }),
               Err(_) => None,


### PR DESCRIPTION
Since `u128>=0` is always satisfied.