### PR TITLE
Update dump.rs for public descriptor dumping.

### DIFF
--- a/src/subcommand/wallet/dump.rs
+++ b/src/subcommand/wallet/dump.rs
@@ -1,14 +1,25 @@
 use super::*;
+use std::collections::BTreeMap;
 
-pub(crate) fn run(wallet: Wallet) -> SubcommandResult {
-  eprintln!(
-    "==========================================
-= THIS STRING CONTAINS YOUR PRIVATE KEYS =
-=        DO NOT SHARE WITH ANYONE        =
-=========================================="
-  );
+pub(crate) fn run(wallet: Wallet, matches: &ArgMatches) -> SubcommandResult {
+    let dump_private_keys = matches.is_present("dump-private-keys");
 
-  Ok(Some(Box::new(
-    wallet.bitcoin_client().list_descriptors(Some(true))?,
-  )))
+    let warning_message = if dump_private_keys {
+        "==========================================\n\
+         = THIS STRING CONTAINS YOUR PRIVATE KEYS =\n\
+         =        DO NOT SHARE WITH ANYONE        =\n\
+         =========================================="
+    } else {
+        "==========================================\n\
+         =        PUBLIC DESCRIPTOR OUTPUT        =\n\
+         =       HANDLE WITH CARE, BUT LESS       =\n\
+         =       SENSITIVE THAN PRIVATE KEYS      =\n\
+         =========================================="
+    };
+
+    eprintln!(warning_message);
+
+    Ok(Some(Box::new(
+        wallet.bitcoin_client().list_descriptors(Some(dump_private_keys))?,
+    )))
 }


### PR DESCRIPTION
Added ability to dump public keys by default instead of private keys, needs --dump_private_keys for the private keys to dump instead.  Kept the warning because dumping your public descriptor is dangerous to privacy the same way private keys are dangerous to security.  Not a rust dev, sorry. 