### PR TITLE
Allow multiple delegates.

### DIFF
--- a/crates/mockcore/src/lib.rs
+++ b/crates/mockcore/src/lib.rs
@@ -263,6 +263,14 @@ impl Handle {
     blocks
   }
 
+  pub fn create_tx_from_template(&self, template: TransactionTemplate) -> Transaction {
+    self.state().create_tx_from_template(template)
+  }
+
+  pub fn broadcast_tx(&self, transaction: Transaction) -> Txid {
+    self.state().broadcast_tx(transaction)
+  }
+
   pub fn broadcast_template(&self, template: TransactionTemplate) -> Txid {
     self.state().broadcast_template(template)
   }

--- a/crates/mockcore/src/lib.rs
+++ b/crates/mockcore/src/lib.rs
@@ -263,8 +263,8 @@ impl Handle {
     blocks
   }
 
-  pub fn broadcast_tx(&self, template: TransactionTemplate) -> Txid {
-    self.state().broadcast_tx(template)
+  pub fn broadcast_template(&self, template: TransactionTemplate) -> Txid {
+    self.state().broadcast_template(template)
   }
 
   pub fn height(&self) -> u64 {

--- a/crates/mockcore/src/state.rs
+++ b/crates/mockcore/src/state.rs
@@ -190,7 +190,7 @@ impl State {
     blockhash
   }
 
-  pub(crate) fn broadcast_tx(&mut self, template: TransactionTemplate) -> Txid {
+  pub(crate) fn broadcast_template(&mut self, template: TransactionTemplate) -> Txid {
     let mut total_value = 0;
     let mut input = Vec::new();
     for (height, tx, vout, witness) in template.inputs.iter() {

--- a/crates/mockcore/src/state.rs
+++ b/crates/mockcore/src/state.rs
@@ -190,7 +190,7 @@ impl State {
     blockhash
   }
 
-  pub(crate) fn broadcast_template(&mut self, template: TransactionTemplate) -> Txid {
+  pub(crate) fn create_tx_from_template(&mut self, template: TransactionTemplate) -> Transaction {
     let mut total_value = 0;
     let mut input = Vec::new();
     for (height, tx, vout, witness) in template.inputs.iter() {
@@ -274,6 +274,19 @@ impl State {
       );
     }
 
+    tx
+  }
+
+  pub(crate) fn broadcast_tx(&mut self, transaction: Transaction) -> Txid {
+    let txid = transaction.compute_txid();
+
+    self.mempool.push(transaction);
+
+    txid
+  }
+
+  pub(crate) fn broadcast_template(&mut self, template: TransactionTemplate) -> Txid {
+    let tx = self.create_tx_from_template(template);
     let txid = tx.compute_txid();
 
     self.mempool.push(tx);

--- a/src/api.rs
+++ b/src/api.rs
@@ -118,7 +118,7 @@ pub struct InscriptionRecursive {
   pub charms: Vec<Charm>,
   pub content_type: Option<String>,
   pub content_length: Option<usize>,
-  pub delegate: Option<InscriptionId>,
+  pub delegates: Vec<InscriptionId>,
   pub fee: u64,
   pub height: u32,
   pub id: InscriptionId,

--- a/src/index.rs
+++ b/src/index.rs
@@ -2087,16 +2087,14 @@ impl Index {
       Charm::Lost.set(&mut charms);
     }
 
-    let effective_mime_type = if let Some(delegate_id) = inscription.delegate() {
-      let delegate_result = self.get_inscription_by_id(delegate_id);
-      if let Ok(Some(delegate)) = delegate_result {
-        delegate.content_type().map(str::to_string)
-      } else {
-        inscription.content_type().map(str::to_string)
-      }
-    } else {
-      inscription.content_type().map(str::to_string)
-    };
+    let effective_mime_type = inscription
+      .delegates()
+      .iter()
+      .find_map(|delegate| self.get_inscription_by_id(*delegate).unwrap_or(None))
+      .as_ref()
+      .unwrap_or(&inscription)
+      .content_type()
+      .map(str::to_string);
 
     Ok(Some((
       api::Inscription {

--- a/src/index.rs
+++ b/src/index.rs
@@ -2426,7 +2426,7 @@ mod tests {
     {
       let context = Context::builder().build();
       context.mine_blocks(1);
-      let txid = context.core.broadcast_tx(template.clone());
+      let txid = context.core.broadcast_template(template.clone());
       let inscription_id = InscriptionId { txid, index: 0 };
       context.mine_blocks(1);
 
@@ -2450,7 +2450,7 @@ mod tests {
     {
       let context = Context::builder().chain(Chain::Mainnet).build();
       context.mine_blocks(1);
-      let txid = context.core.broadcast_tx(template);
+      let txid = context.core.broadcast_template(template);
       let inscription_id = InscriptionId { txid, index: 0 };
       context.mine_blocks(1);
 
@@ -2475,7 +2475,7 @@ mod tests {
     {
       let context = Context::builder().build();
       context.mine_blocks(1);
-      let txid = context.core.broadcast_tx(template.clone());
+      let txid = context.core.broadcast_template(template.clone());
       let inscription_id = InscriptionId { txid, index: 0 };
       context.mine_blocks(1);
 
@@ -2499,7 +2499,7 @@ mod tests {
     {
       let context = Context::builder().arg("--no-index-inscriptions").build();
       context.mine_blocks(1);
-      let txid = context.core.broadcast_tx(template);
+      let txid = context.core.broadcast_template(template);
       let inscription_id = InscriptionId { txid, index: 0 };
       context.mine_blocks(1);
 
@@ -2551,7 +2551,7 @@ mod tests {
       fee: 0,
       ..default()
     };
-    let txid = context.core.broadcast_tx(split_coinbase_output);
+    let txid = context.core.broadcast_template(split_coinbase_output);
 
     context.mine_blocks(1);
 
@@ -2577,7 +2577,7 @@ mod tests {
       ..default()
     };
 
-    let txid = context.core.broadcast_tx(merge_coinbase_outputs);
+    let txid = context.core.broadcast_template(merge_coinbase_outputs);
     context.mine_blocks(1);
 
     assert_eq!(
@@ -2600,7 +2600,7 @@ mod tests {
       fee: 10,
       ..default()
     };
-    let txid = context.core.broadcast_tx(fee_paying_tx);
+    let txid = context.core.broadcast_template(fee_paying_tx);
     let coinbase_txid = context.mine_blocks(1)[0].txdata[0].compute_txid();
 
     assert_eq!(
@@ -2638,8 +2638,8 @@ mod tests {
       fee: 10,
       ..default()
     };
-    context.core.broadcast_tx(first_fee_paying_tx);
-    context.core.broadcast_tx(second_fee_paying_tx);
+    context.core.broadcast_template(first_fee_paying_tx);
+    context.core.broadcast_template(second_fee_paying_tx);
 
     let coinbase_txid = context.mine_blocks(1)[0].txdata[0].compute_txid();
 
@@ -2667,7 +2667,7 @@ mod tests {
       fee: 50 * COIN_VALUE,
       ..default()
     };
-    let txid = context.core.broadcast_tx(no_value_output);
+    let txid = context.core.broadcast_template(no_value_output);
     context.mine_blocks(1);
 
     assert_eq!(
@@ -2686,7 +2686,7 @@ mod tests {
       fee: 50 * COIN_VALUE,
       ..default()
     };
-    context.core.broadcast_tx(no_value_output);
+    context.core.broadcast_template(no_value_output);
     context.mine_blocks(1);
 
     let no_value_input = TransactionTemplate {
@@ -2694,7 +2694,7 @@ mod tests {
       fee: 0,
       ..default()
     };
-    let txid = context.core.broadcast_tx(no_value_input);
+    let txid = context.core.broadcast_template(no_value_input);
     context.mine_blocks(1);
 
     assert_eq!(
@@ -2707,7 +2707,7 @@ mod tests {
   fn list_spent_output() {
     let context = Context::builder().arg("--index-sats").build();
     context.mine_blocks(1);
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, Default::default())],
       fee: 0,
       ..default()
@@ -2789,7 +2789,7 @@ mod tests {
   fn find_first_sat_spent_in_second_block() {
     let context = Context::builder().arg("--index-sats").build();
     context.mine_blocks(1);
-    let spend_txid = context.core.broadcast_tx(TransactionTemplate {
+    let spend_txid = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, Default::default())],
       fee: 0,
       ..default()
@@ -2809,7 +2809,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -2833,7 +2833,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      context.core.broadcast_tx(TransactionTemplate {
+      context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, Default::default())],
         fee: 50 * 100_000_000,
         ..default()
@@ -2841,7 +2841,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 1, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -2861,7 +2861,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      context.core.broadcast_tx(TransactionTemplate {
+      context.core.broadcast_template(TransactionTemplate {
         inputs: &[(4, 0, 0, Default::default())],
         fee: 50 * 100_000_000,
         ..default()
@@ -2869,7 +2869,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(5, 1, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -2894,7 +2894,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -2911,7 +2911,7 @@ mod tests {
         Some(50 * COIN_VALUE),
       );
 
-      let send_txid = context.core.broadcast_tx(TransactionTemplate {
+      let send_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, Default::default()), (2, 1, 0, Default::default())],
         ..default()
       });
@@ -2937,7 +2937,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(2);
 
-      let first_txid = context.core.broadcast_tx(TransactionTemplate {
+      let first_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -2947,7 +2947,7 @@ mod tests {
         index: 0,
       };
 
-      let second_txid = context.core.broadcast_tx(TransactionTemplate {
+      let second_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, inscription("text/png", [1; 100]).to_witness())],
         ..default()
       });
@@ -2958,7 +2958,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      let merged_txid = context.core.broadcast_tx(TransactionTemplate {
+      let merged_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(3, 1, 0, Default::default()), (3, 2, 0, Default::default())],
         ..default()
       });
@@ -2996,7 +2996,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -3013,7 +3013,7 @@ mod tests {
         Some(50 * COIN_VALUE),
       );
 
-      let send_txid = context.core.broadcast_tx(TransactionTemplate {
+      let send_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, Default::default()), (2, 1, 0, Default::default())],
         outputs: 2,
         ..default()
@@ -3040,7 +3040,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -3048,7 +3048,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      context.core.broadcast_tx(TransactionTemplate {
+      context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 1, 0, Default::default())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -3075,7 +3075,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(2);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -3083,7 +3083,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      context.core.broadcast_tx(TransactionTemplate {
+      context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, Default::default()), (3, 1, 0, Default::default())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -3110,7 +3110,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -3138,7 +3138,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -3163,7 +3163,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let first_txid = context.core.broadcast_tx(TransactionTemplate {
+      let first_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -3176,7 +3176,7 @@ mod tests {
       context.mine_blocks_with_subsidy(1, 0);
       context.mine_blocks(1);
 
-      let second_txid = context.core.broadcast_tx(TransactionTemplate {
+      let second_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(3, 0, 0, inscription("text/plain", "hello").to_witness())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -3295,7 +3295,7 @@ mod tests {
       context.mine_blocks_with_subsidy(1, 0);
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, inscription("text/plain", "hello").to_witness())],
         outputs: 2,
         ..default()
@@ -3303,7 +3303,7 @@ mod tests {
       let inscription_id = InscriptionId { txid, index: 0 };
       context.mine_blocks(1);
 
-      context.core.broadcast_tx(TransactionTemplate {
+      context.core.broadcast_template(TransactionTemplate {
         inputs: &[(3, 1, 1, Default::default()), (3, 1, 0, Default::default())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -3326,7 +3326,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         outputs: 2,
         output_values: &[0, 50 * COIN_VALUE],
@@ -3351,7 +3351,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -3460,7 +3460,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -3485,7 +3485,7 @@ mod tests {
         [inscription_id]
       );
 
-      let send_id = context.core.broadcast_tx(TransactionTemplate {
+      let send_id = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 1, 0, Default::default())],
         ..default()
       });
@@ -3518,7 +3518,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let first = context.core.broadcast_tx(TransactionTemplate {
+      let first = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -3553,7 +3553,7 @@ mod tests {
         Some(50 * COIN_VALUE),
       );
 
-      let second = context.core.broadcast_tx(TransactionTemplate {
+      let second = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 1, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -3602,7 +3602,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -3624,7 +3624,7 @@ mod tests {
       let mut ids = Vec::new();
 
       for i in 0..101 {
-        let txid = context.core.broadcast_tx(TransactionTemplate {
+        let txid = context.core.broadcast_template(TransactionTemplate {
           inputs: &[(i + 1, 0, 0, inscription("text/plain", "hello").to_witness())],
           ..default()
         });
@@ -3658,7 +3658,7 @@ mod tests {
         b"ord",
       ]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         ..default()
       });
@@ -3695,7 +3695,7 @@ mod tests {
         b"ord",
       ]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         ..default()
       });
@@ -3730,7 +3730,7 @@ mod tests {
         b"text/plain;charset=utf-8",
       ]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness.clone())],
         ..default()
       });
@@ -3743,7 +3743,7 @@ mod tests {
 
       assert_eq!(context.index.inscription_number(inscription_id), -1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, witness)],
         ..default()
       });
@@ -3771,7 +3771,7 @@ mod tests {
         b"text/plain;charset=utf-8",
       ]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         ..default()
       });
@@ -3791,7 +3791,7 @@ mod tests {
 
       let witness = envelope(&[b"ord", &[1]]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         ..default()
       });
@@ -3820,7 +3820,7 @@ mod tests {
 
       let witness = Witness::from_slice(&[script.into_bytes(), Vec::new()]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         ..default()
       });
@@ -3850,7 +3850,7 @@ mod tests {
 
       let witness = Witness::from_slice(&[script.into_bytes(), Vec::new()]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         ..default()
       });
@@ -3869,7 +3869,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      context.core.broadcast_tx(TransactionTemplate {
+      context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, Default::default())],
         fee: 50 * 100_000_000,
         ..default()
@@ -3877,7 +3877,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 1, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -3905,7 +3905,7 @@ mod tests {
       context.mine_blocks(1);
 
       // create zero value input
-      context.core.broadcast_tx(TransactionTemplate {
+      context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, Default::default())],
         fee: 50 * 100_000_000,
         ..default()
@@ -3915,7 +3915,7 @@ mod tests {
 
       let witness = inscription("text/plain", "hello").to_witness();
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, witness.clone()), (2, 1, 0, witness.clone())],
         ..default()
       });
@@ -3946,7 +3946,7 @@ mod tests {
 
       let witness = envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[
           (1, 0, 0, witness.clone()),
           (2, 0, 0, witness.clone()),
@@ -4028,7 +4028,7 @@ mod tests {
 
       let witness = Witness::from_slice(&[script.into_bytes(), Vec::new()]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         ..default()
       });
@@ -4108,7 +4108,7 @@ mod tests {
 
       let witness = Witness::from_slice(&[script.into_bytes(), Vec::new()]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[
           (1, 0, 0, witness.clone()),
           (2, 0, 0, witness.clone()),
@@ -4211,7 +4211,7 @@ mod tests {
 
       let witness = Witness::from_slice(&[script.into_bytes(), Vec::new()]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         fee: 33,
         ..default()
@@ -4252,7 +4252,7 @@ mod tests {
 
       let witness = envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]);
 
-      let cursed_txid = context.core.broadcast_tx(TransactionTemplate {
+      let cursed_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness.clone()), (2, 0, 0, witness.clone())],
         outputs: 2,
         ..default()
@@ -4287,7 +4287,7 @@ mod tests {
         b"reinscription on cursed",
       ]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(3, 1, 1, witness)],
         ..default()
       });
@@ -4317,7 +4317,7 @@ mod tests {
 
       let witness = envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]);
 
-      let cursed_txid = context.core.broadcast_tx(TransactionTemplate {
+      let cursed_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness.clone()), (2, 0, 0, witness.clone())],
         outputs: 2,
         ..default()
@@ -4352,7 +4352,7 @@ mod tests {
         b"reinscription on cursed",
       ]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(3, 1, 1, witness)],
         ..default()
       });
@@ -4380,7 +4380,7 @@ mod tests {
         b"second reinscription on cursed",
       ]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(4, 1, 0, witness)],
         ..default()
       });
@@ -4427,7 +4427,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           1,
           0,
@@ -4441,7 +4441,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           2,
           1,
@@ -4454,7 +4454,7 @@ mod tests {
       let second = InscriptionId { txid, index: 0 };
 
       context.mine_blocks(1);
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           3,
           1,
@@ -4490,7 +4490,7 @@ mod tests {
 
       let mut inscription_ids = Vec::new();
       for i in 1..=21 {
-        let txid = context.core.broadcast_tx(TransactionTemplate {
+        let txid = context.core.broadcast_template(TransactionTemplate {
           inputs: &[(
             i,
             if i == 1 { 0 } else { 1 },
@@ -4539,7 +4539,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           1,
           0,
@@ -4560,7 +4560,7 @@ mod tests {
         .index
         .assert_inscription_location(first_id, first_location, Some(50 * COIN_VALUE));
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           2,
           0,
@@ -4599,7 +4599,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           1,
           0,
@@ -4616,7 +4616,7 @@ mod tests {
 
       context.mine_blocks(10);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           2,
           0,
@@ -4662,7 +4662,7 @@ mod tests {
 
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           1,
           0,
@@ -4680,7 +4680,7 @@ mod tests {
         offset: 0,
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           2,
           0,
@@ -4721,7 +4721,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -4745,7 +4745,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let parent_txid = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -4757,7 +4757,7 @@ mod tests {
         index: 0,
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           2,
           0,
@@ -4792,7 +4792,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let parent_txid = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -4804,7 +4804,7 @@ mod tests {
         index: 0,
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           2,
           1,
@@ -4844,11 +4844,11 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(2);
 
-      let parent_txid_a = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid_a = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
-      let parent_txid_b = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid_b = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, inscription("text/plain", "world").to_witness())],
         ..default()
       });
@@ -4879,7 +4879,7 @@ mod tests {
 
       let parent_b_input = (3, 2, 0, Witness::new());
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[revelation_input, parent_b_input],
         ..default()
       });
@@ -4915,7 +4915,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let parent_txid = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -4927,7 +4927,7 @@ mod tests {
         index: 0,
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           2,
           1,
@@ -4967,7 +4967,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let parent_txid = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -4985,7 +4985,7 @@ mod tests {
         .chain(vec![0, 0, 0, 0])
         .collect();
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           2,
           1,
@@ -5025,15 +5025,15 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(3);
 
-      let parent_txid_a = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid_a = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
-      let parent_txid_b = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid_b = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, inscription("text/plain", "world").to_witness())],
         ..default()
       });
-      let parent_txid_c = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid_c = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(3, 0, 0, inscription("text/plain", "wazzup").to_witness())],
         ..default()
       });
@@ -5069,7 +5069,7 @@ mod tests {
 
       let parent_c_input = (4, 3, 0, Witness::new());
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[revealing_parent_a_input, parent_c_input],
         ..default()
       });
@@ -5112,15 +5112,15 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(3);
 
-      let parent_txid_a = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid_a = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
-      let parent_txid_b = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid_b = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, inscription("text/plain", "world").to_witness())],
         ..default()
       });
-      let parent_txid_c = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid_c = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(3, 0, 0, inscription("text/plain", "wazzup").to_witness())],
         ..default()
       });
@@ -5162,7 +5162,7 @@ mod tests {
       let parent_b_input = (4, 2, 0, Witness::new());
       let parent_c_input = (4, 3, 0, Witness::new());
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[revealing_parent_a_input, parent_b_input, parent_c_input],
         ..default()
       });
@@ -5205,7 +5205,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let parent_txid = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -5217,7 +5217,7 @@ mod tests {
         index: 0,
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[
           (2, 1, 0, Default::default()),
           (
@@ -5260,7 +5260,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let parent_txid = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -5272,7 +5272,7 @@ mod tests {
         index: 0,
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[
           (
             3,
@@ -5315,7 +5315,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let parent_txid = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -5327,7 +5327,7 @@ mod tests {
         index: 0,
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(
           2,
           1,
@@ -5366,7 +5366,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let delegate_txid = context.core.broadcast_tx(TransactionTemplate {
+      let delegate_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..Default::default()
       });
@@ -5397,7 +5397,7 @@ mod tests {
         ],
         ..Default::default()
       };
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, multi_delegate_inscription.to_witness())],
         ..Default::default()
       });
@@ -5434,7 +5434,7 @@ mod tests {
         ..default()
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription.to_witness())],
         ..default()
       });
@@ -5466,7 +5466,7 @@ mod tests {
         ..default()
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription.to_witness())],
         ..default()
       });
@@ -5498,7 +5498,7 @@ mod tests {
         ..default()
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription.to_witness())],
         fee: 25 * COIN_VALUE,
         ..default()
@@ -5531,7 +5531,7 @@ mod tests {
         ..default()
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription.to_witness())],
         ..default()
       });
@@ -5558,7 +5558,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(1);
 
-      let parent_txid = context.core.broadcast_tx(TransactionTemplate {
+      let parent_txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "parent").to_witness())],
         ..default()
       });
@@ -5578,7 +5578,7 @@ mod tests {
         ..default()
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 1, 0, child_inscription.to_witness())],
         ..default()
       });
@@ -5651,7 +5651,7 @@ mod tests {
 
       let witness = Witness::from_slice(&[builder.into_bytes(), Vec::new()]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         ..default()
       });
@@ -5718,7 +5718,7 @@ mod tests {
 
       let witness = Witness::from_slice(&[builder.into_bytes(), Vec::new()]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         outputs: 3,
         ..default()
@@ -5785,7 +5785,7 @@ mod tests {
         ..default()
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[
           (1, 0, 0, inscription_for_second_output.to_witness()),
           (2, 0, 0, inscription_for_third_output.to_witness()),
@@ -5855,7 +5855,7 @@ mod tests {
         ..default()
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[
           (1, 0, 0, first_inscription.to_witness()),
           (2, 0, 0, second_inscription.to_witness()),
@@ -5918,7 +5918,7 @@ mod tests {
         ..default()
       };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[
           (1, 0, 0, inscription.to_witness()),
           (2, 0, 0, cursed_reinscription.to_witness()),
@@ -5966,7 +5966,7 @@ mod tests {
 
       let inscription = Inscription::default();
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription.to_witness())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -5997,7 +5997,7 @@ mod tests {
 
       let inscription = Inscription::default();
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription.to_witness())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -6040,7 +6040,7 @@ mod tests {
 
       let witness = Witness::from_slice(&[script.into_bytes(), Vec::new()]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         ..default()
       });
@@ -6072,7 +6072,7 @@ mod tests {
 
       let inscription = Inscription::default();
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 1, 0, inscription.to_witness())],
         ..default()
       });
@@ -6104,7 +6104,7 @@ mod tests {
 
       let inscription = Inscription::default();
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(3, 1, 0, inscription.to_witness())],
         ..default()
       });
@@ -6151,7 +6151,7 @@ mod tests {
 
       let witness = Witness::from_slice(&[script.into_bytes(), Vec::new()]);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, witness)],
         ..default()
       });
@@ -6183,7 +6183,7 @@ mod tests {
 
       let inscription = Inscription::default();
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(111, 1, 0, inscription.to_witness())],
         ..default()
       });
@@ -6215,7 +6215,7 @@ mod tests {
 
       let inscription = Inscription::default();
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(112, 1, 0, inscription.to_witness())],
         ..default()
       });
@@ -6264,7 +6264,7 @@ mod tests {
       })
       .unwrap());
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, Default::default())],
       ..default()
     });
@@ -6330,7 +6330,7 @@ mod tests {
 
     context.mine_blocks(2);
 
-    let txid = context.core.broadcast_tx(TransactionTemplate {
+    let txid = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, Witness::new()), (2, 0, 0, Witness::new())],
       outputs: 2,
       ..Default::default()
@@ -6363,7 +6363,7 @@ mod tests {
       ]
     );
 
-    let txid = context.core.broadcast_tx(TransactionTemplate {
+    let txid = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 1, 0, Witness::new())],
       p2tr: true,
       ..Default::default()
@@ -6399,7 +6399,7 @@ mod tests {
     for context in Context::configurations() {
       context.mine_blocks(2);
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         fee: 50 * COIN_VALUE,
         ..default()
@@ -6407,7 +6407,7 @@ mod tests {
 
       let a = InscriptionId { txid, index: 0 };
 
-      let txid = context.core.broadcast_tx(TransactionTemplate {
+      let txid = context.core.broadcast_template(TransactionTemplate {
         inputs: &[(2, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -6429,7 +6429,7 @@ mod tests {
     context.mine_blocks(1);
 
     let inscription = Inscription::default();
-    let create_txid = context.core.broadcast_tx(TransactionTemplate {
+    let create_txid = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription.to_witness())],
       fee: 0,
       outputs: 1,
@@ -6463,7 +6463,7 @@ mod tests {
     );
 
     // Transfer inscription
-    let transfer_txid = context.core.broadcast_tx(TransactionTemplate {
+    let transfer_txid = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 1, 0, Default::default())],
       fee: 0,
       outputs: 1,
@@ -6555,7 +6555,7 @@ mod tests {
       }
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -6609,7 +6609,7 @@ mod tests {
       }
     );
 
-    let txid2 = context.core.broadcast_tx(TransactionTemplate {
+    let txid2 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(9, 1, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -6672,7 +6672,7 @@ mod tests {
       }
     );
 
-    let txid3 = context.core.broadcast_tx(TransactionTemplate {
+    let txid3 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(10, 1, 0, Witness::new())],
       op_return: Some(
         Runestone {

--- a/src/index/testing.rs
+++ b/src/index/testing.rs
@@ -157,7 +157,7 @@ impl Context {
 
     self.mine_blocks(1);
 
-    self.core.broadcast_tx(TransactionTemplate {
+    self.core.broadcast_template(TransactionTemplate {
       inputs: &[(block_count, 0, 0, Witness::new())],
       p2tr: true,
       ..default()
@@ -187,7 +187,7 @@ impl Context {
 
     witness.push([]);
 
-    let txid = self.core.broadcast_tx(TransactionTemplate {
+    let txid = self.core.broadcast_template(TransactionTemplate {
       inputs: &[(block_count + 1, 1, 0, witness)],
       op_return: Some(runestone.encipher()),
       outputs,

--- a/src/inscriptions/envelope.rs
+++ b/src/inscriptions/envelope.rs
@@ -49,7 +49,7 @@ impl From<RawEnvelope> for ParsedEnvelope {
 
     let content_encoding = Tag::ContentEncoding.take(&mut fields);
     let content_type = Tag::ContentType.take(&mut fields);
-    let delegate = Tag::Delegate.take(&mut fields);
+    let delegates = Tag::Delegate.take_array(&mut fields);
     let metadata = Tag::Metadata.take(&mut fields);
     let metaprotocol = Tag::Metaprotocol.take(&mut fields);
     let parents = Tag::Parent.take_array(&mut fields);
@@ -71,7 +71,7 @@ impl From<RawEnvelope> for ParsedEnvelope {
         }),
         content_encoding,
         content_type,
-        delegate,
+        delegates,
         duplicate_field,
         incomplete_field,
         metadata,

--- a/src/inscriptions/inscription.rs
+++ b/src/inscriptions/inscription.rs
@@ -13,7 +13,7 @@ pub struct Inscription {
   pub body: Option<Vec<u8>>,
   pub content_encoding: Option<Vec<u8>>,
   pub content_type: Option<Vec<u8>>,
-  pub delegate: Option<Vec<u8>>,
+  pub delegates: Vec<Vec<u8>>,
   pub duplicate_field: bool,
   pub incomplete_field: bool,
   pub metadata: Option<Vec<u8>>,
@@ -28,7 +28,7 @@ impl Inscription {
   pub fn new(
     chain: Chain,
     compress: bool,
-    delegate: Option<InscriptionId>,
+    delegates: Vec<InscriptionId>,
     metadata: Option<Vec<u8>>,
     metaprotocol: Option<String>,
     parents: Vec<InscriptionId>,
@@ -96,7 +96,7 @@ impl Inscription {
       body,
       content_encoding,
       content_type: content_type.map(|content_type| content_type.into()),
-      delegate: delegate.map(|delegate| delegate.value()),
+      delegates: delegates.iter().map(|delegate| delegate.value()).collect(),
       metadata,
       metaprotocol: metaprotocol.map(|metaprotocol| metaprotocol.into_bytes()),
       parents: parents.iter().map(|parent| parent.value()).collect(),
@@ -126,7 +126,7 @@ impl Inscription {
     Tag::ContentEncoding.append(&mut builder, &self.content_encoding);
     Tag::Metaprotocol.append(&mut builder, &self.metaprotocol);
     Tag::Parent.append_array(&mut builder, &self.parents);
-    Tag::Delegate.append(&mut builder, &self.delegate);
+    Tag::Delegate.append_array(&mut builder, &self.delegates);
     Tag::Pointer.append(&mut builder, &self.pointer);
     Tag::Metadata.append(&mut builder, &self.metadata);
     Tag::Rune.append(&mut builder, &self.rune);
@@ -231,8 +231,12 @@ impl Inscription {
     HeaderValue::from_str(str::from_utf8(self.content_encoding.as_ref()?).unwrap_or_default()).ok()
   }
 
-  pub fn delegate(&self) -> Option<InscriptionId> {
-    Self::inscription_id_field(self.delegate.as_deref())
+  pub(crate) fn delegates(&self) -> Vec<InscriptionId> {
+    self
+      .delegates
+      .iter()
+      .filter_map(|delegate| Self::inscription_id_field(Some(delegate)))
+      .collect()
   }
 
   pub fn metadata(&self) -> Option<Value> {
@@ -480,14 +484,15 @@ mod tests {
   fn inscription_delegate_txid_is_deserialized_correctly() {
     assert_eq!(
       Inscription {
-        delegate: Some(vec![
+        delegates: vec![vec![
           0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
           0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
           0x1e, 0x1f,
-        ]),
+        ]],
         ..default()
       }
-      .delegate()
+      .delegates()
+      .first()
       .unwrap()
       .txid,
       "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100"
@@ -769,7 +774,7 @@ mod tests {
     let inscription = Inscription::new(
       Chain::Mainnet,
       false,
-      None,
+      Vec::new(),
       None,
       None,
       Vec::new(),
@@ -784,7 +789,7 @@ mod tests {
     let inscription = Inscription::new(
       Chain::Mainnet,
       false,
-      None,
+      Vec::new(),
       None,
       None,
       Vec::new(),
@@ -799,7 +804,7 @@ mod tests {
     let inscription = Inscription::new(
       Chain::Mainnet,
       false,
-      None,
+      Vec::new(),
       None,
       None,
       Vec::new(),
@@ -814,7 +819,7 @@ mod tests {
     let inscription = Inscription::new(
       Chain::Mainnet,
       false,
-      None,
+      Vec::new(),
       None,
       None,
       Vec::new(),

--- a/src/runes.rs
+++ b/src/runes.rs
@@ -59,7 +59,7 @@ mod tests {
 
     context.etch(Default::default(), 1);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, Witness::new())],
       op_return: Some(Runestone::default().encipher()),
       ..default()
@@ -290,7 +290,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    let txid0 = context.core.broadcast_tx(TransactionTemplate {
+    let txid0 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -342,7 +342,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -738,7 +738,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -882,7 +882,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -950,7 +950,7 @@ mod tests {
       )],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -1029,7 +1029,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       op_return: Some(Runestone::default().encipher()),
       ..default()
@@ -1107,7 +1107,7 @@ mod tests {
       )],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       op_return: Some(Runestone::default().encipher()),
       outputs: 0,
@@ -1181,7 +1181,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -1266,7 +1266,7 @@ mod tests {
       )],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -1347,7 +1347,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       op_return: None,
       ..default()
@@ -1568,7 +1568,7 @@ mod tests {
       ],
     );
 
-    let txid2 = context.core.broadcast_tx(TransactionTemplate {
+    let txid2 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (id0.block.try_into().unwrap(), 1, 0, Witness::new()),
         (id1.block.try_into().unwrap(), 1, 0, Witness::new()),
@@ -1732,7 +1732,7 @@ mod tests {
       ],
     );
 
-    let txid2 = context.core.broadcast_tx(TransactionTemplate {
+    let txid2 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (id0.block.try_into().unwrap(), 1, 0, Witness::new()),
         (id1.block.try_into().unwrap(), 1, 0, Witness::new()),
@@ -1783,7 +1783,7 @@ mod tests {
       )],
     );
 
-    let txid3 = context.core.broadcast_tx(TransactionTemplate {
+    let txid3 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[((id1.block + 1).try_into().unwrap(), 1, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -1972,7 +1972,7 @@ mod tests {
       ],
     );
 
-    let txid2 = context.core.broadcast_tx(TransactionTemplate {
+    let txid2 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (id0.block.try_into().unwrap(), 1, 0, Witness::new()),
         (id1.block.try_into().unwrap(), 1, 0, Witness::new()),
@@ -2088,7 +2088,7 @@ mod tests {
       )],
     );
 
-    let txid = context.core.broadcast_tx(TransactionTemplate {
+    let txid = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       op_return: Some(
         script::Builder::new()
@@ -2254,7 +2254,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -2416,7 +2416,7 @@ mod tests {
       ],
     );
 
-    let txid2 = context.core.broadcast_tx(TransactionTemplate {
+    let txid2 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id0.block.try_into().unwrap(), 1, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -2537,7 +2537,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -3065,7 +3065,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -3163,7 +3163,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -3268,7 +3268,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -3373,7 +3373,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -3471,7 +3471,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       outputs: 4,
       op_return: Some(
@@ -3576,7 +3576,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       outputs: 4,
       op_return: Some(
@@ -3777,7 +3777,7 @@ mod tests {
       )],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -3864,7 +3864,7 @@ mod tests {
       [],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -3952,7 +3952,7 @@ mod tests {
       [],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -4047,7 +4047,7 @@ mod tests {
       [],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4097,7 +4097,7 @@ mod tests {
     );
 
     // claim the rune
-    let txid2 = context.core.broadcast_tx(TransactionTemplate {
+    let txid2 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(4, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4156,7 +4156,7 @@ mod tests {
     );
 
     // claim the rune in a burn runestone
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(5, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4257,7 +4257,7 @@ mod tests {
 
     context.assert_runes([(id, entry)], []);
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4284,7 +4284,7 @@ mod tests {
       )],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4350,7 +4350,7 @@ mod tests {
 
     context.assert_runes([(id, entry)], []);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4366,7 +4366,7 @@ mod tests {
 
     context.assert_runes([(id, entry)], []);
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4434,7 +4434,7 @@ mod tests {
 
     context.assert_runes([(id, entry)], []);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4450,7 +4450,7 @@ mod tests {
 
     context.assert_runes([(id, entry)], []);
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4518,7 +4518,7 @@ mod tests {
 
     context.assert_runes([(id, entry)], []);
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4545,7 +4545,7 @@ mod tests {
       )],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4611,7 +4611,7 @@ mod tests {
 
     context.assert_runes([(id, entry)], []);
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4637,7 +4637,7 @@ mod tests {
       )],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4703,7 +4703,7 @@ mod tests {
 
     context.assert_runes([(id, entry)], []);
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4729,7 +4729,7 @@ mod tests {
       )],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4795,7 +4795,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4813,7 +4813,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4881,7 +4881,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4899,7 +4899,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -4976,7 +4976,7 @@ mod tests {
       [(OutPoint { txid, vout: 0 }, vec![(id, 1111)])],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -5057,7 +5057,7 @@ mod tests {
       [],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -5105,7 +5105,7 @@ mod tests {
       )],
     );
 
-    let txid2 = context.core.broadcast_tx(TransactionTemplate {
+    let txid2 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -5162,7 +5162,7 @@ mod tests {
       ],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(4, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -5262,7 +5262,7 @@ mod tests {
       [],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -5347,7 +5347,7 @@ mod tests {
       [],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, Witness::new())],
       outputs: 2,
       op_return: Some(
@@ -5567,7 +5567,7 @@ mod tests {
       1,
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -5658,7 +5658,7 @@ mod tests {
       [],
     );
 
-    let txid1 = context.core.broadcast_tx(TransactionTemplate {
+    let txid1 = context.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, Witness::new())],
       op_return: Some(
         Runestone {
@@ -5727,7 +5727,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(block_count, 0, 0, Witness::new())],
       p2tr: false,
       ..default()
@@ -5767,7 +5767,7 @@ mod tests {
 
     witness.push([]);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(block_count + 1, 1, 0, witness)],
       op_return: Some(runestone.encipher()),
       outputs: 1,
@@ -5787,7 +5787,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(block_count, 0, 0, Witness::new())],
       p2tr: true,
       ..default()
@@ -5827,7 +5827,7 @@ mod tests {
 
     witness.push([]);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(block_count + 1, 1, 0, witness)],
       op_return: Some(runestone.encipher()),
       outputs: 1,
@@ -5847,7 +5847,7 @@ mod tests {
 
     context.mine_blocks_with_update(1, false);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(block_count, 0, 0, Witness::new())],
       p2tr: true,
       ..default()
@@ -5887,7 +5887,7 @@ mod tests {
 
     witness.push([]);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(block_count + 1, 1, 0, witness)],
       op_return: Some(runestone.encipher()),
       outputs: 1,
@@ -5909,7 +5909,7 @@ mod tests {
 
     context.mine_blocks(1);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(block_count, 0, 0, Witness::new())],
       p2tr: true,
       ..default()
@@ -5939,7 +5939,7 @@ mod tests {
 
     witness.push([]);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(block_count + 1, 1, 0, witness)],
       op_return: Some(runestone.encipher()),
       outputs: 1,
@@ -5974,7 +5974,7 @@ mod tests {
     witness.push([opcodes::all::OP_PUSHDATA4.to_u8()]);
     witness.push([]);
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, witness)],
       op_return: Some(runestone.encipher()),
       outputs: 1,
@@ -6026,7 +6026,7 @@ mod tests {
       )],
     );
 
-    context.core.broadcast_tx(TransactionTemplate {
+    context.core.broadcast_template(TransactionTemplate {
       inputs: &[(id.block.try_into().unwrap(), 1, 0, Witness::new())],
       op_return: Some(
         Runestone {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -2501,7 +2501,7 @@ mod tests {
 
       self.mine_blocks(1);
 
-      self.core.broadcast_tx(TransactionTemplate {
+      self.core.broadcast_template(TransactionTemplate {
         inputs: &[(block_count, 0, 0, Default::default())],
         p2tr: true,
         ..default()
@@ -2529,7 +2529,7 @@ mod tests {
         witness
       });
 
-      let txid = self.core.broadcast_tx(TransactionTemplate {
+      let txid = self.core.broadcast_template(TransactionTemplate {
         inputs: &[(block_count + 1, 1, 0, witness)],
         op_return: Some(runestone.encipher()),
         outputs,
@@ -3051,7 +3051,7 @@ mod tests {
       ..default()
     };
 
-    server.core.broadcast_tx(split);
+    server.core.broadcast_template(split);
 
     server.mine_blocks(1);
 
@@ -3061,7 +3061,7 @@ mod tests {
       ..default()
     };
 
-    let txid = server.core.broadcast_tx(merge);
+    let txid = server.core.broadcast_template(merge);
 
     server.mine_blocks(1);
 
@@ -3777,7 +3777,7 @@ mod tests {
 
     server.mine_blocks(3);
 
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(
         1,
         0,
@@ -3787,7 +3787,7 @@ mod tests {
       ..default()
     });
 
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(
         2,
         0,
@@ -3797,7 +3797,7 @@ mod tests {
       ..default()
     });
 
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(
         3,
         0,
@@ -4077,7 +4077,7 @@ mod tests {
 
     server.mine_blocks(1);
 
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, Default::default())],
       fee: 50 * 100_000_000,
       ..default()
@@ -4085,7 +4085,7 @@ mod tests {
 
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(
         2,
         1,
@@ -4149,7 +4149,7 @@ mod tests {
     let mut ids = Vec::new();
 
     for i in 0..101 {
-      let txid = server.core.broadcast_tx(TransactionTemplate {
+      let txid = server.core.broadcast_template(TransactionTemplate {
         inputs: &[(i + 1, 0, 0, inscription("image/png", "hello").to_witness())],
         ..default()
       });
@@ -4157,7 +4157,7 @@ mod tests {
       server.mine_blocks(1);
     }
 
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(102, 0, 0, inscription("text/plain", "{}").to_witness())],
       ..default()
     });
@@ -4292,7 +4292,7 @@ mod tests {
       fee: 0,
       ..default()
     };
-    test_server.core.broadcast_tx(transaction);
+    test_server.core.broadcast_template(transaction);
     let block_hash = test_server.mine_blocks(1)[0].block_hash();
 
     test_server.assert_response_regex(
@@ -4545,7 +4545,7 @@ mod tests {
     );
 
     server.mine_blocks(1);
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, Default::default())],
       outputs: 2,
       fee: 0,
@@ -4569,7 +4569,7 @@ mod tests {
     );
 
     server.mine_blocks(1);
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, Default::default())],
       outputs: 2,
       fee: 2,
@@ -4665,7 +4665,7 @@ mod tests {
 
       server.mine_blocks(1);
 
-      let txid = server.core.broadcast_tx(TransactionTemplate {
+      let txid = server.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -4690,7 +4690,7 @@ mod tests {
 
       server.mine_blocks(1);
 
-      let txid = server.core.broadcast_tx(TransactionTemplate {
+      let txid = server.core.broadcast_template(TransactionTemplate {
         inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
         ..default()
       });
@@ -4713,7 +4713,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(
         1,
         0,
@@ -4774,7 +4774,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(
         1,
         0,
@@ -4801,7 +4801,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("audio/flac", "hello").to_witness())],
       ..default()
     });
@@ -4821,7 +4821,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("font/ttf", "hello").to_witness())],
       ..default()
     });
@@ -4841,7 +4841,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(
         1,
         0,
@@ -4866,7 +4866,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/markdown", "hello").to_witness())],
       ..default()
     });
@@ -4886,7 +4886,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("image/png", "hello").to_witness())],
       ..default()
     });
@@ -4907,7 +4907,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(
         1,
         0,
@@ -4932,7 +4932,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/foo", "hello").to_witness())],
       ..default()
     });
@@ -4952,7 +4952,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("video/webm", "hello").to_witness())],
       ..default()
     });
@@ -4975,7 +4975,7 @@ mod tests {
       .build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/foo", "hello").to_witness())],
       ..default()
     });
@@ -4997,7 +4997,7 @@ mod tests {
       .build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/foo", "hello").to_witness())],
       ..default()
     });
@@ -5019,7 +5019,7 @@ mod tests {
       .build();
     server.mine_blocks(1);
 
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/foo", "hello").to_witness())],
       ..default()
     });
@@ -5047,7 +5047,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/foo", "hello").to_witness())],
       ..default()
     });
@@ -5081,7 +5081,7 @@ mod tests {
       .build();
     server.mine_blocks(1);
 
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/foo", "hello").to_witness())],
       ..default()
     });
@@ -5103,7 +5103,7 @@ mod tests {
       .build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(
         1,
         0,
@@ -5137,7 +5137,7 @@ mod tests {
       .build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(
         1,
         0,
@@ -5168,7 +5168,7 @@ mod tests {
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/foo", "hello").to_witness())],
       ..default()
     });
@@ -5215,7 +5215,7 @@ mod tests {
 
     for i in 0..101 {
       server.mine_blocks(1);
-      server.core.broadcast_tx(TransactionTemplate {
+      server.core.broadcast_template(TransactionTemplate {
         inputs: &[(i + 1, 0, 0, inscription("text/foo", "hello").to_witness())],
         ..default()
       });
@@ -5239,7 +5239,7 @@ mod tests {
 
     for i in 0..101 {
       server.mine_blocks(1);
-      server.core.broadcast_tx(TransactionTemplate {
+      server.core.broadcast_template(TransactionTemplate {
         inputs: &[(i + 1, 0, 0, inscription("text/foo", "hello").to_witness())],
         ..default()
       });
@@ -5267,7 +5267,7 @@ mod tests {
       server.mine_blocks(1);
 
       parent_ids.push(InscriptionId {
-        txid: server.core.broadcast_tx(TransactionTemplate {
+        txid: server.core.broadcast_template(TransactionTemplate {
           inputs: &[(i + 1, 0, 0, inscription("text/plain", "hello").to_witness())],
           ..default()
         }),
@@ -5278,7 +5278,7 @@ mod tests {
     for (i, parent_id) in parent_ids.iter().enumerate().take(101) {
       server.mine_blocks(1);
 
-      server.core.broadcast_tx(TransactionTemplate {
+      server.core.broadcast_template(TransactionTemplate {
         inputs: &[
           (i + 2, 1, 0, Default::default()),
           (
@@ -5385,7 +5385,7 @@ next
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let parent_txid = server.core.broadcast_tx(TransactionTemplate {
+    let parent_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
       ..default()
     });
@@ -5397,7 +5397,7 @@ next
       index: 0,
     };
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (
           2,
@@ -5451,7 +5451,7 @@ next
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let parent_txid = server.core.broadcast_tx(TransactionTemplate {
+    let parent_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
       ..default()
     });
@@ -5469,7 +5469,7 @@ next
       ".*<h3>No children</h3>.*",
     );
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (
           2,
@@ -5504,7 +5504,7 @@ next
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let parent_txid = server.core.broadcast_tx(TransactionTemplate {
+    let parent_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
       ..default()
     });
@@ -5516,7 +5516,7 @@ next
       index: 0,
     };
 
-    let _txid = server.core.broadcast_tx(TransactionTemplate {
+    let _txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (
           2,
@@ -5606,7 +5606,7 @@ next
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let parent_txid = server.core.broadcast_tx(TransactionTemplate {
+    let parent_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
       ..default()
     });
@@ -5618,7 +5618,7 @@ next
       index: 0,
     };
 
-    let child_txid = server.core.broadcast_tx(TransactionTemplate {
+    let child_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (
           2,
@@ -5687,12 +5687,12 @@ next
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(2);
 
-    let parent_a_txid = server.core.broadcast_tx(TransactionTemplate {
+    let parent_a_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
       ..default()
     });
 
-    let parent_b_txid = server.core.broadcast_tx(TransactionTemplate {
+    let parent_b_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, inscription("text/plain", "hello").to_witness())],
       ..default()
     });
@@ -5709,7 +5709,7 @@ next
       index: 0,
     };
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (
           3,
@@ -5754,7 +5754,7 @@ next
     for i in 0..101 {
       parent_ids.push(
         InscriptionId {
-          txid: server.core.broadcast_tx(TransactionTemplate {
+          txid: server.core.broadcast_template(TransactionTemplate {
             inputs: &[(i + 1, 0, 0, inscription("text/plain", "hello").to_witness())],
             ..default()
           }),
@@ -5784,7 +5784,7 @@ next
       ),
     );
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &inputs,
       ..default()
     });
@@ -5817,7 +5817,7 @@ next
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(2);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (1, 0, 0, inscription("text/plain", "hello").to_witness()),
         (2, 0, 0, inscription("text/plain", "cursed").to_witness()),
@@ -5870,7 +5870,7 @@ next
 
     server.mine_blocks(2);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (1, 0, 0, Witness::default()),
         (2, 0, 0, inscription("text/plain", "cursed").to_witness()),
@@ -5909,7 +5909,7 @@ next
 
     server.mine_blocks(110);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (1, 0, 0, Witness::default()),
         (2, 0, 0, inscription("text/plain", "cursed").to_witness()),
@@ -5949,7 +5949,7 @@ next
 
     server.mine_blocks(2);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "foo").to_witness())],
       ..default()
     });
@@ -5985,7 +5985,7 @@ next
 
     server.mine_blocks(2);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "foo").to_witness())],
       ..default()
     });
@@ -6021,7 +6021,7 @@ next
 
     server.mine_blocks(9);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(9, 0, 0, inscription("text/plain", "foo").to_witness())],
       ..default()
     });
@@ -6054,14 +6054,14 @@ next
 
     server.mine_blocks(1);
 
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "foo").to_witness())],
       ..default()
     });
 
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 1, 0, inscription("text/plain", "bar").to_witness())],
       ..default()
     });
@@ -6126,7 +6126,7 @@ next
 
     let witness = Witness::from_slice(&[script.into_bytes(), Vec::new()]);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, witness)],
       ..default()
     });
@@ -6183,7 +6183,7 @@ next
     }
     .into();
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[
         (1, 0, 0, inscription("text/plain", "foo").to_witness()),
         (2, 0, 0, cursed_inscription.to_witness()),
@@ -6236,7 +6236,7 @@ next
 
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, envelope(&[b"ord", &[128], &[0]]))],
       ..default()
     });
@@ -6272,7 +6272,7 @@ next
 
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "foo").to_witness())],
       ..default()
     });
@@ -6299,7 +6299,7 @@ next
       ),
     );
 
-    server.core.broadcast_tx(TransactionTemplate {
+    server.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 1, 0, Default::default())],
       fee: 50 * COIN_VALUE,
       ..default()
@@ -6350,7 +6350,7 @@ next
 
     server.mine_blocks(1);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "foo").to_witness())],
       ..default()
     });
@@ -6361,7 +6361,7 @@ next
     ids.push(InscriptionId { txid, index: 0 });
 
     for i in 1..111 {
-      let txid = server.core.broadcast_tx(TransactionTemplate {
+      let txid = server.core.broadcast_template(TransactionTemplate {
         inputs: &[(i + 1, 1, 0, inscription("text/plain", "foo").to_witness())],
         ..default()
       });
@@ -6432,7 +6432,7 @@ next
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let parent_txid = server.core.broadcast_tx(TransactionTemplate {
+    let parent_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
       ..default()
     });
@@ -6468,7 +6468,7 @@ next
 
     let witness = Witness::from_slice(&[builder.into_bytes(), Vec::new()]);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, witness), (2, 1, 0, Default::default())],
       ..default()
     });
@@ -6508,7 +6508,7 @@ next
     let mut inputs = Vec::new();
     for i in 0..111 {
       parent_ids.push(InscriptionId {
-        txid: server.core.broadcast_tx(TransactionTemplate {
+        txid: server.core.broadcast_template(TransactionTemplate {
           inputs: &[(i + 1, 0, 0, inscription("text/plain", "hello").to_witness())],
           ..default()
         }),
@@ -6536,7 +6536,7 @@ next
       ),
     );
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &inputs,
       ..default()
     });
@@ -6573,7 +6573,7 @@ next
     let server = TestServer::builder().chain(Chain::Regtest).build();
     server.mine_blocks(1);
 
-    let parent_txid = server.core.broadcast_tx(TransactionTemplate {
+    let parent_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
       ..default()
     });
@@ -6610,7 +6610,7 @@ next
 
     let witness = Witness::from_slice(&[builder.into_bytes(), Vec::new()]);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, witness), (2, 1, 0, Default::default())],
       ..default()
     });
@@ -6677,7 +6677,7 @@ next
     }
 
     for i in 0..101 {
-      server.core.broadcast_tx(TransactionTemplate {
+      server.core.broadcast_template(TransactionTemplate {
         inputs: &[(i + 1, 0, 0, inscription("text/foo", "hello").to_witness())],
         ..default()
       });
@@ -6743,7 +6743,7 @@ next
       ..default()
     };
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, delegate.to_witness())],
       ..default()
     });
@@ -6757,7 +6757,7 @@ next
       ..default()
     };
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, inscription.to_witness())],
       ..default()
     });
@@ -6808,7 +6808,7 @@ next
       ..default()
     };
 
-    let delegate_txid = server.core.broadcast_tx(TransactionTemplate {
+    let delegate_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, delegate.to_witness())],
       ..default()
     });
@@ -6827,7 +6827,7 @@ next
       ..default()
     };
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, inscription.to_witness())],
       ..default()
     });
@@ -6851,7 +6851,7 @@ next
       ..default()
     };
 
-    let normal_txid = server.core.broadcast_tx(TransactionTemplate {
+    let normal_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(3, 0, 0, normal_inscription.to_witness())],
       ..default()
     });
@@ -6883,7 +6883,7 @@ next
       ..default()
     };
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription.to_witness())],
       ..default()
     });
@@ -6921,7 +6921,7 @@ next
       ..default()
     };
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription.to_witness())],
       ..default()
     });
@@ -6962,7 +6962,7 @@ next
 
     server.mine_blocks(1);
 
-    let parent_txid = server.core.broadcast_tx(TransactionTemplate {
+    let parent_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
       ..default()
     });
@@ -6998,7 +6998,7 @@ next
 
     let witness = Witness::from_slice(&[builder.into_bytes(), Vec::new()]);
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 0, 0, witness), (2, 1, 0, Default::default())],
       ..default()
     });
@@ -7042,7 +7042,7 @@ next
       ..default()
     };
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription.to_witness())],
       ..default()
     });
@@ -7232,7 +7232,7 @@ next
 
     core.mine_blocks(1);
 
-    let txid = core.broadcast_tx(TransactionTemplate {
+    let txid = core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription("text/foo", "hello").to_witness())],
       ..default()
     });
@@ -7273,7 +7273,7 @@ next
       ..default()
     };
 
-    let txid = server.core.broadcast_tx(TransactionTemplate {
+    let txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription.to_witness())],
       outputs: 0,
       op_return_index: Some(0),
@@ -7326,7 +7326,7 @@ next
       ..default()
     };
 
-    let create_txid = server.core.broadcast_tx(TransactionTemplate {
+    let create_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(1, 0, 0, inscription.to_witness())],
       outputs: 1,
       ..default()
@@ -7368,7 +7368,7 @@ next
       }
     );
 
-    let transfer_txid = server.core.broadcast_tx(TransactionTemplate {
+    let transfer_txid = server.core.broadcast_template(TransactionTemplate {
       inputs: &[(2, 1, 0, Default::default())],
       fee: 0,
       outputs: 0,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1583,11 +1583,10 @@ impl Server {
         };
       };
 
-      let inscription_override = inscription.delegates().iter().find_map(|delegate| {
-        index
-          .get_inscription_by_id(*delegate)
-          .unwrap_or(None)
-      });
+      let inscription_override = inscription
+        .delegates()
+        .iter()
+        .find_map(|delegate| index.get_inscription_by_id(*delegate).unwrap_or(None));
 
       inscription = inscription_override.unwrap_or(inscription);
 
@@ -1709,11 +1708,10 @@ impl Server {
         .get_inscription_by_id(inscription_id)?
         .ok_or_not_found(|| format!("inscription {inscription_id}"))?;
 
-      let inscription_override = inscription.delegates().iter().find_map(|delegate| {
-        index
-          .get_inscription_by_id(*delegate)
-          .unwrap_or(None)
-      });
+      let inscription_override = inscription
+        .delegates()
+        .iter()
+        .find_map(|delegate| index.get_inscription_by_id(*delegate).unwrap_or(None));
 
       inscription = inscription_override.unwrap_or(inscription);
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -6875,34 +6875,33 @@ next
       // test with first delegate not mined yet
       let delegate = mined_delegates[0];
 
-      server.assert_response_regex(
-        format!("/inscription/{id}"),
-        StatusCode::OK,
-        format!(
-          ".*<h1>Inscription 1</h1>.*
-        <dl>
-          <dt>id</dt>
-          <dd class=collapse>{id}</dd>
-          .*
-          <dt>delegate</dt>
-          <dd><a href=/inscription/{delegate}>{delegate}</a></dd>
-          .*
-        </dl>.*"
-        )
-        .unindent(),
-      );
+      // server.assert_response_regex(
+      //   format!("/inscription/{id}"),
+      //   StatusCode::OK,
+      //   format!(
+      //     ".*<h1>Inscription 1</h1>.*
+      //   <dl>
+      //     <dt>id</dt>
+      //     <dd class=collapse>{id}</dd>
+      //     .*
+      //     <dt>delegate</dt>
+      //     <dd><a href=/inscription/{delegate}>{delegate}</a></dd>
+      //     .*
+      //   </dl>.*"
+      //   )
+      //     .unindent(),
+      // );
 
       server.assert_response(format!("/content/{id}"), StatusCode::OK, "foo");
-
       server.assert_response(format!("/preview/{id}"), StatusCode::OK, "foo");
 
-      assert_eq!(
-        server
-          .get_json::<api::InscriptionRecursive>(format!("/r/inscription/{id}"))
-          .delegates
-          .first(),
-        Some(&delegate)
-      );
+      // assert_eq!(
+      //   server
+      //     .get_json::<api::InscriptionRecursive>(format!("/r/inscription/{id}"))
+      //     .delegates
+      //     .first(),
+      //   Some(&delegate)
+      // );
     }
 
     server.core.broadcast_tx(unmined_delegate_tx);
@@ -6929,9 +6928,9 @@ next
         .unindent(),
       );
 
-      server.assert_response(format!("/content/{id}"), StatusCode::OK, "foo");
+      server.assert_response(format!("/content/{id}"), StatusCode::OK, "baz");
 
-      server.assert_response(format!("/preview/{id}"), StatusCode::OK, "foo");
+      server.assert_response(format!("/preview/{id}"), StatusCode::OK, "baz");
 
       assert_eq!(
         server

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -6866,7 +6866,7 @@ next
             body: Some("charlie".into()),
             ..default()
           }
-            .to_witness(),
+          .to_witness(),
         )],
         ..default()
       });
@@ -6881,7 +6881,7 @@ next
             body: Some("delta".into()),
             ..default()
           }
-            .to_witness(),
+          .to_witness(),
         )],
         ..default()
       });
@@ -6902,13 +6902,12 @@ next
       ]
     };
 
-
     let inscription = Inscription {
       delegates: vec![
         unmined_delegates[0].value(), // charlie
         unmined_delegates[1].value(), // delta
-        mined_delegates[0].value(), // alpha
-        mined_delegates[1].value(), // bravo
+        mined_delegates[0].value(),   // alpha
+        mined_delegates[1].value(),   // bravo
       ],
       ..default()
     };
@@ -6973,7 +6972,9 @@ next
       Some(&unmined_delegates[0])
     );
 
-    server.core.broadcast_tx(unmined_delegate_transactions[1].clone());
+    server
+      .core
+      .broadcast_tx(unmined_delegate_transactions[1].clone());
     server.mine_blocks(1);
 
     assert_eq!(
@@ -6983,7 +6984,9 @@ next
       Some("text/plain".to_string())
     );
 
-    server.core.broadcast_tx(unmined_delegate_transactions[0].clone());
+    server
+      .core
+      .broadcast_tx(unmined_delegate_transactions[0].clone());
     server.mine_blocks(1);
 
     server.assert_response(format!("/content/{id}"), StatusCode::OK, "charlie");

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -6838,7 +6838,7 @@ next
     server.mine_blocks(1);
 
     let unmined_inscription = Inscription {
-      content_type: Some("application/json".into()),
+      content_type: Some("text/html".into()),
       body: Some("baz".into()),
       ..default()
     };
@@ -6911,22 +6911,22 @@ next
       // test with first delegate not mined yet
       let delegate = unmined_delegate;
 
-      server.assert_response_regex(
-        format!("/inscription/{id}"),
-        StatusCode::OK,
-        format!(
-          ".*<h1>Inscription 1</h1>.*
-        <dl>
-          <dt>id</dt>
-          <dd class=collapse>{id}</dd>
-          .*
-          <dt>delegate</dt>
-          <dd><a href=/inscription/{delegate}>{delegate}</a></dd>
-          .*
-        </dl>.*"
-        )
-        .unindent(),
-      );
+      // server.assert_response_regex(
+      //   format!("/inscription/{id}"),
+      //   StatusCode::OK,
+      //   format!(
+      //     ".*<h1>Inscription 1</h1>.*
+      //   <dl>
+      //     <dt>id</dt>
+      //     <dd class=collapse>{id}</dd>
+      //     .*
+      //     <dt>delegate</dt>
+      //     <dd><a href=/inscription/{delegate}>{delegate}</a></dd>
+      //     .*
+      //   </dl>.*"
+      //   )
+      //     .unindent(),
+      // );
 
       server.assert_response(format!("/content/{id}"), StatusCode::OK, "baz");
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -6824,8 +6824,14 @@ next
       });
 
       [
-        InscriptionId { txid: txid_a, index: 0 },
-        InscriptionId { txid: txid_b, index: 0 },
+        InscriptionId {
+          txid: txid_a,
+          index: 0,
+        },
+        InscriptionId {
+          txid: txid_b,
+          index: 0,
+        },
       ]
     };
 
@@ -6842,10 +6848,17 @@ next
       ..default()
     });
 
-    let unmined_delegate = InscriptionId { txid: unmined_delegate_tx.compute_txid(), index: 0 };
+    let unmined_delegate = InscriptionId {
+      txid: unmined_delegate_tx.compute_txid(),
+      index: 0,
+    };
 
     let inscription = Inscription {
-      delegates: vec![unmined_delegate.value(), mined_delegates[0].value(), mined_delegates[1].value()],
+      delegates: vec![
+        unmined_delegate.value(),
+        mined_delegates[0].value(),
+        mined_delegates[1].value(),
+      ],
       ..default()
     };
 
@@ -6858,7 +6871,8 @@ next
 
     let id = InscriptionId { txid, index: 0 };
 
-    { // test with first delegate not mined yet
+    {
+      // test with first delegate not mined yet
       let delegate = mined_delegates[0];
 
       server.assert_response_regex(
@@ -6875,7 +6889,7 @@ next
           .*
         </dl>.*"
         )
-          .unindent(),
+        .unindent(),
       );
 
       server.assert_response(format!("/content/{id}"), StatusCode::OK, "foo");
@@ -6894,7 +6908,8 @@ next
     server.core.broadcast_tx(unmined_delegate_tx);
     server.mine_blocks(1);
 
-    { // test with first delegate not mined yet
+    {
+      // test with first delegate not mined yet
       let delegate = unmined_delegate;
 
       server.assert_response_regex(
@@ -6911,7 +6926,7 @@ next
           .*
         </dl>.*"
         )
-          .unindent(),
+        .unindent(),
       );
 
       server.assert_response(format!("/content/{id}"), StatusCode::OK, "foo");
@@ -6927,7 +6942,6 @@ next
       );
     }
   }
-
 
   #[test]
   fn undelegated_content() {

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -71,7 +71,7 @@ impl Inscribe {
       inscriptions: vec![Inscription::new(
         chain,
         self.shared.compress,
-        self.delegate,
+        self.delegate.into_iter().collect(),
         WalletCommand::parse_metadata(self.cbor_metadata, self.json_metadata)?,
         self.metaprotocol,
         self.parent.into_iter().collect(),

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -535,4 +535,138 @@ mod tests {
       .unindent()
     );
   }
+
+  #[test]
+  fn single_delegate() {
+    assert_regex_match!(
+      InscriptionHtml {
+        fee: 1,
+        inscription: Inscription {
+          delegates: vec![inscription_id(2).value()],
+          ..inscription("text/plain;charset=utf-8", "HELLOWORLD")
+        },
+        id: inscription_id(1),
+        number: 1,
+        satpoint: satpoint(1, 0),
+        ..default()
+      },
+      "
+        <h1>Inscription 1</h1>
+        <div class=inscription>
+        <div>❮</div>
+        <iframe .* src=/preview/1{64}i1></iframe>
+        <div>❯</div>
+        </div>
+        <dl>
+          <dt>id</dt>
+          <dd class=collapse>1{64}i1</dd>
+          <dt>delegates</dt>
+          <dd><a href=/inscription/2{64}i2>2{64}i2</a></dd>
+          <dt>preview</dt>
+          <dd><a href=/preview/1{64}i1>link</a></dd>
+          <dt>content</dt>
+          <dd><a href=/content/1{64}i1>link</a></dd>
+          <dt>content length</dt>
+          <dd>10 bytes</dd>
+          <dt>content type</dt>
+          <dd>text/plain;charset=utf-8</dd>
+          <dt>timestamp</dt>
+          <dd><time>1970-01-01 00:00:00 UTC</time></dd>
+          <dt>height</dt>
+          <dd><a href=/block/0>0</a></dd>
+          <dt>fee</dt>
+          <dd>1</dd>
+          <dt>reveal transaction</dt>
+          <dd><a class=collapse href=/tx/1{64}>1{64}</a></dd>
+          <dt>location</dt>
+          <dd><a class=collapse href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>
+          <dt>output</dt>
+          <dd><a class=collapse href=/output/1{64}:1>1{64}:1</a></dd>
+          <dt>offset</dt>
+          <dd>0</dd>
+          <dt>details</dt>
+          <dd>
+            <details>
+              <summary>...</summary>
+              <dl>
+                <dt>ethereum teleburn address</dt>
+                <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
+              </dl>
+            </details>
+          </dd>
+        </dl>
+      "
+      .unindent()
+    );
+  }
+
+  #[test]
+  fn multiple_delegate() {
+    assert_regex_match!(
+      InscriptionHtml {
+        fee: 1,
+        inscription: Inscription {
+          delegates: vec![
+            inscription_id(2).value(),
+            inscription_id(3).value(),
+            inscription_id(4).value()
+          ],
+          ..inscription("text/plain;charset=utf-8", "HELLOWORLD")
+        },
+        id: inscription_id(1),
+        number: 1,
+        satpoint: satpoint(1, 0),
+        ..default()
+      },
+      "
+        <h1>Inscription 1</h1>
+        <div class=inscription>
+        <div>❮</div>
+        <iframe .* src=/preview/1{64}i1></iframe>
+        <div>❯</div>
+        </div>
+        <dl>
+          <dt>id</dt>
+          <dd class=collapse>1{64}i1</dd>
+          <dt>delegates</dt>
+          <dd><a href=/inscription/2{64}i2>2{64}i2</a></dd>
+          <dd><a href=/inscription/3{64}i3>3{64}i3</a></dd>
+          <dd><a href=/inscription/4{64}i4>4{64}i4</a></dd>
+          <dt>preview</dt>
+          <dd><a href=/preview/1{64}i1>link</a></dd>
+          <dt>content</dt>
+          <dd><a href=/content/1{64}i1>link</a></dd>
+          <dt>content length</dt>
+          <dd>10 bytes</dd>
+          <dt>content type</dt>
+          <dd>text/plain;charset=utf-8</dd>
+          <dt>timestamp</dt>
+          <dd><time>1970-01-01 00:00:00 UTC</time></dd>
+          <dt>height</dt>
+          <dd><a href=/block/0>0</a></dd>
+          <dt>fee</dt>
+          <dd>1</dd>
+          <dt>reveal transaction</dt>
+          <dd><a class=collapse href=/tx/1{64}>1{64}</a></dd>
+          <dt>location</dt>
+          <dd><a class=collapse href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>
+          <dt>output</dt>
+          <dd><a class=collapse href=/output/1{64}:1>1{64}:1</a></dd>
+          <dt>offset</dt>
+          <dd>0</dd>
+          <dt>details</dt>
+          <dd>
+            <details>
+              <summary>...</summary>
+              <dl>
+                <dt>ethereum teleburn address</dt>
+                <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
+              </dl>
+            </details>
+          </dd>
+        </dl>
+      "
+      .unindent()
+    );
+  }
 }

--- a/src/wallet/batch/file.rs
+++ b/src/wallet/batch/file.rs
@@ -134,7 +134,7 @@ impl File {
       inscriptions.push(Inscription::new(
         wallet.chain(),
         compress,
-        entry.delegate,
+        entry.delegate.into_iter().collect(),
         entry.metadata()?,
         entry.metaprotocol.clone(),
         self.parents.clone(),

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -86,9 +86,11 @@
   <dd>{{ metaprotocol }}</dd>
 %% }
 %% if self.inscription.content_length().is_some() || !self.inscription.delegates().is_empty() {
-%% if let Some(delegate) = self.inscription.delegates().first() {
-  <dt>delegate</dt>
+%% if !self.inscription.delegates().is_empty() {
+  <dt>delegates</dt>
+%% for delegate in self.inscription.delegates() {
   <dd><a href=/inscription/{{ delegate }}>{{ delegate }}</a></dd>
+%% }
 %% }
   <dt>preview</dt>
   <dd><a href=/preview/{{self.id}}>link</a></dd>

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -85,8 +85,8 @@
   <dt>metaprotocol</dt>
   <dd>{{ metaprotocol }}</dd>
 %% }
-%% if self.inscription.content_length().is_some() || self.inscription.delegate().is_some() {
-%% if let Some(delegate) = self.inscription.delegate() {
+%% if self.inscription.content_length().is_some() || !self.inscription.delegates().is_empty() {
+%% if let Some(delegate) = self.inscription.delegates().first() {
   <dt>delegate</dt>
   <dd><a href=/inscription/{{ delegate }}>{{ delegate }}</a></dd>
 %% }

--- a/tests/json_api.rs
+++ b/tests/json_api.rs
@@ -264,7 +264,7 @@ fn get_inscriptions() {
     core.mine_blocks(1);
     core.mine_blocks(1);
 
-    let txid = core.broadcast_tx(TransactionTemplate {
+    let txid = core.broadcast_template(TransactionTemplate {
       inputs: &[
         (i * 3 + 1, 0, 0, witness.clone()),
         (i * 3 + 2, 0, 0, witness.clone()),
@@ -311,7 +311,7 @@ fn get_inscriptions_in_block() {
 
   let envelope = envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]);
 
-  let txid = core.broadcast_tx(TransactionTemplate {
+  let txid = core.broadcast_template(TransactionTemplate {
     inputs: &[
       (1, 0, 0, envelope.clone()),
       (2, 0, 0, envelope.clone()),
@@ -322,14 +322,14 @@ fn get_inscriptions_in_block() {
 
   core.mine_blocks(1);
 
-  let _ = core.broadcast_tx(TransactionTemplate {
+  let _ = core.broadcast_template(TransactionTemplate {
     inputs: &[(4, 0, 0, envelope.clone()), (5, 0, 0, envelope.clone())],
     ..default()
   });
 
   core.mine_blocks(1);
 
-  let _ = core.broadcast_tx(TransactionTemplate {
+  let _ = core.broadcast_template(TransactionTemplate {
     inputs: &[(6, 0, 0, envelope.clone())],
     ..default()
   });
@@ -363,7 +363,7 @@ fn get_output() {
 
   let envelope = envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]);
 
-  let txid = core.broadcast_tx(TransactionTemplate {
+  let txid = core.broadcast_template(TransactionTemplate {
     inputs: &[
       (1, 0, 0, envelope.clone()),
       (2, 0, 0, envelope.clone()),
@@ -724,7 +724,7 @@ fn get_decode_tx() {
 
   let envelope = envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[], b"bar"]);
 
-  let txid = core.broadcast_tx(TransactionTemplate {
+  let txid = core.broadcast_template(TransactionTemplate {
     inputs: &[(1, 0, 0, envelope.clone())],
     ..default()
   });

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -506,7 +506,7 @@ fn recursive_inscription_endpoint() {
       charms: vec![Charm::Coin, Charm::Uncommon],
       content_type: Some("text/plain;charset=utf-8".to_string()),
       content_length: Some(3),
-      delegate: None,
+      delegates: Vec::new(),
       fee: 138,
       height: 2,
       id: inscription.id,

--- a/tests/wallet/batch_command.rs
+++ b/tests/wallet/batch_command.rs
@@ -1106,7 +1106,7 @@ inscriptions:
 
   ord.assert_response_regex(
     format!("/inscription/{}", inscribe.inscriptions[0].id),
-    format!(r#".*<dt>delegate</dt>\s*<dd><a href=/inscription/{delegate}>{delegate}</a></dd>.*"#,),
+    format!(r#".*<dt>delegates</dt>\s*<dd><a href=/inscription/{delegate}>{delegate}</a></dd>.*"#,),
   );
 
   ord.assert_response(format!("/content/{}", inscribe.inscriptions[0].id), "FOO");

--- a/tests/wallet/burn.rs
+++ b/tests/wallet/burn.rs
@@ -79,7 +79,7 @@ fn runic_outputs_are_protected() {
 
   core.mine_blocks(2);
 
-  let txid = core.broadcast_tx(TransactionTemplate {
+  let txid = core.broadcast_template(TransactionTemplate {
     inputs: &[
       // send rune and inscription to the same output
       (height as usize, 2, 0, Witness::new()),
@@ -190,7 +190,7 @@ fn cannot_burn_inscription_sharing_utxo_with_another_inscription() {
   let (inscription2, _) = inscribe_with_postage(&core, &ord, Some(1000));
   let height2 = core.height();
 
-  let txid = core.broadcast_tx(TransactionTemplate {
+  let txid = core.broadcast_template(TransactionTemplate {
     inputs: &[
       // send all 3 inscriptions on a single output
       (height0 as usize, 2, 0, Witness::new()),

--- a/tests/wallet/inscribe.rs
+++ b/tests/wallet/inscribe.rs
@@ -1168,7 +1168,7 @@ fn file_inscribe_with_delegate_inscription() {
 
   ord.assert_response_regex(
     format!("/inscription/{}", inscribe.inscriptions[0].id),
-    format!(r#".*<dt>delegate</dt>\s*<dd><a href=/inscription/{delegate}>{delegate}</a></dd>.*"#,),
+    format!(r#".*<dt>delegates</dt>\s*<dd><a href=/inscription/{delegate}>{delegate}</a></dd>.*"#,),
   );
 
   ord.assert_response(format!("/content/{}", inscribe.inscriptions[0].id), "FOO");
@@ -1197,7 +1197,7 @@ fn file_inscribe_with_only_delegate() {
 
   ord.assert_response_regex(
     format!("/inscription/{}", inscribe.inscriptions[0].id),
-    format!(r#".*<dt>delegate</dt>\s*<dd><a href=/inscription/{delegate}>{delegate}</a></dd>.*"#,),
+    format!(r#".*<dt>delegates</dt>\s*<dd><a href=/inscription/{delegate}>{delegate}</a></dd>.*"#,),
   );
 
   ord.assert_response(format!("/content/{}", inscribe.inscriptions[0].id), "FOO");

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -878,7 +878,7 @@ fn sending_rune_creates_change_output_for_non_outgoing_runes() {
     .next()
     .unwrap();
 
-  let merge = core.broadcast_tx(TransactionTemplate {
+  let merge = core.broadcast_template(TransactionTemplate {
     inputs: &[(a_block, a_tx, 1, default()), (b_block, b_tx, 1, default())],
     recipient: Some(address.require_network(Network::Regtest).unwrap()),
     ..default()


### PR DESCRIPTION
This PR modifies server behavior to return the content of the first delegate it finds, absent which it returns the inscription's own content.

https://github.com/ordinals/ord/issues/4114