### PR TITLE
Add manual for centos

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ On Debian and Ubuntu, `ord` requires `libssl-dev` when building from source:
 ```
 sudo apt-get install pkg-config libssl-dev build-essential
 ```
+Or RedHat/Centos, you need to change the command above to:
+
+```
+yum install -y pkgconfig openssl-devel
+yum groupinstall "Development Tools"
+```
 
 You'll also need Rust:
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ On Debian and Ubuntu, `ord` requires `libssl-dev` when building from source:
 ```
 sudo apt-get install pkg-config libssl-dev build-essential
 ```
+
 Or RedHat/Centos, you need to change the command above to:
 
 ```

--- a/README.md
+++ b/README.md
@@ -87,13 +87,15 @@ command line.
 Building
 --------
 
-On Debian and Ubuntu, `ord` requires `libssl-dev` when building from source:
+On Linux, `ord` requires `libssl-dev` when building from source.
+
+On Debian-derived Linux distributions, including Ubuntu:
 
 ```
 sudo apt-get install pkg-config libssl-dev build-essential
 ```
 
-Or RedHat/Centos, you need to change the command above to:
+On Red Hat-derived Linux distributions:
 
 ```
 yum install -y pkgconfig openssl-devel


### PR DESCRIPTION
Just in case someone is using RedHat/Centos, ord latest tag 0.18.1 can be built on centos 8