### PR TITLE
Add documentation to clarify that inscriptions are served from /content/<INSCRIPTION_ID>

### DIFF
--- a/docs/src/inscriptions.md
+++ b/docs/src/inscriptions.md
@@ -70,6 +70,9 @@ Content
 The data model of inscriptions is that of a HTTP response, allowing inscription
 content to be served by a web server and viewed in a web browser.
 
+Inscriptions are served from the URL `/content/<INSCRIPTION_ID>`, where 
+`<INSCRIPTION_ID>` is the ID of the inscription to fetch.
+
 Fields
 ------
 
@@ -148,7 +151,12 @@ off-chain content, thus keeping inscriptions immutable and self-contained.
 
 This is accomplished by loading HTML and SVG inscriptions inside `iframes` with
 the `sandbox` attribute, as well as serving inscription content with
-`Content-Security-Policy` headers.
+`Content-Security-Policy` headers. 
+
+The iframe has a URL of `/content/<INSCRIPTION_ID>`, where `<INSCRIPTION_ID>` is 
+the ID of the rendered inscription. If an inscription has a delegate, 
+`<INSCRIPTION_ID>` is the ID of the inscription being rendered, *not* the ID of 
+the delegate.
 
 Reinscriptions
 --------------

--- a/docs/src/inscriptions.md
+++ b/docs/src/inscriptions.md
@@ -61,7 +61,7 @@ bytes.
 
 The inscription content is contained within the input of a reveal transaction,
 and the inscription is made on the first sat of its input if it has no pointer
-field. This sat can then be tracked using the familiar rules of ordinal 
+field. This sat can then be tracked using the familiar rules of ordinal
 theory, allowing it to be transferred, bought, sold, lost to fees, and recovered.
 
 Content
@@ -69,9 +69,6 @@ Content
 
 The data model of inscriptions is that of a HTTP response, allowing inscription
 content to be served by a web server and viewed in a web browser.
-
-Inscriptions are served from the URL `/content/<INSCRIPTION_ID>`, where 
-`<INSCRIPTION_ID>` is the ID of the inscription to fetch.
 
 Fields
 ------
@@ -151,12 +148,27 @@ off-chain content, thus keeping inscriptions immutable and self-contained.
 
 This is accomplished by loading HTML and SVG inscriptions inside `iframes` with
 the `sandbox` attribute, as well as serving inscription content with
-`Content-Security-Policy` headers. 
+`Content-Security-Policy` headers.
 
-The iframe has a URL of `/content/<INSCRIPTION_ID>`, where `<INSCRIPTION_ID>` is 
-the ID of the rendered inscription. If an inscription has a delegate, 
-`<INSCRIPTION_ID>` is the ID of the inscription being rendered, *not* the ID of 
-the delegate.
+Self-Reference
+--------------
+
+The content of the inscription with ID `INSCRIPTION_ID` must served from the
+URL path `/content/<INSCRIPTION_ID>`.
+
+This allows inscriptions to retrieve their own inscription ID with:
+
+```js
+let inscription_id = window.location.pathname.split("/").pop();
+```
+
+If an inscription with ID X delegates to an inscription with ID Y, that is to
+say, if inscription X contains a delegate field with value Y, the content of
+inscription X must be served from the URL path `/content/X`, *not*
+`/content/Y`.
+
+This allows delegating inscriptions to use their own inscription ID as a seed
+for generative delegate content.
 
 Reinscriptions
 --------------

--- a/docs/src/inscriptions/delegate.md
+++ b/docs/src/inscriptions/delegate.md
@@ -2,8 +2,9 @@ Delegate
 ========
 
 Inscriptions may nominate a delegate inscription. Requests for the content of
-an inscription with a delegate will instead return the content and content type
-of the delegate. This can be used to cheaply create copies of an inscription.
+an inscription with a delegate will instead return the content, content type 
+and content encoding of the delegate. This can be used to cheaply create copies 
+of an inscription.
 
 ### Specification
 

--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -62,9 +62,9 @@ plain-text responses.
 ### Self Referencing
 
 An inscription may fetch data about itself using the endpoints above by 
-using its own inscription ID. Since all inscriptions are rendered in an 
-iframe with a URL of `/content/<INSCRIPTION_ID>`, it can retrieve its own 
-inscription ID from `window.location.pathname` using the following line (or similar)
+using its own inscription ID. Since all inscriptions are rendered with 
+a URL of `/content/<INSCRIPTION_ID>`, it can retrieve its own inscription 
+ID from `window.location.pathname` using the following line (or similar)
 
 ```js
 const inscriptionId = window.location.pathname.match(/\/content\/([\da-f]{64}i\d+)/i)[1]

--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -59,17 +59,6 @@ plain-text responses.
 - `/blockhash/<HEIGHT>`: block hash at given block height.
 - `/blocktime`: UNIX time stamp of latest block.
 
-### Self Referencing
-
-An inscription may fetch data about itself using the endpoints above by 
-using its own inscription ID. Since all inscriptions are rendered with 
-a URL of `/content/<INSCRIPTION_ID>`, it can retrieve its own inscription 
-ID from `window.location.pathname` using the following line (or similar)
-
-```js
-const inscriptionId = window.location.pathname.match(/\/content\/([\da-f]{64}i\d+)/i)[1]
-```
-
 Examples
 --------
 

--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -59,6 +59,17 @@ plain-text responses.
 - `/blockhash/<HEIGHT>`: block hash at given block height.
 - `/blocktime`: UNIX time stamp of latest block.
 
+### Self Referencing
+
+An inscription may fetch data about itself using the endpoints above by 
+using it's own inscription ID. Since all inscriptions are rendered in an 
+iframe with a URL of `/content/<INSCRIPTION_ID>`, it can retrieve its own 
+inscription ID from `window.location.pathname` using the following line (or similar)
+
+```js
+const inscriptionId = window.location.pathname.match(/\/content\/([\da-f]{64}i\d+)/i)[1]
+```
+
 Examples
 --------
 

--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -62,7 +62,7 @@ plain-text responses.
 ### Self Referencing
 
 An inscription may fetch data about itself using the endpoints above by 
-using it's own inscription ID. Since all inscriptions are rendered in an 
+using its own inscription ID. Since all inscriptions are rendered in an 
 iframe with a URL of `/content/<INSCRIPTION_ID>`, it can retrieve its own 
 inscription ID from `window.location.pathname` using the following line (or similar)
 


### PR DESCRIPTION
Closes #2903
Closes #3208

Adds a few lines to the documentation to make it clear that inscriptions are served from /content/<INSCRIPTION_ID>. Many inscriptions rely on this fact to get their own inscription ID, so it is important that this is properly documented so we know we can rely on this.

Also added clarification regarding the url of inscriptions that have delegates. Happy to remove this if people think it is implicit in the other sentences, but since ord.io is currently making this mistake, I thought it is better to clarify.

Also added an example for how inscriptions can self reference and fetch their own inscription ID. Also happy to remove this, as it isn't directly about the protocol, but rather how to use it. But a lot of people ask how to do this, so having it in the handbook would be helpful.