### PR TITLE
feat: allow generate multiple addresses

### DIFF
--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -133,9 +133,9 @@ rpcport={bitcoind_port}
         .arg("200")
         .arg(
           receive
-            .clone()
             .addresses
             .first()
+            .cloned()
             .unwrap()
             .require_network(Network::Regtest)?
             .to_string(),

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -127,16 +127,22 @@ rpcport={bitcoind_port}
       let receive =
         serde_json::from_slice::<crate::subcommand::wallet::receive::Output>(&output.stdout)?;
 
-      for address in receive.addresses {
-        let status = Command::new("bitcoin-cli")
-          .arg(format!("-datadir={relative}"))
-          .arg("generatetoaddress")
-          .arg("200")
-          .arg(address.require_network(Network::Regtest)?.to_string())
-          .status()?;
+      let status = Command::new("bitcoin-cli")
+        .arg(format!("-datadir={relative}"))
+        .arg("generatetoaddress")
+        .arg("200")
+        .arg(
+          receive
+            .clone()
+            .addresses
+            .first()
+            .unwrap()
+            .require_network(Network::Regtest)?
+            .to_string(),
+        )
+        .status()?;
 
-        ensure!(status.success(), "failed to create wallet: {status}");
-      }
+      ensure!(status.success(), "failed to create wallet: {status}");
     }
 
     serde_json::to_writer_pretty(

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -127,16 +127,16 @@ rpcport={bitcoind_port}
       let receive =
         serde_json::from_slice::<crate::subcommand::wallet::receive::Output>(&output.stdout)?;
 
-      let address = receive.address.require_network(Network::Regtest)?;
+      for address in receive.addresses {
+        let status = Command::new("bitcoin-cli")
+          .arg(format!("-datadir={relative}"))
+          .arg("generatetoaddress")
+          .arg("200")
+          .arg(address.require_network(Network::Regtest)?.to_string())
+          .status()?;
 
-      let status = Command::new("bitcoin-cli")
-        .arg(format!("-datadir={relative}"))
-        .arg("generatetoaddress")
-        .arg("200")
-        .arg(address.to_string())
-        .status()?;
-
-      ensure!(status.success(), "failed to create wallet: {status}");
+        ensure!(status.success(), "failed to create wallet: {status}");
+      }
     }
 
     serde_json::to_writer_pretty(

--- a/src/subcommand/wallet.rs
+++ b/src/subcommand/wallet.rs
@@ -53,7 +53,7 @@ pub(crate) enum Subcommand {
   #[command(about = "List wallet inscriptions")]
   Inscriptions,
   #[command(about = "Generate receive address")]
-  Receive,
+  Receive(receive::Receive),
   #[command(about = "Restore wallet")]
   Restore(restore::Restore),
   #[command(about = "List wallet satoshis")]
@@ -96,7 +96,7 @@ impl WalletCommand {
       Subcommand::Etch(etch) => etch.run(wallet),
       Subcommand::Inscribe(inscribe) => inscribe.run(wallet),
       Subcommand::Inscriptions => inscriptions::run(wallet),
-      Subcommand::Receive => receive::run(wallet),
+      Subcommand::Receive(receive) => receive.run(wallet),
       Subcommand::Sats(sats) => sats.run(wallet),
       Subcommand::Send(send) => send.run(wallet),
       Subcommand::Transactions(transactions) => transactions.run(wallet),

--- a/src/subcommand/wallet/receive.rs
+++ b/src/subcommand/wallet/receive.rs
@@ -2,13 +2,30 @@ use super::*;
 
 #[derive(Deserialize, Serialize)]
 pub struct Output {
-  pub address: Address<NetworkUnchecked>,
+  pub addresses: Vec<Address<NetworkUnchecked>>,
 }
 
-pub(crate) fn run(wallet: Wallet) -> SubcommandResult {
-  let address = wallet
-    .bitcoin_client()
-    .get_new_address(None, Some(bitcoincore_rpc::json::AddressType::Bech32m))?;
+#[derive(Debug, Parser)]
+pub(crate) struct Receive {
+  #[arg(
+    short,
+    long,
+    default_value_t = 1,
+    help = "Generate <NUMBER> addresses."
+  )]
+  number: u64,
+}
 
-  Ok(Some(Box::new(Output { address })))
+impl Receive {
+  pub(crate) fn run(self, wallet: Wallet) -> SubcommandResult {
+    let addresses = (0..self.number)
+      .map(|_| {
+        wallet
+          .bitcoin_client()
+          .get_new_address(None, Some(bitcoincore_rpc::json::AddressType::Bech32m))
+      })
+      .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Some(Box::new(Output { addresses })))
+  }
 }

--- a/src/subcommand/wallet/receive.rs
+++ b/src/subcommand/wallet/receive.rs
@@ -7,24 +7,21 @@ pub struct Output {
 
 #[derive(Debug, Parser)]
 pub(crate) struct Receive {
-  #[arg(
-    short,
-    long,
-    default_value_t = 1,
-    help = "Generate <NUMBER> addresses."
-  )]
-  number: u64,
+  #[arg(short, long, help = "Generate <NUMBER> addresses.")]
+  number: Option<u64>,
 }
 
 impl Receive {
   pub(crate) fn run(self, wallet: Wallet) -> SubcommandResult {
-    let addresses = (0..self.number)
-      .map(|_| {
+    let mut addresses: Vec<Address<NetworkUnchecked>> = Vec::new();
+
+    for _ in 0..self.number.unwrap_or(1) {
+      addresses.push(
         wallet
           .bitcoin_client()
-          .get_new_address(None, Some(bitcoincore_rpc::json::AddressType::Bech32m))
-      })
-      .collect::<Result<Vec<_>, _>>()?;
+          .get_new_address(None, Some(bitcoincore_rpc::json::AddressType::Bech32m))?,
+      );
+    }
 
     Ok(Some(Box::new(Output { addresses })))
   }

--- a/tests/wallet/inscribe.rs
+++ b/tests/wallet/inscribe.rs
@@ -477,11 +477,13 @@ fn inscribe_to_specific_destination() {
 
   bitcoin_rpc_server.mine_blocks(1);
 
-  let destination = CommandBuilder::new("wallet receive")
+  let addresses = CommandBuilder::new("wallet receive")
     .bitcoin_rpc_server(&bitcoin_rpc_server)
     .ord_rpc_server(&ord_rpc_server)
     .run_and_deserialize_output::<receive::Output>()
-    .address;
+    .addresses;
+
+  let destination = addresses.first().unwrap();
 
   let txid = CommandBuilder::new(format!(
     "wallet inscribe --destination {} --file degenerate.png --fee-rate 1",

--- a/tests/wallet/inscriptions.rs
+++ b/tests/wallet/inscriptions.rs
@@ -28,15 +28,17 @@ fn inscriptions() {
     format!("https://ordinals.com/inscription/{inscription}")
   );
 
-  let address = CommandBuilder::new("wallet receive")
+  let addresses = CommandBuilder::new("wallet receive")
     .bitcoin_rpc_server(&bitcoin_rpc_server)
     .ord_rpc_server(&ord_rpc_server)
     .run_and_deserialize_output::<receive::Output>()
-    .address;
+    .addresses;
+
+  let destination = addresses.first().unwrap();
 
   let txid = CommandBuilder::new(format!(
     "wallet send --fee-rate 1 {} {inscription}",
-    address.assume_checked()
+    destination.clone().assume_checked()
   ))
   .bitcoin_rpc_server(&bitcoin_rpc_server)
   .ord_rpc_server(&ord_rpc_server)
@@ -105,15 +107,17 @@ fn inscriptions_with_postage() {
 
   assert_eq!(output[0].postage, 10000);
 
-  let address = CommandBuilder::new("wallet receive")
+  let addresses = CommandBuilder::new("wallet receive")
     .bitcoin_rpc_server(&bitcoin_rpc_server)
     .ord_rpc_server(&ord_rpc_server)
     .run_and_deserialize_output::<receive::Output>()
-    .address;
+    .addresses;
+
+  let destination = addresses.first().unwrap();
 
   CommandBuilder::new(format!(
     "wallet send --fee-rate 1 {} {inscription}",
-    address.assume_checked()
+    destination.clone().assume_checked()
   ))
   .bitcoin_rpc_server(&bitcoin_rpc_server)
   .ord_rpc_server(&ord_rpc_server)

--- a/tests/wallet/receive.rs
+++ b/tests/wallet/receive.rs
@@ -12,5 +12,9 @@ fn receive() {
     .ord_rpc_server(&ord_rpc_server)
     .run_and_deserialize_output::<receive::Output>();
 
-  assert!(output.address.is_valid_for_network(Network::Bitcoin));
+  assert!(output
+    .addresses
+    .first()
+    .unwrap()
+    .is_valid_for_network(Network::Bitcoin));
 }


### PR DESCRIPTION
## Description

Allow generating multiple addresses

## Related Issue

Related #3275

## Usage

1. `ord wallet receive`

```json
{
  "addresses": [
    "bcrt1pyeryjjzz5g2e2lxyf29z3j8kvpgr8ecas9cw2ttkyq8x9xhjhcus7ptp6e"
  ]
}
```

2. `ord wallet receive --number 2`

```json
{
  "addresses": [
    "bcrt1pt4a6xttm94j6pyp6dtstqu74axdv99vu00dfp0gwssmkgzymqh9q6c32gq",
    "bcrt1pc9galhk22p6sdle5xp0ggsw5lxhcgttayr9unv8v97s9cf8ysdaqaa9h70"
  ]
}
```
3. `ord wallet receive -n 2`

```json
{
  "addresses": [
    "bcrt1pfjmvlll0ds3fhvnqp2ff4ymt5lncgpphgk3vmf795z0chdyqjytsvt5tuh",
    "bcrt1p8xm6tzqy38cgrwpcg57fx4kh26kf337s758wrap0cy53kqep0nus34veyh"
  ]
}
```
