### PR TITLE
Add note field to inscriptions with tag 15

### DIFF
--- a/src/inscriptions/tag.rs
+++ b/src/inscriptions/tag.rs
@@ -13,6 +13,8 @@ pub(crate) enum Tag {
   ContentEncoding,
   Delegate,
   #[allow(unused)]
+  Note,
+  #[allow(unused)]
   Nop,
 }
 
@@ -32,6 +34,7 @@ impl Tag {
       Self::Metaprotocol => &[7],
       Self::ContentEncoding => &[9],
       Self::Delegate => &[11],
+      Self::Note => &[15],
       Self::Nop => &[255],
     }
   }


### PR DESCRIPTION
Add a `note` field to inscriptions. [chisel.xyz](https://chisel.xyz/) puts a note that the inscription was inscribed by chisel in tag 15. This seems reasonable, and similar to BitTorrent's `created_by` field. This PR adds the field to the `Tag` enum, to ensure we don't accidentally use it in the future. This field will probably never be displayed, since users probably don't want the tool which created the inscription to display on /inscription, and they can include that in the metadata if they do.