### PR TITLE
record the final mint transaction

### DIFF
--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -49,6 +49,7 @@ pub struct RuneEntry {
   pub mints: u128,
   pub number: u64,
   pub premine: u128,
+  pub final_mint: Option<Txid>,
   pub spaced_rune: SpacedRune,
   pub symbol: Option<char>,
   pub terms: Option<Terms>,


### PR DESCRIPTION
It is not easy to check an onchain transaction mint successfully, because of the mint cap term. Saving the final mint transaction id, we can ensure all transactions before that tranaction id satisfy the cap condition.