### PR TITLE
Downgrade to alpha

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -78,7 +78,7 @@ where
 
   fn superscript(&self) -> String {
     if self.config.chain == Chain::Mainnet {
-      "beta".into()
+      "alpha".into()
     } else {
       self.config.chain.to_string()
     }
@@ -148,7 +148,7 @@ mod tests {
   <body>
   <header>
     <nav>
-      <a href=/ title=home>Ordinals<sup>beta</sup></a>
+      <a href=/ title=home>Ordinals<sup>alpha</sup></a>
       .*
       <a href=/clock title=clock>.*</a>
       <a href=/rare.txt title=rare>.*</a>
@@ -178,7 +178,7 @@ mod tests {
         index_sats: true,
         ..Default::default()
       })),
-      r".*<nav>\s*<a href=/ title=home>Ordinals<sup>beta</sup></a>.*"
+      r".*<nav>\s*<a href=/ title=home>Ordinals<sup>alpha</sup></a>.*"
     );
   }
 
@@ -192,7 +192,7 @@ mod tests {
         index_sats: false,
         ..Default::default()
       })),
-      r".*<nav>\s*<a href=/ title=home>Ordinals<sup>beta</sup></a>.*<a href=/clock title=clock>.*</a>\s*<form action=/search.*",
+      r".*<nav>\s*<a href=/ title=home>Ordinals<sup>alpha</sup></a>.*<a href=/clock title=clock>.*</a>\s*<form action=/search.*",
     );
   }
 


### PR DESCRIPTION
Since runes functionality is new and complicated, downgrade from `beta` to `alpha` to help set expectations.