### PR TITLE
update libssl-dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Building
 On Debian and Ubuntu, `ord` requires `libssl-dev` when building from source:
 
 ```
-sudo apt-get install libssl-dev
+sudo apt-get install pkg-config libssl-dev
 ```
 
 You'll also need Rust:


### PR DESCRIPTION
ubuntu command wasn't working for me, found this one that works instead (ubuntu on windows)