### PR TITLE
Allow runestone to be deserialized from json

### DIFF
--- a/src/runes/edict.rs
+++ b/src/runes/edict.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Default, Serialize, Debug, PartialEq, Copy, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 pub struct Edict {
   pub id: RuneId,
   pub amount: u128,

--- a/src/runes/etching.rs
+++ b/src/runes/etching.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Default, Serialize, Debug, PartialEq, Copy, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 pub struct Etching {
   pub divisibility: u8,
   pub mint: Option<Mint>,

--- a/src/runes/mint.rs
+++ b/src/runes/mint.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Default, Serialize, Debug, PartialEq, Copy, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 pub struct Mint {
   pub deadline: Option<u32>, // unix timestamp
   pub limit: Option<u128>,   // claim amount

--- a/src/runes/runestone.rs
+++ b/src/runes/runestone.rs
@@ -2,7 +2,7 @@ use super::*;
 
 const MAX_SPACERS: u32 = 0b00000111_11111111_11111111_11111111;
 
-#[derive(Default, Serialize, Debug, PartialEq)]
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Runestone {
   pub cenotaph: bool,
   pub claim: Option<RuneId>,
@@ -1709,5 +1709,42 @@ mod tests {
     }
 
     assert_eq!(MAX_SPACERS, rune.parse::<SpacedRune>().unwrap().spacers);
+  }
+
+  #[test]
+  fn runestone_can_be_serialized_and_deserialized() {
+    let rune_name = "MYAWESOMERUNE";
+    let rs = Runestone::from_transaction(&Transaction {
+      input: Vec::new(),
+      output: vec![TxOut {
+        script_pubkey: Runestone {
+          edicts: vec![Edict {
+            id: RuneId::default(),
+            amount: 1111,
+            output: 0,
+          }],
+          etching: Some(Etching {
+            rune: Some(Rune(4)),
+            mint: Some(Mint {
+              limit: Some(1000),
+              term: Some(0),
+              ..Default::default()
+            }),
+            ..Default::default()
+          }),
+          ..Default::default()
+        }
+        .encipher(),
+        value: 0,
+      }],
+      lock_time: LockTime::ZERO,
+      version: 2,
+    })
+    .unwrap();
+
+    assert_eq!(
+      rs,
+      serde_json::from_str(&serde_json::to_string(&rs).unwrap()).unwrap()
+    );
   }
 }

--- a/src/runes/runestone.rs
+++ b/src/runes/runestone.rs
@@ -1710,41 +1710,4 @@ mod tests {
 
     assert_eq!(MAX_SPACERS, rune.parse::<SpacedRune>().unwrap().spacers);
   }
-
-  #[test]
-  fn runestone_can_be_serialized_and_deserialized() {
-    let rune_name = "MYAWESOMERUNE";
-    let rs = Runestone::from_transaction(&Transaction {
-      input: Vec::new(),
-      output: vec![TxOut {
-        script_pubkey: Runestone {
-          edicts: vec![Edict {
-            id: RuneId::default(),
-            amount: 1111,
-            output: 0,
-          }],
-          etching: Some(Etching {
-            rune: Some(Rune(4)),
-            mint: Some(Mint {
-              limit: Some(1000),
-              term: Some(0),
-              ..Default::default()
-            }),
-            ..Default::default()
-          }),
-          ..Default::default()
-        }
-        .encipher(),
-        value: 0,
-      }],
-      lock_time: LockTime::ZERO,
-      version: 2,
-    })
-    .unwrap();
-
-    assert_eq!(
-      rs,
-      serde_json::from_str(&serde_json::to_string(&rs).unwrap()).unwrap()
-    );
-  }
 }


### PR DESCRIPTION
Allow runestone to be deserialized from json.

This would be super-helpful intermediary step until we get a separate library for encoding/decoding payloads.

@casey @raphjaph , I know there are some versions of these that are already deserializable and used by the wallet(eg. wallet/inscribeetch.rs), but if wallet does not expose customization for some fields, they will not be included there. This is needed for protocol convertors, to actually have the exact same structures.