### PR TITLE
Add commit interval

### DIFF
--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -98,7 +98,7 @@ impl<'index> Updater<'index> {
 
       uncommitted += 1;
 
-      if uncommitted == 5000 {
+      if uncommitted >= self.index.settings.commit_interval {
         self.commit(wtx, value_cache)?;
         value_cache = HashMap::new();
         uncommitted = 0;

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -98,7 +98,7 @@ impl<'index> Updater<'index> {
 
       uncommitted += 1;
 
-      if uncommitted >= self.index.settings.commit_interval {
+      if uncommitted == self.index.settings.commit_interval {
         self.commit(wtx, value_cache)?;
         value_cache = HashMap::new();
         uncommitted = 0;

--- a/src/options.rs
+++ b/src/options.rs
@@ -33,7 +33,7 @@ pub struct Options {
   #[arg(
     long,
     default_value = "5000",
-    help = "Set index commit interval to <COMMIT_INTERVAL>."
+    help = "Commit index every <COMMIT_INTERVAL> blocks."
   )]
   pub(crate) commit_interval: usize,
   #[arg(

--- a/src/options.rs
+++ b/src/options.rs
@@ -32,6 +32,12 @@ pub struct Options {
   pub(crate) db_cache_size: Option<usize>,
   #[arg(
     long,
+    default_value = "5000",
+    help = "Set index commit interval to <COMMIT_INTERVAL>."
+  )]
+  pub(crate) commit_interval: usize,
+  #[arg(
+    long,
     help = "Don't look for inscriptions below <FIRST_INSCRIPTION_HEIGHT>."
   )]
   pub(crate) first_inscription_height: Option<u32>,

--- a/src/options.rs
+++ b/src/options.rs
@@ -33,7 +33,7 @@ pub struct Options {
   #[arg(
     long,
     default_value = "5000",
-    help = "Commit index every <COMMIT_INTERVAL> blocks."
+    help = "Commit to index every <COMMIT_INTERVAL> blocks."
   )]
   pub(crate) commit_interval: usize,
   #[arg(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -10,6 +10,7 @@ pub struct Settings {
   pub(crate) credentials: Option<(String, String)>,
   pub(crate) data_dir: PathBuf,
   pub(crate) db_cache_size: Option<usize>,
+  pub(crate) commit_interval: usize,
   pub(crate) first_inscription_height: Option<u32>,
   pub(crate) height_limit: Option<u32>,
   pub(crate) hidden: HashSet<InscriptionId>,
@@ -86,6 +87,7 @@ impl Settings {
       credentials: options.username.zip(options.password),
       data_dir: options.data_dir,
       db_cache_size: options.db_cache_size,
+      commit_interval: options.commit_interval,
       first_inscription_height: options.first_inscription_height,
       height_limit: options.height_limit,
       hidden: config.hidden.unwrap_or_default(),
@@ -849,6 +851,13 @@ mod tests {
       Arguments::try_parse_from(["ord", "--db-cache-size", "16000000000", "index", "update"])
         .unwrap();
     assert_eq!(arguments.options.db_cache_size, Some(16000000000));
+  }
+
+  #[test]
+  fn setting_commit_interval() {
+    let arguments =
+      Arguments::try_parse_from(["ord", "--commit-interval", "500", "index", "update"]).unwrap();
+    assert_eq!(arguments.options.commit_interval, 500);
   }
 
   #[test]


### PR DESCRIPTION
## Description

When using a low memory cloud server, I found that reducing the commit cache size can increase index speed.

## Use Case

[ordxscan](https://www.ordxscan.com/) mainnet ord index. 

## Related Issue

Related #3158


