### PR TITLE
Adjust docker file to work with `just`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,29 @@ FROM rust:1.75.0-bookworm as builder
 
 WORKDIR /usr/src/ord
 
+# Create ~/bin directory
+RUN mkdir -p ~/bin
+
+# Download and extract just to ~/bin/just
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/bin
+
+# Add ~/bin to the PATH
+ENV PATH="/root/bin:${PATH}"
+
 COPY . .
 
 RUN cargo build --bin ord --release
 
 FROM debian:bookworm-slim
 
+# Install Rust, build-essential, pkg-config, libssl-dev, and ripgrep
+RUN apt-get update && apt-get install -y curl build-essential pkg-config libssl-dev ripgrep && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+    . $HOME/.cargo/env
+
 COPY --from=builder /usr/src/ord/target/release/ord /usr/local/bin
+COPY --from=builder /root/bin/just /usr/local/bin
+
 RUN apt-get update && apt-get install -y openssl
 
 ENV RUST_BACKTRACE=1

--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ A Docker image can be built with:
 docker build -t ordinals/ord .
 ```
 
+#### Docker Compose
+A docker image can be built with docker-compose using the following command
+
+```
+docker-compose build
+```
+
+After building the image you can step into the container with the following command
+```
+docker-compose run --rm ord bash
+```
+
+Once in the container, you can run just commands such as `just ci`
+
 ### Homebrew
 
 `ord` is available in [Homebrew](https://brew.sh/):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  ord:
+    build: .
+    volumes:
+      - .:/usr/src/ord
+    environment:
+      RUST_BACKTRACE: 1
+      RUST_LOG: info
+    working_dir: /usr/src/ord


### PR DESCRIPTION
Here I've adjusted the docker file to allow developers to work in the container and use the just command.  I've also create a docker-compose file for those that prefer docker-compose and allow for easier multi-container interactions in the future