### PR TITLE
Use `image-rendering: auto` when downscaling images

### DIFF
--- a/static/preview-image.js
+++ b/static/preview-image.js
@@ -1,0 +1,15 @@
+function resize() {
+  if (
+    body.clientWidth * window.devicePixelRatio < img.naturalWidth
+    || body.clientHeight * window.devicePixelRatio < img.naturalHeight
+  ) {
+    body.style.imageRendering = 'auto';
+  } else {
+    body.removeAttribute('style');
+  }
+}
+
+let body = document.body;
+let img = document.getElementsByTagName('img')[0];
+
+(new ResizeObserver(resize)).observe(body);

--- a/templates/preview-image.html
+++ b/templates/preview-image.html
@@ -25,6 +25,7 @@
         width: 100%;
       }
     </style>
+    <script src=/static/preview-image.js type=module defer></script>
   </head>
   <body>
     <img src=/content/{{self.inscription_id}}></img>


### PR DESCRIPTION
I think this is an improvement for all image formats and image types. `image-rendering: pixelated` is only important when upscaling pixel art. When upscaling other kinds of images, and when downscaling everything, `image-rendering: auto` is preferred.

This makes the image preview use `auto` rendering, when the body is less than the size of the image, A.K.A., downscaling.

This still leaves things suboptimal when upscaling non pixel art, but I can't think of a non-disruptive change to fix that.