### PR TITLE
Encode claims with tag

### DIFF
--- a/src/runes/tag.rs
+++ b/src/runes/tag.rs
@@ -9,6 +9,7 @@ pub(super) enum Tag {
   Term = 8,
   Deadline = 10,
   DefaultOutput = 12,
+  Claim = 14,
   #[allow(unused)]
   Burn = 254,
 

--- a/src/subcommand/wallet/etch.rs
+++ b/src/subcommand/wallet/etch.rs
@@ -72,6 +72,7 @@ impl Etch {
       }],
       default_output: None,
       burn: false,
+      claim: None,
     };
 
     let script_pubkey = runestone.encipher();

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -975,6 +975,7 @@ fn sending_rune_creates_transaction_with_expected_runestone() {
         output: 2
       }],
       burn: false,
+      claim: None,
     },
   );
 }


### PR DESCRIPTION
This PR changes claims from being a property of edict IDs, to being done with a dedicated tag.

This has a few advantages:
- Only one rune can be claimed at a time with a given runestone. Claim limits make claims costly because the claimant must pay transaction fees. If a given runestone can claim more than one rune, the the transaction fee is amortized across multiple claims. Making a claim a tag prevents this.
- The code for claiming with a claim bit is weird.
- If you want to claim a rune for the maximum amount, and send it to the default output, this can be done with a claim tag without needing an edict.
- The code is actually much cleaner.

I also finally refactored `RuneUpdater::index_runes` into multiple functions.