### PR TITLE
Add `ord env` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.vagrant
 /.vscode
 /docs/build
+/env
 /fuzz/artifacts
 /fuzz/corpus
 /fuzz/coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "clap",
+ "colored",
  "criterion",
  "ctrlc",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ brotli = "3.4.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 ciborium = "0.2.1"
 clap = { version = "4.4.2", features = ["derive"] }
+colored = "2.0.4"
 ctrlc = { version = "3.2.1", features = ["termination"] }
 dirs = "5.0.0"
 env_logger = "0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ use {
     mem,
     net::ToSocketAddrs,
     path::{Path, PathBuf},
-    process,
+    process::{self, Command, Stdio},
     str::FromStr,
     sync::{
       atomic::{self, AtomicBool},

--- a/src/options.rs
+++ b/src/options.rs
@@ -235,12 +235,21 @@ impl Options {
     let client = Client::new(&rpc_url, auth)
       .with_context(|| format!("failed to connect to Bitcoin Core RPC at {rpc_url}"))?;
 
-    let rpc_chain = match client.get_blockchain_info()?.chain.as_str() {
-      "main" => Chain::Mainnet,
-      "test" => Chain::Testnet,
-      "regtest" => Chain::Regtest,
-      "signet" => Chain::Signet,
-      other => bail!("Bitcoin RPC server on unknown chain: {other}"),
+    let rpc_chain = loop {
+      match client.get_blockchain_info() {
+        Ok(blockchain_info) => {
+          break match blockchain_info.chain.as_str() {
+            "main" => Chain::Mainnet,
+            "test" => Chain::Testnet,
+            "regtest" => Chain::Regtest,
+            "signet" => Chain::Signet,
+            other => bail!("Bitcoin RPC server on unknown chain: {other}"),
+          }
+        }
+        Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
+          if err.code == -28 => {}
+        Err(err) => bail!("Failed to connect to Bitcoin Core RPC at `{rpc_url}`:  {err}"),
+      }
     };
 
     let ord_chain = self.chain();

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub mod balances;
 pub mod decode;
+pub mod env;
 pub mod epochs;
 pub mod find;
 pub mod index;
@@ -21,6 +22,8 @@ pub(crate) enum Subcommand {
   Balances,
   #[command(about = "Decode a transaction")]
   Decode(decode::Decode),
+  #[command(about = "Start a regtest ord and bitcoind instance")]
+  Env(env::Env),
   #[command(about = "List the first satoshis of each reward epoch")]
   Epochs,
   #[command(about = "Find a satoshi's current location")]
@@ -52,6 +55,7 @@ impl Subcommand {
     match self {
       Self::Balances => balances::run(options),
       Self::Decode(decode) => decode.run(options),
+      Self::Env(env) => env.run(),
       Self::Epochs => epochs::run(),
       Self::Find(find) => find.run(options),
       Self::Index(index) => index.run(options),

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -1,4 +1,4 @@
-use {super::*, std::net::TcpListener};
+use {super::*, colored::Colorize, std::net::TcpListener};
 
 struct KillOnDrop(process::Child);
 
@@ -9,6 +9,7 @@ impl Drop for KillOnDrop {
       .status()
       .unwrap()
       .success());
+    self.0.wait().unwrap();
   }
 }
 
@@ -106,20 +107,23 @@ rpcport={bitcoind_port}
       ensure!(status.success(), "failed to create wallet: {status}");
     }
 
+    thread::sleep(Duration::from_millis(250));
+
+    // todo: timeout when creating bitcoin core client
+
     eprintln!(
-      "==> env started in {}
-
-example `bitcoin-cli` command:
+      "{}
 bitcoin-cli -datadir='{}' getblockchaininfo
-
-example `ord` command:
-ord --regtest --bitcoin-data-dir '{}' --data-dir '{}' wallet --server-url '{}' balance
-",
+{}
+{} --regtest --bitcoin-data-dir '{}' --data-dir '{}' --rpc-url '{}' wallet --server-url {} balance",
+      "Example `bitcoin-cli` command:".blue().bold(),
       self.directory.display(),
-      self.directory.display(),
+      "Example `ord` command:".blue().bold(),
+      ord.display(),
       self.directory.display(),
       self.directory.display(),
       rpc_url,
+      format!("http://127.0.0.1:{ord_port}"),
     );
 
     loop {

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -18,8 +18,6 @@ pub(crate) struct Env {
   directory: PathBuf,
 }
 
-// bitcoin-cli -datadir=env getblockchaininfo
-
 impl Env {
   pub(crate) fn run(self) -> SubcommandResult {
     let (bitcoind_port, ord_port) = (
@@ -35,7 +33,7 @@ impl Env {
         .port(),
     );
 
-    let env = std::env::current_dir()?.join(self.directory);
+    let env = std::env::current_dir()?.join(&self.directory);
 
     fs::create_dir_all(&env)?;
 
@@ -63,6 +61,11 @@ rpcport={bitcoind_port}
         .arg(format!("-conf={config}"))
         .stdout(Stdio::null())
         .spawn()?,
+    );
+
+    eprintln!(
+      "example `bitcoin-cli` command: bitcoin-cli -datadir='{}' getblockchaininfo",
+      self.directory.display()
     );
 
     loop {

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -109,19 +109,16 @@ rpcport={bitcoind_port}
 
     thread::sleep(Duration::from_millis(250));
 
-    // todo: timeout when creating bitcoin core client
+    let directory = self.directory.to_str().unwrap().to_string();
 
     eprintln!(
       "{}
-bitcoin-cli -datadir='{}' getblockchaininfo
+bitcoin-cli -datadir='{directory}' getblockchaininfo
 {}
-{} --regtest --bitcoin-data-dir '{}' --data-dir '{}' --rpc-url '{}' wallet --server-url {} balance",
+{} --regtest --bitcoin-data-dir '{directory}' --data-dir '{directory}' --rpc-url '{}' wallet --server-url {} balance",
       "Example `bitcoin-cli` command:".blue().bold(),
-      self.directory.display(),
       "Example `ord` command:".blue().bold(),
       ord.display(),
-      self.directory.display(),
-      self.directory.display(),
       rpc_url,
       format!("http://127.0.0.1:{ord_port}"),
     );

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -115,12 +115,11 @@ rpcport={bitcoind_port}
       "{}
 bitcoin-cli -datadir='{directory}' getblockchaininfo
 {}
-{} --regtest --bitcoin-data-dir '{directory}' --data-dir '{directory}' --rpc-url '{}' wallet --server-url {} balance",
+{} --regtest --bitcoin-data-dir '{directory}' --data-dir '{directory}' --rpc-url '{}' wallet --server-url http://127.0.0.1:{ord_port} balance",
       "Example `bitcoin-cli` command:".blue().bold(),
       "Example `ord` command:".blue().bold(),
       ord.display(),
       rpc_url,
-      format!("http://127.0.0.1:{ord_port}"),
     );
 
     loop {

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -1,0 +1,117 @@
+use {super::*, std::net::TcpListener};
+
+struct KillOnDrop(process::Child);
+
+impl Drop for KillOnDrop {
+  fn drop(&mut self) {
+    assert!(Command::new("kill")
+      .arg(self.0.id().to_string())
+      .status()
+      .unwrap()
+      .success());
+  }
+}
+
+#[derive(Debug, Parser)]
+pub(crate) struct Env {
+  #[arg(default_value = "env", help = "Create env in <DIRECTORY>.")]
+  directory: PathBuf,
+}
+
+// bitcoin-cli -datadir=env getblockchaininfo
+
+impl Env {
+  pub(crate) fn run(self) -> SubcommandResult {
+    let (bitcoind_port, ord_port) = (
+      TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port(),
+      TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port(),
+    );
+
+    let env = std::env::current_dir()?.join(self.directory);
+
+    fs::create_dir_all(&env)?;
+
+    let env_string = env
+      .to_str()
+      .with_context(|| format!("directory `{}` is not valid unicode", env.display()))?;
+
+    let config = env.join("bitcoin.conf").to_str().unwrap().to_string();
+
+    fs::write(
+      env.join("bitcoin.conf"),
+      format!(
+        "regtest=1
+datadir={env_string}
+listen=0
+txindex=1
+[regtest]
+rpcport={bitcoind_port}
+",
+      ),
+    )?;
+
+    let _bitcoind = KillOnDrop(
+      Command::new("bitcoind")
+        .arg(format!("-conf={config}"))
+        .stdout(Stdio::null())
+        .spawn()?,
+    );
+
+    loop {
+      if env.join("regtest/.cookie").try_exists()? {
+        break;
+      }
+    }
+
+    fs::write(env.join("ord.port"), format!("{ord_port}\n"))?;
+
+    let ord = std::env::current_exe()?;
+
+    let _ord = KillOnDrop(
+      Command::new(&ord)
+        .arg("--regtest")
+        .arg("--bitcoin-data-dir")
+        .arg(&env)
+        .arg("--data-dir")
+        .arg(&env)
+        .arg("--rpc-url")
+        .arg(format!("http://localhost:{bitcoind_port}"))
+        .arg("server")
+        .arg("--http-port")
+        .arg(ord_port.to_string())
+        .spawn()?,
+    );
+
+    if !env.join("regtest/wallets/ord").try_exists()? {
+      let status = Command::new(&ord)
+        .arg("--regtest")
+        .arg("--bitcoin-data-dir")
+        .arg(&env)
+        .arg("--data-dir")
+        .arg(&env)
+        .arg("--rpc-url")
+        .arg(format!("http://localhost:{bitcoind_port}"))
+        .arg("wallet")
+        .arg("create")
+        .status()?;
+
+      ensure!(status.success(), "failed to create wallet: {status}");
+    }
+
+    loop {
+      if SHUTTING_DOWN.load(atomic::Ordering::Relaxed) {
+        break Ok(None);
+      }
+
+      thread::sleep(Duration::from_millis(100));
+    }
+  }
+}

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -70,8 +70,6 @@ rpcport={bitcoind_port}
       }
     }
 
-    fs::write(env.join("ord.port"), format!("{ord_port}\n"))?;
-
     let ord = std::env::current_exe()?;
 
     let rpc_url = format!("http://localhost:{bitcoind_port}");

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -89,6 +89,8 @@ rpcport={bitcoind_port}
         .spawn()?,
     );
 
+    thread::sleep(Duration::from_millis(250));
+
     if !env.join("regtest/wallets/ord").try_exists()? {
       let status = Command::new(&ord)
         .arg("--regtest")
@@ -104,8 +106,6 @@ rpcport={bitcoind_port}
 
       ensure!(status.success(), "failed to create wallet: {status}");
     }
-
-    thread::sleep(Duration::from_millis(250));
 
     let directory = self.directory.to_str().unwrap().to_string();
 


### PR DESCRIPTION
Fixes #3135. I want to also finish #3145 before landing this, so that we can configure everything config file, so ord commands can be `ord --data-dir=env` and all flags are read from `env/ord.yaml`.