### PR TITLE
Make edicts stricter

### DIFF
--- a/src/index/updater/rune_updater.rs
+++ b/src/index/updater/rune_updater.rs
@@ -11,7 +11,7 @@ struct Claim {
 struct Etched {
   balance: u128,
   divisibility: u8,
-  id: u128,
+  id: RuneId,
   mint: Option<MintEntry>,
   rune: Rune,
   spacers: u32,
@@ -42,7 +42,12 @@ pub(super) struct RuneUpdater<'a, 'db, 'tx> {
 }
 
 impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
-  pub(super) fn index_runes(&mut self, index: usize, tx: &Transaction, txid: Txid) -> Result<()> {
+  pub(super) fn index_runes(
+    &mut self,
+    tx_index: usize,
+    tx: &Transaction,
+    txid: Txid,
+  ) -> Result<()> {
     let runestone = Runestone::from_transaction(tx);
 
     let mut unallocated = self.unallocated(tx)?;
@@ -58,7 +63,7 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
         .and_then(|default| usize::try_from(default).ok())
     });
 
-    let mut allocated: Vec<HashMap<u128, u128>> = vec![HashMap::new(); tx.output.len()];
+    let mut allocated: Vec<HashMap<RuneId, u128>> = vec![HashMap::new(); tx.output.len()];
 
     if let Some(runestone) = runestone {
       if let Some(claim) = runestone
@@ -74,7 +79,7 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
         update.supply += claim.limit;
       }
 
-      let mut etched = self.etched(index, tx, &runestone)?;
+      let mut etched = self.etched(tx_index, tx, &runestone)?;
 
       if !burn {
         for Edict { id, amount, output } in runestone.edicts {
@@ -82,12 +87,11 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
             continue;
           };
 
-          // Skip edicts not referring to valid outputs
-          if output > tx.output.len() {
-            continue;
-          }
+          // edicts with output values greater than the number of outputs
+          // should never be produced by the edict parser
+          assert!(output <= tx.output.len());
 
-          let (balance, id) = if id == 0 {
+          let (balance, id) = if id == RuneId::default() {
             // If this edict allocates new issuance runes, skip it
             // if no issuance was present, or if the issuance was invalid.
             // Additionally, replace ID 0 with the newly assigned ID, and
@@ -158,7 +162,7 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
       }
     }
 
-    let mut burned: HashMap<u128, u128> = HashMap::new();
+    let mut burned: HashMap<RuneId, u128> = HashMap::new();
 
     if burn {
       for (id, balance) in unallocated {
@@ -209,13 +213,13 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
 
       buffer.clear();
 
-      let mut balances = balances.into_iter().collect::<Vec<(u128, u128)>>();
+      let mut balances = balances.into_iter().collect::<Vec<(RuneId, u128)>>();
 
       // Sort balances by id so tests can assert balances in a fixed order
       balances.sort();
 
       for (id, balance) in balances {
-        varint::encode_to_vec(id, &mut buffer);
+        varint::encode_to_vec(id.into(), &mut buffer);
         varint::encode_to_vec(balance, &mut buffer);
       }
 
@@ -329,7 +333,7 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
 
   fn etched(
     &mut self,
-    index: usize,
+    tx_index: usize,
     tx: &Transaction,
     runestone: &Runestone,
   ) -> Result<Option<Etched>> {
@@ -364,7 +368,7 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
     // with 2**16 + 1 transactions, there is no test that checks that
     // an eching in a transaction with an out-of-bounds index is
     // ignored.
-    let Ok(index) = u16::try_from(index) else {
+    let Ok(index) = u16::try_from(tx_index) else {
       return Ok(None);
     };
 
@@ -379,7 +383,10 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
         u128::MAX
       },
       divisibility: etching.divisibility,
-      id: u128::from(self.height) << 16 | u128::from(index),
+      id: RuneId {
+        block: self.height,
+        tx: index,
+      },
       rune,
       spacers: etching.spacers,
       symbol: etching.symbol,
@@ -442,9 +449,9 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
     Ok(false)
   }
 
-  fn unallocated(&mut self, tx: &Transaction) -> Result<HashMap<u128, u128>> {
+  fn unallocated(&mut self, tx: &Transaction) -> Result<HashMap<RuneId, u128>> {
     // map of rune ID to un-allocated balance of that rune
-    let mut unallocated: HashMap<u128, u128> = HashMap::new();
+    let mut unallocated: HashMap<RuneId, u128> = HashMap::new();
 
     // increment unallocated runes with the runes in tx inputs
     for input in &tx.input {
@@ -459,7 +466,7 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
           i += len;
           let (balance, len) = varint::decode(&buffer[i..]);
           i += len;
-          *unallocated.entry(id).or_default() += balance;
+          *unallocated.entry(id.try_into().unwrap()).or_default() += balance;
         }
       }
     }

--- a/src/index/updater/rune_updater.rs
+++ b/src/index/updater/rune_updater.rs
@@ -71,7 +71,7 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
         .and_then(|id| self.claim(id).transpose())
         .transpose()?
       {
-        *unallocated.entry(claim.id.into()).or_default() += claim.limit;
+        *unallocated.entry(claim.id).or_default() += claim.limit;
 
         let update = self.updates.entry(claim.id).or_default();
 
@@ -262,11 +262,7 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
 
     // increment entries with burned runes
     for (id, amount) in burned {
-      self
-        .updates
-        .entry(RuneId::try_from(id).unwrap())
-        .or_default()
-        .burned += amount;
+      self.updates.entry(id).or_default().burned += amount;
     }
 
     Ok(())
@@ -283,7 +279,6 @@ impl<'a, 'db, 'tx> RuneUpdater<'a, 'db, 'tx> {
       symbol,
     } = etched;
 
-    let id = RuneId::try_from(id).unwrap();
     self.rune_to_id.insert(rune.0, id.store())?;
     self.transaction_id_to_rune.insert(&txid.store(), rune.0)?;
     let number = self.runes;

--- a/src/runes.rs
+++ b/src/runes.rs
@@ -611,7 +611,7 @@ mod tests {
   }
 
   #[test]
-  fn allocations_to_invalid_outputs_are_ignored() {
+  fn allocations_to_invalid_outputs_burn_runestone() {
     let context = Context::builder().arg("--index-runes").build();
 
     let (txid, id) = context.etch(
@@ -643,12 +643,12 @@ mod tests {
         RuneEntry {
           etching: txid,
           rune: Rune(RUNE),
-          supply: 100,
+          supply: 0,
           timestamp: id.block,
           ..Default::default()
         },
       )],
-      [(OutPoint { txid, vout: 0 }, vec![(id, 100)])],
+      [],
     );
   }
 

--- a/src/runes.rs
+++ b/src/runes.rs
@@ -132,7 +132,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -173,7 +173,7 @@ mod tests {
       context.etch(
         Runestone {
           edicts: vec![Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           }],
@@ -198,7 +198,7 @@ mod tests {
       let (txid, id) = context.etch(
         Runestone {
           edicts: vec![Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           }],
@@ -235,7 +235,7 @@ mod tests {
       context.etch(
         Runestone {
           edicts: vec![Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           }],
@@ -257,7 +257,7 @@ mod tests {
       let (txid, id) = context.etch(
         Runestone {
           edicts: vec![Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           }],
@@ -298,7 +298,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           }],
@@ -344,7 +344,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           }],
@@ -413,7 +413,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -453,12 +453,12 @@ mod tests {
       Runestone {
         edicts: vec![
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           },
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           },
@@ -495,12 +495,12 @@ mod tests {
       Runestone {
         edicts: vec![
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX / 2,
             output: 0,
           },
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           },
@@ -539,7 +539,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: 100,
           output: 0,
         }],
@@ -575,12 +575,12 @@ mod tests {
       Runestone {
         edicts: vec![
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 100,
             output: 0,
           },
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 100,
             output: 1,
           },
@@ -618,12 +618,12 @@ mod tests {
       Runestone {
         edicts: vec![
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 100,
             output: 0,
           },
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 100,
             output: 3,
           },
@@ -659,7 +659,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -738,7 +738,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -774,7 +774,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -827,7 +827,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           }],
@@ -865,7 +865,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -935,7 +935,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1004,7 +1004,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1069,7 +1069,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1145,7 +1145,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1221,7 +1221,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1293,7 +1293,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1362,7 +1362,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1392,7 +1392,7 @@ mod tests {
     context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1429,7 +1429,7 @@ mod tests {
     let (txid0, id0) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1465,7 +1465,7 @@ mod tests {
     let (txid1, id1) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1571,7 +1571,7 @@ mod tests {
     let (txid0, id0) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1607,7 +1607,7 @@ mod tests {
     let (txid1, id1) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1781,7 +1781,7 @@ mod tests {
     let (txid0, id0) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1817,7 +1817,7 @@ mod tests {
     let (txid1, id1) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -1942,7 +1942,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2010,7 +2010,7 @@ mod tests {
     let (txid0, id0) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2026,7 +2026,7 @@ mod tests {
     let (txid1, id1) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2091,7 +2091,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2130,7 +2130,7 @@ mod tests {
         Runestone {
           edicts: vec![
             Edict {
-              id: 0,
+              id: RuneId::default(),
               amount: 100,
               output: 0,
             },
@@ -2177,7 +2177,7 @@ mod tests {
     let (txid0, id0) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2213,7 +2213,7 @@ mod tests {
     let (txid1, id1) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2343,7 +2343,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX / 2,
           output: 0,
         }],
@@ -2422,7 +2422,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 1,
         }],
@@ -2458,7 +2458,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2494,12 +2494,12 @@ mod tests {
       Runestone {
         edicts: vec![
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           },
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 0,
             output: 1,
           },
@@ -2535,7 +2535,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: 0,
           output: 5,
         }],
@@ -2576,12 +2576,12 @@ mod tests {
       Runestone {
         edicts: vec![
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 1000,
             output: 0,
           },
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 0,
             output: 5,
           },
@@ -2635,12 +2635,12 @@ mod tests {
       Runestone {
         edicts: vec![
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 0,
             output: 5,
           },
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 1000,
             output: 0,
           },
@@ -2681,7 +2681,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: 1000,
           output: 5,
         }],
@@ -2722,12 +2722,12 @@ mod tests {
       Runestone {
         edicts: vec![
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX - 3000,
             output: 0,
           },
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 1000,
             output: 5,
           },
@@ -2768,12 +2768,12 @@ mod tests {
       Runestone {
         edicts: vec![
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: 1000,
             output: 5,
           },
           Edict {
-            id: 0,
+            id: RuneId::default(),
             amount: u128::MAX,
             output: 0,
           },
@@ -2817,7 +2817,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2906,7 +2906,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -3002,7 +3002,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -3098,7 +3098,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -3187,7 +3187,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -3283,7 +3283,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -3393,7 +3393,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -3430,7 +3430,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: 0,
           output: 0,
         }],
@@ -3465,7 +3465,7 @@ mod tests {
     let (txid0, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -3667,7 +3667,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: 1000,
             output: 0,
           }],
@@ -3712,7 +3712,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: 1000,
             output: 0,
           }],
@@ -3768,7 +3768,7 @@ mod tests {
           burn: true,
           claim: Some(id),
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: 1000,
             output: 0,
           }],
@@ -3860,7 +3860,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: 1000,
             output: 0,
           }],
@@ -3905,7 +3905,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: 1000,
             output: 0,
           }],
@@ -3953,7 +3953,7 @@ mod tests {
     let (txid, id) = context.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: 1000,
           output: 0,
         }],
@@ -3995,7 +3995,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: 1,
             output: 3,
           }],
@@ -4313,7 +4313,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: 1000,
             output: 0,
           }],
@@ -4358,7 +4358,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: 1000,
             output: 0,
           }],
@@ -4441,7 +4441,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: 0,
             output: 3,
           }],
@@ -4505,7 +4505,7 @@ mod tests {
           ..Default::default()
         }),
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: 2000,
           output: 0,
         }],
@@ -4575,7 +4575,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: MAX_LIMIT + 1,
             output: 0,
           }],
@@ -4669,7 +4669,7 @@ mod tests {
           ..Default::default()
         }),
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: 2000,
           output: 0,
         }],
@@ -4707,7 +4707,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: u128::from(id),
+            id,
             amount: 2000,
             output: 0,
           }],
@@ -4798,17 +4798,17 @@ mod tests {
         Runestone {
           edicts: vec![
             Edict {
-              id: u128::from(id),
+              id,
               amount: 500,
               output: 0,
             },
             Edict {
-              id: u128::from(id),
+              id,
               amount: 500,
               output: 0,
             },
             Edict {
-              id: u128::from(id),
+              id,
               amount: 500,
               output: 0,
             },

--- a/src/runes.rs
+++ b/src/runes.rs
@@ -697,7 +697,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: id.into(),
+            id,
             amount: u128::MAX,
             output: 0,
           }],
@@ -1712,12 +1712,12 @@ mod tests {
         Runestone {
           edicts: vec![
             Edict {
-              id: id0.into(),
+              id: id0,
               amount: u128::MAX / 2,
               output: 1,
             },
             Edict {
-              id: id1.into(),
+              id: id1,
               amount: u128::MAX / 2,
               output: 1,
             },
@@ -1881,12 +1881,12 @@ mod tests {
         Runestone {
           edicts: vec![
             Edict {
-              id: id0.into(),
+              id: id0,
               amount: u128::MAX,
               output: 0,
             },
             Edict {
-              id: id1.into(),
+              id: id1,
               amount: u128::MAX,
               output: 0,
             },
@@ -2135,7 +2135,7 @@ mod tests {
               output: 0,
             },
             Edict {
-              id: id.into(),
+              id,
               amount: u128::MAX,
               output: 0,
             },
@@ -2274,12 +2274,12 @@ mod tests {
         Runestone {
           edicts: vec![
             Edict {
-              id: id0.into(),
+              id: id0,
               amount: u128::MAX,
               output: 0,
             },
             Edict {
-              id: id1.into(),
+              id: id1,
               amount: u128::MAX,
               output: 0,
             },
@@ -2381,7 +2381,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: id.into(),
+            id,
             amount: u128::MAX,
             output: 0,
           }],
@@ -2856,7 +2856,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: id.into(),
+            id,
             amount: 0,
             output: 3,
           }],
@@ -2946,12 +2946,12 @@ mod tests {
         Runestone {
           edicts: vec![
             Edict {
-              id: id.into(),
+              id,
               amount: 1000,
               output: 0,
             },
             Edict {
-              id: id.into(),
+              id,
               amount: 0,
               output: 3,
             },
@@ -3042,12 +3042,12 @@ mod tests {
         Runestone {
           edicts: vec![
             Edict {
-              id: id.into(),
+              id,
               amount: 0,
               output: 3,
             },
             Edict {
-              id: id.into(),
+              id,
               amount: 1000,
               output: 1,
             },
@@ -3137,7 +3137,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: id.into(),
+            id,
             amount: 1000,
             output: 3,
           }],
@@ -3227,12 +3227,12 @@ mod tests {
         Runestone {
           edicts: vec![
             Edict {
-              id: id.into(),
+              id,
               amount: u128::MAX - 2000,
               output: 0,
             },
             Edict {
-              id: id.into(),
+              id,
               amount: 1000,
               output: 5,
             },
@@ -3323,12 +3323,12 @@ mod tests {
         Runestone {
           edicts: vec![
             Edict {
-              id: id.into(),
+              id,
               amount: 1000,
               output: 5,
             },
             Edict {
-              id: id.into(),
+              id,
               amount: u128::MAX,
               output: 0,
             },
@@ -3504,7 +3504,7 @@ mod tests {
       op_return: Some(
         Runestone {
           edicts: vec![Edict {
-            id: id.into(),
+            id,
             amount: 0,
             output: 1,
           }],

--- a/src/runes/edict.rs
+++ b/src/runes/edict.rs
@@ -2,7 +2,24 @@ use super::*;
 
 #[derive(Default, Serialize, Debug, PartialEq, Copy, Clone)]
 pub struct Edict {
-  pub id: u128,
+  pub id: RuneId,
   pub amount: u128,
   pub output: u128,
+}
+
+impl Edict {
+  pub(crate) fn from_integers(
+    tx: &Transaction,
+    id: u128,
+    amount: u128,
+    output: u128,
+  ) -> Option<Self> {
+    let id = RuneId::try_from(id).ok()?;
+
+    if output > u128::try_from(tx.output.len()).ok()? {
+      return None;
+    }
+
+    Some(Self { id, amount, output })
+  }
 }

--- a/src/runes/rune_id.rs
+++ b/src/runes/rune_id.rs
@@ -1,6 +1,6 @@
 use {super::*, std::num::TryFromIntError};
 
-#[derive(Debug, PartialEq, Copy, Clone, Hash, Eq, Ord, PartialOrd)]
+#[derive(Debug, PartialEq, Copy, Clone, Hash, Eq, Ord, PartialOrd, Default)]
 pub struct RuneId {
   pub block: u32,
   pub tx: u16,

--- a/src/runes/runestone.rs
+++ b/src/runes/runestone.rs
@@ -758,6 +758,18 @@ mod tests {
   }
 
   #[test]
+  fn output_over_max_is_burn() {
+    pretty_assert_eq!(
+      decipher(&[Tag::Body.into(), 1, 2, 2]),
+      Runestone {
+        edicts: Vec::new(),
+        burn: true,
+        ..Default::default()
+      },
+    );
+  }
+
+  #[test]
   fn tag_with_no_value_is_ignored() {
     assert_eq!(
       decipher(&[Tag::Flags.into(), 1, Tag::Flags.into()]),

--- a/src/runes/runestone.rs
+++ b/src/runes/runestone.rs
@@ -1291,7 +1291,7 @@ mod tests {
     case(
       vec![Edict {
         amount: 0,
-        id: RuneId { block: 0, tx: 0 }.into(),
+        id: RuneId { block: 0, tx: 0 },
         output: 0,
       }],
       Some(Etching {
@@ -1305,7 +1305,7 @@ mod tests {
     case(
       vec![Edict {
         amount: u128::MAX,
-        id: RuneId { block: 0, tx: 0 }.into(),
+        id: RuneId { block: 0, tx: 0 },
         output: 0,
       }],
       Some(Etching {
@@ -1322,8 +1322,7 @@ mod tests {
         id: RuneId {
           block: 1_000_000,
           tx: u16::MAX,
-        }
-        .into(),
+        },
         output: 0,
       }],
       None,
@@ -1336,8 +1335,7 @@ mod tests {
         id: RuneId {
           block: 1_000_000,
           tx: u16::MAX,
-        }
-        .into(),
+        },
         output: 0,
       }],
       None,
@@ -1351,8 +1349,7 @@ mod tests {
           id: RuneId {
             block: 1_000_000,
             tx: u16::MAX,
-          }
-          .into(),
+          },
           output: 0,
         },
         Edict {
@@ -1360,8 +1357,7 @@ mod tests {
           id: RuneId {
             block: 1_000_000,
             tx: u16::MAX,
-          }
-          .into(),
+          },
           output: 0,
         },
       ],
@@ -1376,8 +1372,7 @@ mod tests {
           id: RuneId {
             block: 1_000_000,
             tx: u16::MAX,
-          }
-          .into(),
+          },
           output: 0,
         },
         Edict {
@@ -1385,8 +1380,7 @@ mod tests {
           id: RuneId {
             block: 1_000_000,
             tx: u16::MAX,
-          }
-          .into(),
+          },
           output: 0,
         },
         Edict {
@@ -1394,8 +1388,7 @@ mod tests {
           id: RuneId {
             block: 1_000_000,
             tx: u16::MAX,
-          }
-          .into(),
+          },
           output: 0,
         },
       ],
@@ -1410,8 +1403,7 @@ mod tests {
           id: RuneId {
             block: 1_000_000,
             tx: u16::MAX,
-          }
-          .into(),
+          },
           output: 0,
         };
         4
@@ -1427,8 +1419,7 @@ mod tests {
           id: RuneId {
             block: 1_000_000,
             tx: u16::MAX,
-          }
-          .into(),
+          },
           output: 0,
         };
         5
@@ -1444,8 +1435,7 @@ mod tests {
           id: RuneId {
             block: 0,
             tx: u16::MAX,
-          }
-          .into(),
+          },
           output: 0,
         };
         5
@@ -1461,8 +1451,7 @@ mod tests {
           id: RuneId {
             block: 1_000_000,
             tx: u16::MAX,
-          }
-          .into(),
+          },
           output: 0,
         };
         5

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -2540,7 +2540,7 @@ mod tests {
     server.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2620,7 +2620,7 @@ mod tests {
     server.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2661,7 +2661,7 @@ mod tests {
     let (txid, id) = server.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2723,7 +2723,7 @@ mod tests {
     let (txid, id) = server.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2832,7 +2832,7 @@ mod tests {
     let (txid, id) = server.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2932,7 +2932,7 @@ mod tests {
     let (txid, id) = server.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],
@@ -2991,7 +2991,7 @@ mod tests {
     let (txid, id) = server.etch(
       Runestone {
         edicts: vec![Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: u128::MAX,
           output: 0,
         }],

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -300,7 +300,7 @@ impl Send {
     let runestone = Runestone {
       edicts: vec![Edict {
         amount,
-        id: id.into(),
+        id,
         output: 2,
       }],
       ..Default::default()

--- a/src/test.rs
+++ b/src/test.rs
@@ -131,6 +131,10 @@ pub(crate) fn inscription_id(n: u32) -> InscriptionId {
   format!("{}i{n}", hex.repeat(64)).parse().unwrap()
 }
 
+pub(crate) fn rune_id(tx: u16) -> RuneId {
+  RuneId { block: 0, tx }
+}
+
 pub(crate) fn envelope(payload: &[&[u8]]) -> Witness {
   let mut builder = script::Builder::new()
     .push_opcode(opcodes::OP_FALSE)

--- a/src/wallet/inscribe/batch.rs
+++ b/src/wallet/inscribe/batch.rs
@@ -444,7 +444,7 @@ impl Batch {
         });
 
         edicts.push(Edict {
-          id: 0,
+          id: RuneId::default(),
           amount: premine,
           output: output.into(),
         });

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -1043,7 +1043,7 @@ fn sending_rune_creates_transaction_with_expected_runestone() {
       default_output: None,
       etching: None,
       edicts: vec![Edict {
-        id: etch.id.into(),
+        id: etch.id,
         amount: 750,
         output: 2
       }],


### PR DESCRIPTION
- Make `Edict::id` `RuneId` instead of `u128`
- If an edict has an invalid id, the runestone is a burn
- If an edict has an invalid output, the runestone is a burn