### PR TITLE
Render closed-interval-ranges for human legibility.

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -610,6 +610,13 @@ impl Server {
           .ok_or_not_found(|| format!("output {outpoint}"))?
       };
 
+      let human_legible_ranges: Option<Vec<(u64, u64)>> = sat_ranges.map(|ranges| {
+        ranges
+          .into_iter()
+          .map(|(start, end)| (start, end - 1))
+          .collect()
+      });
+
       let inscriptions = index.get_inscriptions_on_output(outpoint)?;
 
       let runes = index.get_rune_balances_for_outpoint(outpoint)?;
@@ -624,7 +631,7 @@ impl Server {
           output,
           indexed,
           runes,
-          sat_ranges,
+          human_legible_ranges,
           spent,
         ))
         .into_response()
@@ -635,7 +642,7 @@ impl Server {
           outpoint,
           output,
           runes,
-          sat_ranges,
+          sat_ranges: human_legible_ranges,
           spent,
         }
         .page(server_config)

--- a/templates/output.html
+++ b/templates/output.html
@@ -37,10 +37,10 @@
 <h2>{{"Sat Range".tally(sat_ranges.len())}}</h2>
 <ul class=monospace>
 %% for (start, end) in sat_ranges {
-%% if end - start == 1 {
+%% if start == end {
   <li><a href=/sat/{{start}} class={{Sat(*start).rarity()}}>{{start}}</a></li>
 %% } else {
-  <li><a href=/range/{{start}}/{{end}} class={{Sat(*start).rarity()}}>{{start}}–{{end}}</a></li>
+  <li><a href=/range/{{start}}/{{end+1}} class={{Sat(*start).rarity()}}>{{start}}–{{end}}</a></li>
 %% }
 %% }
 </ul>

--- a/templates/range.html
+++ b/templates/range.html
@@ -1,4 +1,4 @@
-<h1>Sat Range {{self.start}}–{{self.end}}</h1>
+<h1>Sat Range {{self.start}}–{{self.end.n()-1}}</h1>
 <dl>
   <dt>value</dt><dd>{{self.end.n() - self.start.n()}}</dd>
   <dt>first</dt><dd><a href=/sat/{{self.start.n()}} class={{self.start.rarity()}}>{{self.start.n()}}</a></dd>


### PR DESCRIPTION
Currently, a satoshi range of [10; 12], which contains the elements {10, 11, 12}, would be rendered as 10-13. It's convenient for calculating its value, but highly misleading because it suggests that 13 is part of the interval, which it isn't. 

The issue stems from the asymmetry of interval openness: the beginning of the interval is closed, and the ending is open.

To facilitate human legibility and convenience, the ends of intervals are now rendered as closed, too.

This PR might be controversial, so feel free to close.