### PR TITLE
add --no-wait flag to not wait for etching to mature

### DIFF
--- a/src/subcommand/wallet/batch_command.rs
+++ b/src/subcommand/wallet/batch_command.rs
@@ -47,6 +47,7 @@ impl Batch {
       mode: batchfile.mode,
       no_backup: self.shared.no_backup,
       no_limit: self.shared.no_limit,
+      no_wait: self.shared.no_wait,
       parent_info,
       postages,
       reinscribe: batchfile.reinscribe,

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -81,6 +81,7 @@ impl Inscribe {
       mode: batch::Mode::SeparateOutputs,
       no_backup: self.shared.no_backup,
       no_limit: self.shared.no_limit,
+      no_wait: self.shared.no_wait,
       parent_info: wallet.get_parent_info(self.parent)?,
       postages: vec![self.postage.unwrap_or(TARGET_POSTAGE)],
       reinscribe: self.reinscribe,

--- a/src/subcommand/wallet/resume.rs
+++ b/src/subcommand/wallet/resume.rs
@@ -10,7 +10,7 @@ pub(crate) fn run(wallet: Wallet) -> SubcommandResult {
     .pending_etchings()?
     .into_iter()
     .map(|(rune, entry)| {
-      wallet.wait_for_maturation(&rune, entry.commit, entry.reveal, entry.output)
+      wallet.wait_for_maturation(&rune, entry.commit, entry.reveal, entry.output, false)
     })
     .collect();
 

--- a/src/subcommand/wallet/shared_args.rs
+++ b/src/subcommand/wallet/shared_args.rs
@@ -21,4 +21,6 @@ pub(super) struct SharedArgs {
     help = "Do not check that transactions are equal to or below the MAX_STANDARD_TX_WEIGHT of 400,000 weight units. Transactions over this limit are currently nonstandard and will not be relayed by bitcoind in its default configuration. Do not use this flag unless you understand the implications."
   )]
   pub(crate) no_limit: bool,
+  #[arg(long, alias = "nowait", help = "Do not wait for etching to mature.")]
+  pub(crate) no_wait: bool,
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -302,13 +302,14 @@ impl Wallet {
     commit: Transaction,
     reveal: Transaction,
     output: batch::Output,
+    no_wait: bool,
   ) -> Result<batch::Output> {
     eprintln!("Waiting for rune commitment {} to mature…", commit.txid());
 
     self.save_etching(rune, &commit, &reveal, output.clone())?;
 
     loop {
-      if SHUTTING_DOWN.load(atomic::Ordering::Relaxed) {
+      if SHUTTING_DOWN.load(atomic::Ordering::Relaxed) || no_wait {
         eprintln!("Suspending batch. Run `ord wallet resume` to continue.");
         return Ok(output);
       }

--- a/src/wallet/batch/plan.rs
+++ b/src/wallet/batch/plan.rs
@@ -9,6 +9,7 @@ pub struct Plan {
   pub(crate) mode: Mode,
   pub(crate) no_backup: bool,
   pub(crate) no_limit: bool,
+  pub(crate) no_wait: bool,
   pub(crate) parent_info: Option<ParentInfo>,
   pub(crate) postages: Vec<Amount>,
   pub(crate) reinscribe: bool,
@@ -28,6 +29,7 @@ impl Default for Plan {
       mode: Mode::SharedOutput,
       no_backup: false,
       no_limit: false,
+      no_wait: false,
       parent_info: None,
       postages: vec![Amount::from_sat(10_000)],
       reinscribe: false,
@@ -151,6 +153,7 @@ impl Plan {
           self.inscriptions.clone(),
           rune.clone(),
         ),
+        self.no_wait,
       )?)))
     } else {
       let reveal = match wallet


### PR DESCRIPTION
if you're going to C-c anyway, you can instead pass the `--no-wait` flag when you do an etching. Makes it easier to wrap this in a script, if you're into such degeneracy.

not in love with the way this gets passed through, so marking it a draft for now. 