### PR TITLE
fix: flaky tests error

### DIFF
--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -131,26 +131,6 @@ impl TestServer {
       .unwrap()
   }
 
-  // pub(crate) fn sync_server(&self) {
-  //   let client = Client::new(&self.bitcoin_rpc_url, Auth::None).unwrap();
-  //   let chain_block_count = client.get_block_count().unwrap() + 1;
-
-  //   for i in 0.. {
-  //     let response = reqwest::blocking::get(self.url().join("/blockcount").unwrap()).unwrap();
-
-  //     assert_eq!(response.status(), StatusCode::OK);
-
-  //     let ord_height = response.text().unwrap().parse::<u64>().unwrap();
-
-  //     if ord_height >= chain_block_count {
-  //       break;
-  //     } else if i == 20 {
-  //       panic!("index failed to synchronize with chain");
-  //     }
-  //     thread::sleep(Duration::from_millis(50));
-  //   }
-  // }
-
   pub(crate) fn sync_server(&self) {
     let client = Client::new(&self.bitcoin_rpc_url, Auth::None).unwrap();
     let chain_block_count = client.get_block_count().unwrap() + 1;


### PR DESCRIPTION
## Description

for `cargo test `, some error case:

`case 1`: 
```
called `Result::unwrap()` on an `Err` value: Os { code: 24, kind: Uncategorized, message: "Too many open files" }
``` 
> solution: use `ulimit` command to add resource , such as: `ulimit -n 10240`

`case 2`:  spawn too many server

try to add exponential backoff mechanism(sleep time) to retry,  Not sure it can fix the CI error. 
 
## Related Issue

Related #3133

## Proposed Changelog

- Added exponential backoff mechanism(sleep time) to retry for test
