### PR TITLE
Index inscriptions by address

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -9,6 +9,12 @@ pub use crate::templates::{
 };
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Address {
+  pub address: bitcoin::Address<NetworkUnchecked>,
+  pub inscriptions: Vec<InscriptionId>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Block {
   pub hash: BlockHash,
   pub target: BlockHash,
@@ -119,7 +125,7 @@ pub struct Inscriptions {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Output {
-  pub address: Option<Address<NetworkUnchecked>>,
+  pub address: Option<bitcoin::Address<NetworkUnchecked>>,
   pub indexed: bool,
   pub inscriptions: Vec<InscriptionId>,
   pub runes: Vec<(SpacedRune, Pile)>,

--- a/src/index.rs
+++ b/src/index.rs
@@ -2021,6 +2021,7 @@ impl Index {
     }
   }
 
+  #[allow(dead_code)]
   pub(crate) fn get_inscription_ids_by_address(
     &self,
     address: Address,

--- a/src/index.rs
+++ b/src/index.rs
@@ -83,6 +83,7 @@ define_table! { STATISTIC_TO_COUNT, u64, u64 }
 define_table! { TRANSACTION_ID_TO_RUNE, &TxidValue, u128 }
 define_table! { TRANSACTION_ID_TO_TRANSACTION, &TxidValue, &[u8] }
 define_table! { WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP, u32, u128 }
+define_table! { ADDRESS_TO_INSCRIPTION_IDS, &[u8], Vec<InscriptionIdValue> }
 
 #[derive(Copy, Clone)]
 pub(crate) enum Statistic {
@@ -101,6 +102,7 @@ pub(crate) enum Statistic {
   IndexTransactions = 12,
   IndexSpentSats = 13,
   InitialSyncTime = 14,
+  IndexAddresses = 15,
 }
 
 impl Statistic {
@@ -217,6 +219,7 @@ pub struct Index {
   index_sats: bool,
   index_spent_sats: bool,
   index_transactions: bool,
+  index_addresses: bool,
   settings: Settings,
   path: PathBuf,
   started: DateTime<Utc>,
@@ -339,6 +342,7 @@ impl Index {
         tx.open_table(SEQUENCE_NUMBER_TO_SATPOINT)?;
         tx.open_table(TRANSACTION_ID_TO_RUNE)?;
         tx.open_table(WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP)?;
+        tx.open_table(ADDRESS_TO_INSCRIPTION_IDS)?;
 
         {
           let mut outpoint_to_sat_ranges = tx.open_table(OUTPOINT_TO_SAT_RANGES)?;
@@ -372,6 +376,12 @@ impl Index {
             u64::from(settings.index_transactions()),
           )?;
 
+          Self::set_statistic(
+            &mut statistics,
+            Statistic::IndexAddresses,
+            u64::from(settings.index_addresses()),
+          )?;
+
           Self::set_statistic(&mut statistics, Statistic::Schema, SCHEMA_VERSION)?;
         }
 
@@ -386,6 +396,7 @@ impl Index {
     let index_sats;
     let index_spent_sats;
     let index_transactions;
+    let index_addresses;
 
     {
       let tx = database.begin_read()?;
@@ -394,6 +405,7 @@ impl Index {
       index_sats = Self::is_statistic_set(&statistics, Statistic::IndexSats)?;
       index_spent_sats = Self::is_statistic_set(&statistics, Statistic::IndexSpentSats)?;
       index_transactions = Self::is_statistic_set(&statistics, Statistic::IndexTransactions)?;
+      index_addresses = Self::is_statistic_set(&statistics, Statistic::IndexAddresses)?;
     }
 
     let genesis_block_coinbase_transaction =
@@ -412,6 +424,7 @@ impl Index {
       index_sats,
       index_spent_sats,
       index_transactions,
+      index_addresses,
       settings: settings.clone(),
       path,
       started: Utc::now(),
@@ -2006,6 +2019,24 @@ impl Index {
         }
       }
     }
+  }
+
+  pub(crate) fn get_inscription_ids_by_address(
+    &self,
+    address: Address,
+  ) -> Result<Vec<InscriptionId>> {
+    Ok(
+      self
+        .database
+        .begin_read()?
+        .open_table(ADDRESS_TO_INSCRIPTION_IDS)?
+        .get(address.to_string().as_bytes())?
+        .unwrap()
+        .value()
+        .iter()
+        .map(|entry| InscriptionId::load(*entry))
+        .collect(),
+    )
   }
 
   fn inscriptions_on_output<'a: 'tx, 'tx>(

--- a/src/index.rs
+++ b/src/index.rs
@@ -46,7 +46,7 @@ mod updater;
 #[cfg(test)]
 pub(crate) mod testing;
 
-const SCHEMA_VERSION: u64 = 24;
+const SCHEMA_VERSION: u64 = 25;
 
 macro_rules! define_table {
   ($name:ident, $key:ty, $value:ty) => {

--- a/src/index.rs
+++ b/src/index.rs
@@ -235,6 +235,12 @@ impl Index {
     settings: &Settings,
     event_sender: Option<tokio::sync::mpsc::Sender<Event>>,
   ) -> Result<Self> {
+    if settings.index_addresses() && !settings.index_transactions() {
+      bail!(
+        "cannot index addresses without transactions, consider adding --index-transactions flag"
+      );
+    }
+
     let client = settings.bitcoin_rpc_client(None)?;
 
     let path = settings.index().to_owned();
@@ -511,6 +517,7 @@ impl Index {
       sat_index: statistic(Statistic::IndexSats)? != 0,
       started: self.started,
       transaction_index: statistic(Statistic::IndexTransactions)? != 0,
+      address_index: statistic(Statistic::IndexAddresses)? != 0,
       unrecoverably_reorged: self.unrecoverably_reorged.load(atomic::Ordering::Relaxed),
       uptime: (Utc::now() - self.started).to_std()?,
     })

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -386,6 +386,7 @@ impl<'index> Updater<'index> {
     let mut sequence_number_to_satpoint = wtx.open_table(SEQUENCE_NUMBER_TO_SATPOINT)?;
     let mut statistic_to_count = wtx.open_table(STATISTIC_TO_COUNT)?;
     let mut transaction_id_to_transaction = wtx.open_table(TRANSACTION_ID_TO_TRANSACTION)?;
+    let mut address_to_inscription_ids = wtx.open_table(ADDRESS_TO_INSCRIPTION_IDS)?;
 
     let mut lost_sats = statistic_to_count
       .get(&Statistic::LostSats.key())?
@@ -441,6 +442,8 @@ impl<'index> Updater<'index> {
       timestamp: block.header.time,
       transaction_buffer: Vec::new(),
       transaction_id_to_transaction: &mut transaction_id_to_transaction,
+      address_to_inscription_ids: &mut address_to_inscription_ids,
+      index_addresses: self.index.index_addresses,
       unbound_inscriptions,
       value_cache,
       value_receiver,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -577,7 +577,7 @@ impl<'a, 'tx> InscriptionUpdater<'a, 'tx> {
     transaction: &Transaction,
     new_satpoint: SatPoint,
   ) -> Result {
-    if !self.index_addresses || !self.index_transactions {
+    if !self.index_addresses {
       return Ok(());
     }
 

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -571,7 +571,7 @@ impl<'a, 'tx> InscriptionUpdater<'a, 'tx> {
     Ok(())
   }
 
-  fn index_address_to_inscription<'address>(
+  fn index_address_to_inscription(
     &mut self,
     flotsam: &Flotsam,
     transaction: &Transaction,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -592,7 +592,8 @@ impl<'a, 'tx> InscriptionUpdater<'a, 'tx> {
           self.transaction_to_address(&transaction, old_satpoint.outpoint.vout.into_usize())?;
 
         let mut inscription_ids = self.get_inscription_ids_by_address(&address)?;
-        inscription_ids.retain(|&id| id != flotsam.inscription_id.store());
+        let inscription_id_entry = flotsam.inscription_id.store();
+        inscription_ids.retain(|&id| id != inscription_id_entry);
 
         self
           .address_to_inscription_ids

--- a/src/options.rs
+++ b/src/options.rs
@@ -61,6 +61,8 @@ pub struct Options {
   pub(crate) index_spent_sats: bool,
   #[arg(long, help = "Store transactions in index.")]
   pub(crate) index_transactions: bool,
+  #[arg(long, help = "Store addresses inscriptions in index.")]
+  pub(crate) index_addresses: bool,
   #[arg(long, help = "Run in integration test mode.")]
   pub(crate) integration_test: bool,
   #[arg(long, help = "Minify JSON output.")]

--- a/src/options.rs
+++ b/src/options.rs
@@ -61,7 +61,10 @@ pub struct Options {
   pub(crate) index_spent_sats: bool,
   #[arg(long, help = "Store transactions in index.")]
   pub(crate) index_transactions: bool,
-  #[arg(long, help = "Store addresses inscriptions in index.")]
+  #[arg(
+    long,
+    help = "Store addresses inscriptions in index. Relies on transactions index."
+  )]
   pub(crate) index_addresses: bool,
   #[arg(long, help = "Run in integration test mode.")]
   pub(crate) integration_test: bool,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -22,6 +22,7 @@ pub struct Settings {
   index_sats: bool,
   index_spent_sats: bool,
   index_transactions: bool,
+  index_addresses: bool,
   integration_test: bool,
   no_index_inscriptions: bool,
   server_password: Option<String>,
@@ -136,6 +137,7 @@ impl Settings {
       index_sats: self.index_sats || source.index_sats,
       index_spent_sats: self.index_spent_sats || source.index_spent_sats,
       index_transactions: self.index_transactions || source.index_transactions,
+      index_addresses: self.index_addresses || source.index_addresses,
       integration_test: self.integration_test || source.integration_test,
       no_index_inscriptions: self.no_index_inscriptions || source.no_index_inscriptions,
       server_password: self.server_password.or(source.server_password),
@@ -170,6 +172,7 @@ impl Settings {
       index_sats: options.index_sats,
       index_spent_sats: options.index_spent_sats,
       index_transactions: options.index_transactions,
+      index_addresses: options.index_addresses,
       integration_test: options.integration_test,
       no_index_inscriptions: options.no_index_inscriptions,
       server_password: options.server_password,
@@ -248,6 +251,7 @@ impl Settings {
       index_sats: get_bool("INDEX_SATS"),
       index_spent_sats: get_bool("INDEX_SPENT_SATS"),
       index_transactions: get_bool("INDEX_TRANSACTIONS"),
+      index_addresses: get_bool("INDEX_ADDRESSES"),
       integration_test: get_bool("INTEGRATION_TEST"),
       no_index_inscriptions: get_bool("NO_INDEX_INSCRIPTIONS"),
       server_password: get_string("SERVER_PASSWORD"),
@@ -277,6 +281,7 @@ impl Settings {
       index_sats: true,
       index_spent_sats: false,
       index_transactions: false,
+      index_addresses: false,
       integration_test: false,
       no_index_inscriptions: false,
       server_password: None,
@@ -356,6 +361,7 @@ impl Settings {
       index_sats: self.index_sats,
       index_spent_sats: self.index_spent_sats,
       index_transactions: self.index_transactions,
+      index_addresses: self.index_addresses,
       integration_test: self.integration_test,
       no_index_inscriptions: self.no_index_inscriptions,
       server_password: self.server_password,
@@ -528,6 +534,10 @@ impl Settings {
 
   pub(crate) fn index_transactions(&self) -> bool {
     self.index_transactions
+  }
+
+  pub(crate) fn index_addresses(&self) -> bool {
+    self.index_addresses
   }
 
   pub(crate) fn integration_test(&self) -> bool {
@@ -998,6 +1008,7 @@ mod tests {
       ("INDEX_SATS", "1"),
       ("INDEX_SPENT_SATS", "1"),
       ("INDEX_TRANSACTIONS", "1"),
+      ("INDEX_ADDRESSES", "1"),
       ("INTEGRATION_TEST", "1"),
       ("NO_INDEX_INSCRIPTIONS", "1"),
       ("SERVER_PASSWORD", "server password"),
@@ -1041,6 +1052,7 @@ mod tests {
         index_sats: true,
         index_spent_sats: true,
         index_transactions: true,
+        index_addresses: true,
         integration_test: true,
         no_index_inscriptions: true,
         server_password: Some("server password".into()),
@@ -1073,6 +1085,7 @@ mod tests {
           "--index-sats",
           "--index-spent-sats",
           "--index-transactions",
+          "--index-addresses",
           "--index=index",
           "--integration-test",
           "--no-index-inscriptions",
@@ -1101,6 +1114,7 @@ mod tests {
         index_sats: true,
         index_spent_sats: true,
         index_transactions: true,
+        index_addresses: true,
         integration_test: true,
         no_index_inscriptions: true,
         server_password: Some("server password".into()),

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -3240,6 +3240,8 @@ mod tests {
   <dd>false</dd>
   <dt>transaction index</dt>
   <dd>false</dd>
+  <dt>address index</dt>
+  <dd>false</dd>
   <dt>git branch</dt>
   <dd>.*</dd>
   <dt>git commit</dt>

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -930,6 +930,7 @@ impl Server {
           inscriptions,
           address,
         }
+        .page(server_config)
         .into_response()
       })
     })

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -899,6 +899,7 @@ impl Server {
   }
 
   async fn address(
+    Extension(server_config): Extension<Arc<ServerConfig>>,
     Extension(settings): Extension<Arc<Settings>>,
     Extension(index): Extension<Arc<Index>>,
     Path(address): Path<String>,

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -2,6 +2,7 @@ use {super::*, boilerplate::Boilerplate};
 
 pub(crate) use {
   crate::subcommand::server::ServerConfig,
+  address::AddressHtml,
   block::BlockHtml,
   children::ChildrenHtml,
   clock::ClockSvg,
@@ -30,6 +31,7 @@ pub use {
   transaction::TransactionHtml,
 };
 
+pub mod address;
 pub mod block;
 pub mod blocks;
 mod children;

--- a/src/templates/address.rs
+++ b/src/templates/address.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+#[derive(Boilerplate)]
+pub(crate) struct AddressHtml {
+  pub(crate) inscriptions: Vec<InscriptionId>,
+  pub(crate) address: Address,
+}
+
+impl PageContent for AddressHtml {
+  fn title(&self) -> String {
+    "Address".into()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn positive() {
+    assert_regex_match!(
+      AddressHtml {
+        inscriptions: vec![inscription_id(1), inscription_id(2)],
+        address: Address::from_str(
+          "bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8"
+        )
+        .unwrap()
+        .require_network(Network::Bitcoin)
+        .unwrap(),
+      },
+      "<h1>Address bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8</h1>
+      <div class=thumbnails>
+        <a href=/inscription/1{64}i1><iframe .* src=/preview/1{64}i1></iframe></a>
+        <a href=/inscription/2{64}i2><iframe .* src=/preview/2{64}i2></iframe></a>
+      </div>.*"
+        .unindent()
+    );
+  }
+}

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -107,7 +107,7 @@ mod tests {
         <dl>
           .*
           <dt>address</dt>
-          <dd class=monospace>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</dd>
+          <dd><a class=monospace href=/address/bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</a></dd>
           <dt>value</dt>
           <dd>1</dd>
           .*

--- a/src/templates/output.rs
+++ b/src/templates/output.rs
@@ -41,7 +41,7 @@ mod tests {
         <dl>
           <dt>value</dt><dd>3</dd>
           <dt>script pubkey</dt><dd class=monospace>OP_DUP OP_HASH160 OP_PUSHBYTES_20 0{40} OP_EQUALVERIFY OP_CHECKSIG</dd>
-          <dt>address</dt><dd class=monospace>1111111111111111111114oLvT2</dd>
+          <dt>address</dt><dd><a class=monospace href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
           <dt>transaction</dt><dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
           <dt>spent</dt><dd>false</dd>
         </dl>
@@ -100,7 +100,7 @@ mod tests {
         <dl>
           <dt>value</dt><dd>3</dd>
           <dt>script pubkey</dt><dd class=monospace>OP_DUP OP_HASH160 OP_PUSHBYTES_20 0{40} OP_EQUALVERIFY OP_CHECKSIG</dd>
-          <dt>address</dt><dd class=monospace>1111111111111111111114oLvT2</dd>
+          <dt>address</dt><dd><a class=monospace href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
           <dt>transaction</dt><dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
           <dt>spent</dt><dd>true</dd>
         </dl>
@@ -132,7 +132,7 @@ mod tests {
         <dl>
           <dt>value</dt><dd>3</dd>
           <dt>script pubkey</dt><dd class=monospace>OP_DUP OP_HASH160 OP_PUSHBYTES_20 0{40} OP_EQUALVERIFY OP_CHECKSIG</dd>
-          <dt>address</dt><dd class=monospace>1111111111111111111114oLvT2</dd>
+          <dt>address</dt><dd><a class=monospace href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
           <dt>transaction</dt><dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
           <dt>spent</dt><dd>false</dd>
         </dl>

--- a/src/templates/status.rs
+++ b/src/templates/status.rs
@@ -16,6 +16,7 @@ pub struct StatusHtml {
   pub sat_index: bool,
   pub started: DateTime<Utc>,
   pub transaction_index: bool,
+  pub address_index: bool,
   pub unrecoverably_reorged: bool,
   pub uptime: Duration,
 }

--- a/templates/address.html
+++ b/templates/address.html
@@ -1,0 +1,6 @@
+<h1>Address {{ self.address }}</h1>
+<div class=thumbnails>
+%% for id in &self.inscriptions {
+  {{Iframe::thumbnail(*id)}}
+%% }
+</div>

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -58,9 +58,9 @@
   </dd>
 %% }
 %% if let Some(output) = &self.output {
-%% if let Ok(address) = self.chain.address_from_script(&output.script_pubkey ) {
+%% if let Ok(address) = self.chain.address_from_script(&output.script_pubkey) {
   <dt>address</dt>
-  <dd class=monospace>{{ address }}</dd>
+  <dd><a class=monospace href=/address/{{ address }}>{{ address }}</a></dd>
 %% }
   <dt>value</dt>
   <dd>{{ output.value }}</dd>

--- a/templates/output.html
+++ b/templates/output.html
@@ -27,8 +27,8 @@
 %% }
   <dt>value</dt><dd>{{ self.output.value }}</dd>
   <dt>script pubkey</dt><dd class=monospace>{{ self.output.script_pubkey.to_asm_string() }}</dd>
-%% if let Ok(address) = self.chain.address_from_script(&self.output.script_pubkey ) {
-  <dt>address</dt><dd class=monospace>{{ address }}</dd>
+%% if let Ok(address) = self.chain.address_from_script(&self.output.script_pubkey) {
+  <dt>address</dt><dd><a class=monospace href=/address/{{ address }}>{{ address }}</a></dd>
 %% }
   <dt>transaction</dt><dd><a class=monospace href=/tx/{{ self.outpoint.txid }}>{{ self.outpoint.txid }}</a></dd>
   <dt>spent</dt><dd>{{ self.spent }}</dd>

--- a/templates/status.html
+++ b/templates/status.html
@@ -34,6 +34,8 @@
   <dd>{{ self.sat_index }}</dd>
   <dt>transaction index</dt>
   <dd>{{ self.transaction_index }}</dd>
+  <dt>address index</dt>
+  <dd>{{ self.address_index }}</dd>
 %% if !env!("GIT_BRANCH").is_empty() {
   <dt>git branch</dt>
   <dd>{{ env!("GIT_BRANCH") }}</dd>

--- a/templates/transaction.html
+++ b/templates/transaction.html
@@ -31,7 +31,7 @@
       <dt>value</dt><dd>{{ output.value }}</dd>
       <dt>script pubkey</dt><dd class=monospace>{{ output.script_pubkey.to_asm_string() }}</dd>
 %% if let Ok(address) = self.chain.address_from_script(&output.script_pubkey) {
-      <dt>address</dt><dd class=monospace>{{ address }}</dd>
+      <dt>address</dt><dd><a class=monospace href=/address/{{ address }}>{{ address }}</a></dd>
 %% }
     </dl>
   </li>

--- a/tests/json_api.rs
+++ b/tests/json_api.rs
@@ -512,6 +512,7 @@ fn get_status() {
       sat_index: true,
       started: dummy_started,
       transaction_index: false,
+      address_index: false,
       unrecoverably_reorged: false,
       uptime: dummy_duration,
     }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -60,7 +60,7 @@ fn inscription_page() {
   <dt>id</dt>
   <dd class=monospace>{inscription}</dd>
   <dt>address</dt>
-  <dd class=monospace>bc1.*</dd>
+  <dd><a class=monospace href=/address/bc1.*>bc1.*</a></dd>
   <dt>value</dt>
   <dd>10000</dd>
   <dt>preview</dt>
@@ -190,7 +190,7 @@ fn inscription_page_after_send() {
   ord_rpc_server.assert_response_regex(
     format!("/inscription/{inscription}"),
     format!(
-      r".*<h1>Inscription 0</h1>.*<dt>address</dt>\s*<dd class=monospace>bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv</dd>.*<dt>location</dt>\s*<dd class=monospace>{txid}:0:0</dd>.*",
+      r".*<h1>Inscription 0</h1>.*<dt>address</dt>\s*<dd><a class=monospace href=/address/.*</a>.*</dd>.*<dt>location</dt>\s*<dd class=monospace>{txid}:0:0</dd>.*",
     ),
   )
 }

--- a/tests/settings.rs
+++ b/tests/settings.rs
@@ -25,6 +25,7 @@ fn default() {
   "index_sats": false,
   "index_spent_sats": false,
   "index_transactions": false,
+  "index_addresses": false,
   "integration_test": false,
   "no_index_inscriptions": false,
   "server_password": null,

--- a/tests/wallet/inscribe.rs
+++ b/tests/wallet/inscribe.rs
@@ -1600,7 +1600,7 @@ inscriptions:
     format!("/inscription/{}", output.inscriptions[0].id),
     ".*
   <dt>address</dt>
-  <dd class=monospace>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</dd>.*",
+  <dd><a class=monospace href=/address/bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</a></dd>.*",
   );
 
   ord_rpc_server.assert_response_regex(
@@ -1608,7 +1608,7 @@ inscriptions:
     format!(
       ".*
   <dt>address</dt>
-  <dd class=monospace>{}</dd>.*",
+  <dd><a class=monospace href=/address/{0}>{0}</a></dd>.*",
       bitcoin_rpc_server.state().change_addresses[0],
     ),
   );
@@ -1617,7 +1617,7 @@ inscriptions:
     format!("/inscription/{}", output.inscriptions[2].id),
     ".*
   <dt>address</dt>
-  <dd class=monospace>bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k</dd>.*",
+  <dd><a class=monospace href=/address/bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k>bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k</a></dd>.*",
   );
 }
 

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -157,7 +157,7 @@ fn send_inscription_by_sat() {
   ord_rpc_server.assert_response_regex(
     format!("/inscription/{inscription}"),
     format!(
-      ".*<h1>Inscription 0</h1>.*<dt>address</dt>.*<dd class=monospace>{address}</dd>.*<dt>location</dt>.*<dd class=monospace>{send_txid}:0:0</dd>.*",
+      ".*<h1>Inscription 0</h1>.*<dt>address</dt>.*<a class=monospace href=/address/{address}>{address}</a></dd>.*<dt>location</dt>.*<dd class=monospace>{send_txid}:0:0</dd>.*",
     ),
   );
 }


### PR DESCRIPTION
Added an address to inscriptions index and address endpoint with inscriptions. Resolves: #2619 

<img width="1726" alt="image" src="https://github.com/ordinals/ord/assets/40490784/918c1e7e-ce8c-4b94-ad53-2d7c0e4fb54f">

Address index relies on transactions index, how should we handle this? Fail to startup if there are no --index-transactions flag? 