### PR TITLE
change operator to <= for etching when start block height set

### DIFF
--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -63,7 +63,7 @@ impl RuneEntry {
     };
 
     if let Some(start) = self.start() {
-      if height < start {
+      if height <= start {
         return Err(MintError::Start(start));
       }
     }


### PR DESCRIPTION
change operator to <= for etching when start block height set so that mints can be fired off when the next block is the start of a rune mint. This allows users in order to get tx's in the mempool to be confirmed in the same block as the mint start