### PR TITLE
Optimize preview text

### DIFF
--- a/static/preview-text.js
+++ b/static/preview-text.js
@@ -3,12 +3,15 @@ const inscription = document.documentElement.dataset.inscription;
 const response = await fetch(`/content/${inscription}`);
 const text = await response.text();
 for (const pre of document.querySelectorAll('pre')) {
-  pre.textContent = text;
+  try {
+    pre.textContent = JSON.stringify(JSON.parse(text), null, 2);
+  } catch (e) {
+    pre.textContent = text;
+  }
 }
 
 let pre = document.querySelector('body > pre');
-let { width, height } = pre.getBoundingClientRect();
-let columns = width / 16;
-let rows = height / 16;
-pre.style.fontSize = `min(${95/columns}vw, ${95/rows}vh)`;
+pre.style.fontSize = '12px';
 pre.style.opacity = 1;
+pre.style.lineHeight = '1.2';
+pre.style.whiteSpace = 'pre-wrap';


### PR DESCRIPTION
Currently it's difficult to tell what's the text:

![CleanShot-PhZxluE4@2x](https://github.com/ordinals/ord/assets/126733611/be225971-a53f-4fc5-a7a1-d3e3a3ac58c8)

Here's how it looks after the update:

![CleanShot-wryKGaBy@2x](https://github.com/ordinals/ord/assets/126733611/3518edd5-6537-43c8-be2b-f396c4671f15)

Let me know what you think.