### PR TITLE
Use `image-rendering: auto` for AVIF inscriptions

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,6 +10,7 @@ Summary
   - [Pointer](inscriptions/pointer.md)
   - [Provenance](inscriptions/provenance.md)
   - [Recursion](inscriptions/recursion.md)
+  - [Rendering](inscriptions/rendering.md)
 - [FAQ](faq.md)
 - [Contributing](contributing.md)
 - [Donate](donate.md)

--- a/docs/src/inscriptions/rendering.md
+++ b/docs/src/inscriptions/rendering.md
@@ -1,0 +1,35 @@
+Rendering
+=========
+
+Aspect Ratio
+------------
+
+Inscriptions should be rendered with a square aspect ratio. Non-square aspect
+ratio inscriptions should not be cropped, and should instead be centered and
+resized to fit within their container.
+
+Maximum Size
+------------
+
+The `ord` explorer, used by [ordinals.com](https://ordinals.com/), displays
+inscription previews with a maximum size of 576 by 576 pixels, making it a
+reasonable choice when choosing a maximum display size.
+
+Image Rendering
+---------------
+
+The CSS `image-rendering` property controls how images are resampled when
+upscaled and downscaled.
+
+When downscaling image inscriptions, `image-rendering: auto`, should be used.
+This is desirable even when downscaling pixel art.
+
+When upscaling image inscriptions other than AVIF, `image-rendering: pixelated`
+should be used. This is desriable when upscaling pixel art, since it preserves
+the sharp edges of pixels. It is undesirable when upscaling non-pixel art, but
+should still be used for visual compatibility with the `ord` explorer.
+
+When upscaling AVIF and JPEG XL inscriptions, `image-rendering: auto` should be
+used. This allows inscribers to opt-in to non-pixelated upscaling for non-pixel
+art inscriptions. Until such time as JPEG XL is widely supported by browsers,
+it is not a recommended image format.

--- a/src/inscriptions/media.rs
+++ b/src/inscriptions/media.rs
@@ -1,7 +1,8 @@
 use {
+  self::{ImageRendering::*, Language::*, Media::*},
   super::*,
   brotli::enc::backward_references::BrotliEncoderMode::{
-    self, BROTLI_MODE_FONT, BROTLI_MODE_GENERIC, BROTLI_MODE_TEXT,
+    self, BROTLI_MODE_FONT as FONT, BROTLI_MODE_GENERIC as GENERIC, BROTLI_MODE_TEXT as TEXT,
   },
   mp4::{MediaType, Mp4Reader, TrackType},
   std::{fs::File, io::BufReader},
@@ -13,7 +14,7 @@ pub(crate) enum Media {
   Code(Language),
   Font,
   Iframe,
-  Image,
+  Image(ImageRendering),
   Markdown,
   Model,
   Pdf,
@@ -47,45 +48,65 @@ impl Display for Language {
   }
 }
 
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub(crate) enum ImageRendering {
+  Auto,
+  Pixelated,
+}
+
+impl Display for ImageRendering {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    write!(
+      f,
+      "{}",
+      match self {
+        Self::Auto => "auto",
+        Self::Pixelated => "pixelated",
+      }
+    )
+  }
+}
+
 impl Media {
   #[rustfmt::skip]
   const TABLE: &'static [(&'static str, BrotliEncoderMode, Media, &'static [&'static str])] = &[
-    ("application/cbor",            BROTLI_MODE_GENERIC, Media::Unknown,                    &["cbor"]),
-    ("application/json",            BROTLI_MODE_TEXT,    Media::Code(Language::Json),       &["json"]),
-    ("application/octet-stream",    BROTLI_MODE_GENERIC, Media::Unknown,                    &["bin"]),
-    ("application/pdf",             BROTLI_MODE_GENERIC, Media::Pdf,                        &["pdf"]),
-    ("application/pgp-signature",   BROTLI_MODE_TEXT,    Media::Text,                       &["asc"]),
-    ("application/protobuf",        BROTLI_MODE_GENERIC, Media::Unknown,                    &["binpb"]),
-    ("application/x-javascript",    BROTLI_MODE_TEXT,    Media::Code(Language::JavaScript), &[]),
-    ("application/yaml",            BROTLI_MODE_TEXT,    Media::Code(Language::Yaml),       &["yaml", "yml"]),
-    ("audio/flac",                  BROTLI_MODE_GENERIC, Media::Audio,                      &["flac"]),
-    ("audio/mpeg",                  BROTLI_MODE_GENERIC, Media::Audio,                      &["mp3"]),
-    ("audio/wav",                   BROTLI_MODE_GENERIC, Media::Audio,                      &["wav"]),
-    ("font/otf",                    BROTLI_MODE_GENERIC, Media::Font,                       &["otf"]),
-    ("font/ttf",                    BROTLI_MODE_GENERIC, Media::Font,                       &["ttf"]),
-    ("font/woff",                   BROTLI_MODE_GENERIC, Media::Font,                       &["woff"]),
-    ("font/woff2",                  BROTLI_MODE_FONT,    Media::Font,                       &["woff2"]),
-    ("image/apng",                  BROTLI_MODE_GENERIC, Media::Image,                      &["apng"]),
-    ("image/avif",                  BROTLI_MODE_GENERIC, Media::Image,                      &["avif"]),
-    ("image/gif",                   BROTLI_MODE_GENERIC, Media::Image,                      &["gif"]),
-    ("image/jpeg",                  BROTLI_MODE_GENERIC, Media::Image,                      &["jpg", "jpeg"]),
-    ("image/png",                   BROTLI_MODE_GENERIC, Media::Image,                      &["png"]),
-    ("image/svg+xml",               BROTLI_MODE_TEXT,    Media::Iframe,                     &["svg"]),
-    ("image/webp",                  BROTLI_MODE_GENERIC, Media::Image,                      &["webp"]),
-    ("model/gltf+json",             BROTLI_MODE_TEXT,    Media::Model,                      &["gltf"]),
-    ("model/gltf-binary",           BROTLI_MODE_GENERIC, Media::Model,                      &["glb"]),
-    ("model/stl",                   BROTLI_MODE_GENERIC, Media::Unknown,                    &["stl"]),
-    ("text/css",                    BROTLI_MODE_TEXT,    Media::Code(Language::Css),        &["css"]),
-    ("text/html",                   BROTLI_MODE_TEXT,    Media::Iframe,                     &[]),
-    ("text/html;charset=utf-8",     BROTLI_MODE_TEXT,    Media::Iframe,                     &["html"]),
-    ("text/javascript",             BROTLI_MODE_TEXT,    Media::Code(Language::JavaScript), &["js"]),
-    ("text/markdown",               BROTLI_MODE_TEXT,    Media::Markdown,                   &[]),
-    ("text/markdown;charset=utf-8", BROTLI_MODE_TEXT,    Media::Markdown,                   &["md"]),
-    ("text/plain",                  BROTLI_MODE_TEXT,    Media::Text,                       &[]),
-    ("text/plain;charset=utf-8",    BROTLI_MODE_TEXT,    Media::Text,                       &["txt"]),
-    ("text/x-python",               BROTLI_MODE_TEXT,    Media::Code(Language::Python),     &["py"]),
-    ("video/mp4",                   BROTLI_MODE_GENERIC, Media::Video,                      &["mp4"]),
-    ("video/webm",                  BROTLI_MODE_GENERIC, Media::Video,                      &["webm"]),
+    ("application/cbor",            GENERIC, Unknown,          &["cbor"]),
+    ("application/json",            TEXT,    Code(Json),       &["json"]),
+    ("application/octet-stream",    GENERIC, Unknown,          &["bin"]),
+    ("application/pdf",             GENERIC, Pdf,              &["pdf"]),
+    ("application/pgp-signature",   TEXT,    Text,             &["asc"]),
+    ("application/protobuf",        GENERIC, Unknown,          &["binpb"]),
+    ("application/x-javascript",    TEXT,    Code(JavaScript), &[]),
+    ("application/yaml",            TEXT,    Code(Yaml),       &["yaml", "yml"]),
+    ("audio/flac",                  GENERIC, Audio,            &["flac"]),
+    ("audio/mpeg",                  GENERIC, Audio,            &["mp3"]),
+    ("audio/wav",                   GENERIC, Audio,            &["wav"]),
+    ("font/otf",                    GENERIC, Font,             &["otf"]),
+    ("font/ttf",                    GENERIC, Font,             &["ttf"]),
+    ("font/woff",                   GENERIC, Font,             &["woff"]),
+    ("font/woff2",                  FONT,    Font,             &["woff2"]),
+    ("image/apng",                  GENERIC, Image(Pixelated), &["apng"]),
+    ("image/avif",                  GENERIC, Image(Auto),      &["avif"]),
+    ("image/gif",                   GENERIC, Image(Pixelated), &["gif"]),
+    ("image/jpeg",                  GENERIC, Image(Pixelated), &["jpg", "jpeg"]),
+    ("image/jxl",                   GENERIC, Image(Auto),      &[]),
+    ("image/png",                   GENERIC, Image(Pixelated), &["png"]),
+    ("image/svg+xml",               TEXT,    Iframe,           &["svg"]),
+    ("image/webp",                  GENERIC, Image(Pixelated), &["webp"]),
+    ("model/gltf+json",             TEXT,    Model,            &["gltf"]),
+    ("model/gltf-binary",           GENERIC, Model,            &["glb"]),
+    ("model/stl",                   GENERIC, Unknown,          &["stl"]),
+    ("text/css",                    TEXT,    Code(Css),        &["css"]),
+    ("text/html",                   TEXT,    Iframe,           &[]),
+    ("text/html;charset=utf-8",     TEXT,    Iframe,           &["html"]),
+    ("text/javascript",             TEXT,    Code(JavaScript), &["js"]),
+    ("text/markdown",               TEXT,    Markdown,         &[]),
+    ("text/markdown;charset=utf-8", TEXT,    Markdown,         &["md"]),
+    ("text/plain",                  TEXT,    Text,             &[]),
+    ("text/plain;charset=utf-8",    TEXT,    Text,             &["txt"]),
+    ("text/x-python",               TEXT,    Code(Python),     &["py"]),
+    ("video/mp4",                   GENERIC, Video,            &["mp4"]),
+    ("video/webm",                  GENERIC, Video,            &["webm"]),
   ];
 
   pub(crate) fn content_type_for_path(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,10 @@ use {
     blocktime::Blocktime,
     config::Config,
     decimal::Decimal,
-    inscriptions::{media, teleburn, Charm, Media, ParsedEnvelope},
+    inscriptions::{
+      media::{self, ImageRendering, Media},
+      teleburn, Charm, ParsedEnvelope,
+    },
     representation::Representation,
     runes::{Etching, Pile, SpacedRune},
     subcommand::{Subcommand, SubcommandResult},

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1319,13 +1319,16 @@ impl Server {
             .ok_or_not_found(|| format!("inscription {inscription_id} content"))?
             .into_response(),
         ),
-        Media::Image => Ok(
+        Media::Image(image_rendering) => Ok(
           (
             [(
               header::CONTENT_SECURITY_POLICY,
               "default-src 'self' 'unsafe-inline'",
             )],
-            PreviewImageHtml { inscription_id },
+            PreviewImageHtml {
+              image_rendering,
+              inscription_id,
+            },
           )
             .into_response(),
         ),

--- a/src/templates/preview.rs
+++ b/src/templates/preview.rs
@@ -18,6 +18,7 @@ pub(crate) struct PreviewFontHtml {
 
 #[derive(boilerplate::Boilerplate)]
 pub(crate) struct PreviewImageHtml {
+  pub(crate) image_rendering: ImageRendering,
   pub(crate) inscription_id: InscriptionId,
 }
 

--- a/templates/preview-image.html
+++ b/templates/preview-image.html
@@ -15,7 +15,7 @@
         background-repeat: no-repeat;
         background-size: contain;
         height: 100%;
-        image-rendering: pixelated;
+        image-rendering: {{ self.image_rendering }};
         margin: 0;
       }
 


### PR DESCRIPTION
Fixes #1373.