### PR TITLE
Support creating and restoring wallets with accounts

### DIFF
--- a/src/subcommand/wallet/create.rs
+++ b/src/subcommand/wallet/create.rs
@@ -17,6 +17,8 @@ pub(crate) struct Create {
     help = "Use <PASSPHRASE> to derive wallet seed."
   )]
   pub(crate) passphrase: String,
+  #[arg(long, help = "Derive wallet with <ACCOUNT>", default_value = "0")]
+  pub(crate) account: u32,
 }
 
 impl Create {
@@ -26,7 +28,12 @@ impl Create {
 
     let mnemonic = Mnemonic::from_entropy(&entropy)?;
 
-    Wallet::initialize(name, settings, mnemonic.to_seed(&self.passphrase))?;
+    Wallet::initialize(
+      name,
+      settings,
+      mnemonic.to_seed(&self.passphrase),
+      self.account,
+    )?;
 
     Ok(Some(Box::new(Output {
       mnemonic,

--- a/src/subcommand/wallet/restore.rs
+++ b/src/subcommand/wallet/restore.rs
@@ -6,6 +6,8 @@ pub(crate) struct Restore {
   from: Source,
   #[arg(long, help = "Use <PASSPHRASE> when deriving wallet")]
   pub(crate) passphrase: Option<String>,
+  #[arg(long, help = "Derive wallet with <ACCOUNT>", default_value = "0")]
+  pub(crate) account: u32,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone)]
@@ -44,6 +46,7 @@ impl Restore {
           name,
           settings,
           mnemonic.to_seed(self.passphrase.unwrap_or_default()),
+          self.account,
         )?;
       }
     }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -527,7 +527,12 @@ impl Wallet {
     Ok(())
   }
 
-  pub(crate) fn initialize(name: String, settings: &Settings, seed: [u8; 64]) -> Result {
+  pub(crate) fn initialize(
+    name: String,
+    settings: &Settings,
+    seed: [u8; 64],
+    account: u32,
+  ) -> Result {
     Self::check_version(settings.bitcoin_rpc_client(None)?)?.create_wallet(
       &name,
       None,
@@ -549,7 +554,7 @@ impl Wallet {
       .child(ChildNumber::Hardened {
         index: u32::from(network != Network::Bitcoin),
       })
-      .child(ChildNumber::Hardened { index: 0 });
+      .child(ChildNumber::Hardened { index: account });
 
     let derived_private_key = master_private_key.derive_priv(&secp, &derivation_path)?;
 


### PR DESCRIPTION
To do:
- Error if restoring from a descriptor and account is set, since descriptors already contain the account
- Add a test that descriptors created when creating and restoring a wallet with an account contain the account
- Add some test cases that simply check that descriptors generated with the same seeds result in the same descriptor