### PR TITLE
Recursive Runes Endpoint Output

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -250,6 +250,10 @@ impl Server {
           "/r/sat/:sat_number/at/:index",
           get(Self::sat_inscription_at_index),
         )
+        .route(
+          "/r/output/:output",
+          get(Self::output_recursive),
+        )
         .route("/range/:start/:end", get(Self::range))
         .route("/rare.txt", get(Self::rare_txt))
         .route("/rune/:rune", get(Self::rune))
@@ -618,6 +622,18 @@ impl Server {
         response.push(output_info);
       }
       Ok(Json(response).into_response())
+    })
+  }
+
+  async fn output_recursive(
+    Extension(index): Extension<Arc<Index>>,
+    Path(outpoint): Path<OutPoint>,
+  ) -> ServerResult {
+    task::block_in_place(|| {
+      let output_info = index
+        .get_output_info(outpoint)?
+        .ok_or_not_found(|| format!("output {outpoint}"))?;
+       Ok(Json(output_info).into_response())
     })
   }
 


### PR DESCRIPTION
`/r/output/:output`

Its time for the output endpoint

<img width="990" alt="image" src="https://github.com/ordinals/ord/assets/42568538/9800bc94-3767-4e97-9b08-37c7d7d84d2c">

Example of runes with an inscription  https://ordinals.com/output/b84a1dd3cfb9ebb26f240afe7f17bf73f8a1b6cc9774ea26e360fbe077a26669:0

I just proxied the current `/output` response to play around with it. What do we want to keep or remove from the fields? We want  at least `runes` `inscriptions`. This allows artist to choose if they want to activate an inscription via a rune or via an inscription on the output. 

Another cool thing to have would be sat ranges. Then you can start activating inscriptions based on sats in the output if you don't want to activate an inscription with runes or inscriptions. Output gives you all 3 options activating inscriptions with sats, inscriptions or runes. 