### PR TITLE
Add commit cache size option

### DIFF
--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -111,7 +111,7 @@ impl<'index> Updater<'_> {
 
       uncommitted += 1;
 
-      if uncommitted == 5000 {
+      if uncommitted >= self.index.options.commit_cache_size.unwrap_or_default() {
         self.commit(wtx, value_cache)?;
         value_cache = HashMap::new();
         uncommitted = 0;

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -111,7 +111,7 @@ impl<'index> Updater<'_> {
 
       uncommitted += 1;
 
-      if uncommitted >= self.index.options.commit_cache_size.unwrap_or_default() {
+      if uncommitted >= self.index.options.commit_interval {
         self.commit(wtx, value_cache)?;
         value_cache = HashMap::new();
         uncommitted = 0;

--- a/src/options.rs
+++ b/src/options.rs
@@ -37,6 +37,12 @@ pub struct Options {
   pub(crate) db_cache_size: Option<usize>,
   #[arg(
     long,
+    default_value = "5000",
+    help = "Set index commit cache size to <COMMIT_CACHE_SIZE>."
+  )]
+  pub(crate) commit_cache_size: Option<usize>,
+  #[arg(
+    long,
     help = "Don't look for inscriptions below <FIRST_INSCRIPTION_HEIGHT>."
   )]
   pub(crate) first_inscription_height: Option<u32>,
@@ -806,6 +812,13 @@ mod tests {
       Arguments::try_parse_from(["ord", "--db-cache-size", "16000000000", "index", "update"])
         .unwrap();
     assert_eq!(arguments.options.db_cache_size, Some(16000000000));
+  }
+
+  #[test]
+  fn setting_commit_cache_size() {
+    let arguments =
+      Arguments::try_parse_from(["ord", "--commit-cache-size", "500", "index", "update"]).unwrap();
+    assert_eq!(arguments.options.commit_cache_size, Some(500));
   }
 
   #[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -38,9 +38,9 @@ pub struct Options {
   #[arg(
     long,
     default_value = "5000",
-    help = "Set index commit cache size to <COMMIT_CACHE_SIZE>."
+    help = "Set index commit interval to <COMMIT_INTERVAL>."
   )]
-  pub(crate) commit_cache_size: Option<usize>,
+  pub(crate) commit_interval: usize,
   #[arg(
     long,
     help = "Don't look for inscriptions below <FIRST_INSCRIPTION_HEIGHT>."
@@ -817,8 +817,8 @@ mod tests {
   #[test]
   fn setting_commit_cache_size() {
     let arguments =
-      Arguments::try_parse_from(["ord", "--commit-cache-size", "500", "index", "update"]).unwrap();
-    assert_eq!(arguments.options.commit_cache_size, Some(500));
+      Arguments::try_parse_from(["ord", "--commit-interval", "500", "index", "update"]).unwrap();
+    assert_eq!(arguments.options.commit_interval, 500);
   }
 
   #[test]


### PR DESCRIPTION
## Description

When using a low memory cloud server, I found that reducing the commit cache size can increase index speed.

## Use Case

[ordxscan](https://www.ordxscan.com/) mainnet ord index. 

