### PR TITLE
 Allow mint submissions as start block is pending

### DIFF
--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -63,7 +63,7 @@ impl RuneEntry {
     };
 
     if let Some(start) = self.start() {
-      if height < start {
+      if height <= start {
         return Err(MintError::Start(start));
       }
     }

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -63,9 +63,9 @@ impl RuneEntry {
     };
 
     if let Some(start) = self.start() {
-      if height <= start {
-        return Err(MintError::Start(start));
-      }
+        if height < start - 1 {
+            return Err(MintError::Start(start));
+        }
     }
 
     if let Some(end) = self.end() {

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -61,9 +61,9 @@ impl RuneEntry {
     let Some(terms) = self.terms else {
       return Err(MintError::Unmintable);
     };
-
+    
     if let Some(start) = self.start() {
-        if height < start - 1 {
+        if height < (start - 1) {
             return Err(MintError::Start(start));
         }
     }


### PR DESCRIPTION
Current implementation only allows mint submissions after the start block is confirmed meaning ord users can not attempt to compete in that block. This implementation allows for submissions at start - 1, which is a good solution for most users. However, a flag to ignore these checks for power users might be a more composable solution.