### PR TITLE
Update sparrow-wallet.md --name flag update

### DIFF
--- a/docs/src/guides/collecting/sparrow-wallet.md
+++ b/docs/src/guides/collecting/sparrow-wallet.md
@@ -89,9 +89,9 @@ You can then check your wallet's inscriptions using `ord wallet inscriptions`
 
 Note that if you have previously created a wallet with `ord`, then you will already have a wallet with the default name, and will need to give your imported wallet a different name. You can use the `--wallet` parameter in all `ord` commands to reference a different wallet, eg:
 
-`ord --wallet ord_from_sparrow wallet restore "BIP39 SEED PHRASE"`
+`ord wallet --name ord_from_sparrow wallet restore --from mnemonic`
 
-`ord --wallet ord_from_sparrow wallet inscriptions`
+`ord wallet --name ord_from_sparrow wallet inscriptions`
 
 `bitcoin-cli -rpcwallet=ord_from_sparrow rescanblockchain 767430`
 


### PR DESCRIPTION
The --wallet flag no longer works, to import wallet with name we need --name flag instead with --from mnemonic flag instead of the current listed: `ord --wallet ord_from_sparrow wallet restore "BIP39 SEED PHRASE"`