### PR TITLE
Fix type in zh.po

### DIFF
--- a/docs/po/zh.po
+++ b/docs/po/zh.po
@@ -269,9 +269,9 @@ msgid ""
 msgstr ""
 "序数是一种比特币的编号方案，允许跟踪和转移单个聪。这些数字被称作[序号]"
 "(https://ordinals.com)。比特币是按照它们被挖掘的顺序编号的，并从交易输入转移"
-"到交易输出（遵循先进先出原则）。编号方案和传输方案都依赖于_顺序_，编号方案依"
-"赖于比特币被挖掘的_顺序_，而传输方案依赖于交易输入和输出的_顺序_。因此得名，_"
-"序数（Ordinals_。"
+"到交易输出（遵循先进先出原则）。编号方案和传输方案都依赖于 _顺序_，编号方案依"
+"赖于比特币被挖掘的 _顺序_，而传输方案依赖于交易输入和输出的 _顺序_。因此得名，"
+"_序数（Ordinals）_。"
 
 #: src/overview.md:13
 msgid ""
@@ -707,7 +707,7 @@ msgid ""
 "short and get longer, but then all the good, short names would be trapped in "
 "the unspendable genesis block."
 msgstr ""
-"每个聪都有一个名字，由字母 _A_ 到 _Z_构成 随着聪被开采的时间越长，名字越短。 "
+"每个聪都有一个名字，由字母 _A_ 到 _Z_ 构成 随着聪被开采的时间越长，名字越短。"
 "如果他们从短开始，然后变得更长，那么所有好的、短的名字都会被困在无法使用的创"
 "世块中。 "
 
@@ -939,7 +939,7 @@ msgid ""
 "very nature."
 msgstr ""
 "数字文物的定义旨在从其特定的本质上反映NFT _应该_ 是什么, 有时是什么, 以及铭文"
-"_始终_ 是什么 "
+" _始终_ 是什么 "
 
 #: src/inscriptions.md:4
 msgid ""
@@ -1921,7 +1921,7 @@ msgstr ""
 
 #: src/inscriptions/recursion.md:45
 msgid "`/r/sat/<SAT_NUMBER>`: the first 100 inscription ids on a sat."
-msgstr "`/r/sat/<SAT_NUMBER>`: 在一个Sats上的头100个铭文ID.
+msgstr "`/r/sat/<SAT_NUMBER>`: 在一个Sats上的头100个铭文ID."
 
 #: src/inscriptions/recursion.md:46
 msgid ""


### PR DESCRIPTION
- Fixed “order”、“ordinals” and "A through Z" not being properly italicized in《Overview》
- Fixed  "always"  not being properly italicized in 《Digital Artifacts》
- Fixed  Missing closing quotation mark.