### PR TITLE
Store wallets in /wallets subdir of data dir

### DIFF
--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -517,7 +517,10 @@ impl Wallet {
   }
 
   pub(crate) fn open_database(wallet_name: &String, settings: &Settings) -> Result<Database> {
-    let path = settings.data_dir().join(format!("{wallet_name}.redb"));
+    let path = settings
+      .data_dir()
+      .join("wallets")
+      .join(format!("{wallet_name}.redb"));
 
     if let Err(err) = fs::create_dir_all(path.parent().unwrap()) {
       bail!(


### PR DESCRIPTION
I think this is a little better, since otherwise the purpose of the wallet databases can be unclear, and there's a conflict if you want to name your wallet "index".