### PR TITLE
Better error message when bitcoind doesn't start

### DIFF
--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -67,7 +67,8 @@ rpcport={bitcoind_port}
       Command::new("bitcoind")
         .arg(format!("-conf={}", absolute.join("bitcoin.conf").display()))
         .stdout(Stdio::null())
-        .spawn().expect("failed to start bitcoind"),
+        .spawn()
+        .expect("failed to start bitcoind"),
     );
 
     loop {

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -67,7 +67,7 @@ rpcport={bitcoind_port}
       Command::new("bitcoind")
         .arg(format!("-conf={}", absolute.join("bitcoin.conf").display()))
         .stdout(Stdio::null())
-        .spawn().expect("failed to start bitcoind")?,
+        .spawn().expect("failed to start bitcoind"),
     );
 
     loop {

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -67,7 +67,7 @@ rpcport={bitcoind_port}
       Command::new("bitcoind")
         .arg(format!("-conf={}", absolute.join("bitcoin.conf").display()))
         .stdout(Stdio::null())
-        .spawn()?,
+        .spawn().expect("failed to start bitcoind")?,
     );
 
     loop {


### PR DESCRIPTION
Problem:
- if `bitcoind` isn't there, the command `ord env` or `cargo run env` fails with an error message - `No such file or directory`
<img width="498" alt="image" src="https://github.com/ordinals/ord/assets/112330467/80708a47-1a0c-4b37-8f23-3000c56be665">

Now it shows the reason:
<img width="890" alt="image" src="https://github.com/ordinals/ord/assets/112330467/b1749d7d-ab8b-40d1-95ba-a9b479c104a4">