### PR TITLE
Allow inscribing AVIF images

### DIFF
--- a/src/inscriptions/media.rs
+++ b/src/inscriptions/media.rs
@@ -66,7 +66,7 @@ impl Media {
     ("font/woff",                   BROTLI_MODE_GENERIC, Media::Font,                       &["woff"]),
     ("font/woff2",                  BROTLI_MODE_FONT,    Media::Font,                       &["woff2"]),
     ("image/apng",                  BROTLI_MODE_GENERIC, Media::Image,                      &["apng"]),
-    ("image/avif",                  BROTLI_MODE_GENERIC, Media::Image,                      &[]),
+    ("image/avif",                  BROTLI_MODE_GENERIC, Media::Image,                      &["avif"]),
     ("image/gif",                   BROTLI_MODE_GENERIC, Media::Image,                      &["gif"]),
     ("image/jpeg",                  BROTLI_MODE_GENERIC, Media::Image,                      &["jpg", "jpeg"]),
     ("image/png",                   BROTLI_MODE_GENERIC, Media::Image,                      &["png"]),


### PR DESCRIPTION
If you filter out browsers that don't matter, AVIF has pretty much universal support:

<img width="887" alt="Screenshot 2024-02-14 at 9 01 29 PM" src="https://github.com/ordinals/ord/assets/1945/eededaca-bb72-4ad0-a956-75b7846a8987">

I think we should finally enable making AVIF inscriptions natively, since there's a huge jump in image quality.