### PR TITLE
Refactoring send.rs by introducing transfer trait

### DIFF
--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -1,4 +1,10 @@
-use {super::*, crate::outgoing::Outgoing, base64::Engine, bitcoin::psbt::Psbt};
+use {super::*, crate::outgoing::Outgoing};
+use crate::wallet::transfer::amount_tranfer::AmountTransfer;
+use crate::wallet::transfer::inscription_transfer::InscriptionTransfer;
+use crate::wallet::transfer::rune_transfer::RuneTransfer;
+use crate::wallet::transfer::sat_transfer::SatTransfer;
+use crate::wallet::transfer::satpoint_transfer::SatPointTransfer;
+use crate::wallet::transfer::Transfer;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Send {
@@ -30,321 +36,40 @@ impl Send {
       .clone()
       .require_network(wallet.chain().network())?;
 
-    let unsigned_transaction = match self.outgoing {
+    let transfer: Box<dyn Transfer> = match self.outgoing {
       Outgoing::Amount(amount) => {
-        Self::create_unsigned_send_amount_transaction(&wallet, address, amount, self.fee_rate)?
+        Box::new(AmountTransfer{
+          amount
+        })
       }
-      Outgoing::Rune { decimal, rune } => Self::create_unsigned_send_runes_transaction(
-        &wallet,
-        address,
-        rune,
-        decimal,
-        self.postage.unwrap_or(TARGET_POSTAGE),
-        self.fee_rate,
-      )?,
-      Outgoing::InscriptionId(id) => Self::create_unsigned_send_satpoint_transaction(
-        &wallet,
-        address,
-        wallet
-          .inscription_info()
-          .get(&id)
-          .ok_or_else(|| anyhow!("inscription {id} not found"))?
-          .satpoint,
-        self.postage,
-        self.fee_rate,
-        true,
-      )?,
-      Outgoing::SatPoint(satpoint) => Self::create_unsigned_send_satpoint_transaction(
-        &wallet,
-        address,
-        satpoint,
-        self.postage,
-        self.fee_rate,
-        false,
-      )?,
-      Outgoing::Sat(sat) => Self::create_unsigned_send_satpoint_transaction(
-        &wallet,
-        address,
-        wallet.find_sat_in_outputs(sat)?,
-        self.postage,
-        self.fee_rate,
-        true,
-      )?,
+      Outgoing::Rune { decimal, rune } => {
+        Box::new(RuneTransfer {
+          decimal,
+          spaced_rune: rune,
+        })
+      },
+      Outgoing::InscriptionId(id) => {
+        Box::new(InscriptionTransfer {
+          id
+        })
+      },
+      Outgoing::SatPoint(satpoint) => {
+        Box::new(SatPointTransfer {
+          satpoint
+        })
+      },
+      Outgoing::Sat(sat) => {
+        Box::new(SatTransfer {
+          sat
+        })
+      },
     };
-
-    let unspent_outputs = wallet.utxos();
-
-    let (txid, psbt) = if self.dry_run {
-      let psbt = wallet
-        .bitcoin_client()
-        .wallet_process_psbt(
-          &base64::engine::general_purpose::STANDARD
-            .encode(Psbt::from_unsigned_tx(unsigned_transaction.clone())?.serialize()),
-          Some(false),
-          None,
-          None,
-        )?
-        .psbt;
-
-      (unsigned_transaction.txid(), psbt)
-    } else {
-      let psbt = wallet
-        .bitcoin_client()
-        .wallet_process_psbt(
-          &base64::engine::general_purpose::STANDARD
-            .encode(Psbt::from_unsigned_tx(unsigned_transaction.clone())?.serialize()),
-          Some(true),
-          None,
-          None,
-        )?
-        .psbt;
-
-      let signed_tx = wallet
-        .bitcoin_client()
-        .finalize_psbt(&psbt, None)?
-        .hex
-        .ok_or_else(|| anyhow!("unable to sign transaction"))?;
-
-      (
-        wallet.bitcoin_client().send_raw_transaction(&signed_tx)?,
-        psbt,
-      )
-    };
-
-    let mut fee = 0;
-    for txin in unsigned_transaction.input.iter() {
-      let Some(txout) = unspent_outputs.get(&txin.previous_output) else {
-        panic!("input {} not found in utxos", txin.previous_output);
-      };
-      fee += txout.value;
-    }
-
-    for txout in unsigned_transaction.output.iter() {
-      fee = fee.checked_sub(txout.value).unwrap();
-    }
-
-    Ok(Some(Box::new(Output {
-      txid,
-      psbt,
-      outgoing: self.outgoing,
-      fee,
-    })))
-  }
-
-  fn create_unsigned_send_amount_transaction(
-    wallet: &Wallet,
-    destination: Address,
-    amount: Amount,
-    fee_rate: FeeRate,
-  ) -> Result<Transaction> {
-    wallet.lock_non_cardinal_outputs()?;
-
-    let unfunded_transaction = Transaction {
-      version: 2,
-      lock_time: LockTime::ZERO,
-      input: Vec::new(),
-      output: vec![TxOut {
-        script_pubkey: destination.script_pubkey(),
-        value: amount.to_sat(),
-      }],
-    };
-
-    let unsigned_transaction = consensus::encode::deserialize(&fund_raw_transaction(
-      wallet.bitcoin_client(),
-      fee_rate,
-      &unfunded_transaction,
-    )?)?;
-
-    Ok(unsigned_transaction)
-  }
-
-  fn create_unsigned_send_satpoint_transaction(
-    wallet: &Wallet,
-    destination: Address,
-    satpoint: SatPoint,
-    postage: Option<Amount>,
-    fee_rate: FeeRate,
-    sending_inscription: bool,
-  ) -> Result<Transaction> {
-    if !sending_inscription {
-      for inscription_satpoint in wallet.inscriptions().keys() {
-        if satpoint == *inscription_satpoint {
-          bail!("inscriptions must be sent by inscription ID");
-        }
-      }
-    }
-
-    let runic_outputs = wallet.get_runic_outputs()?;
-
-    ensure!(
-      !runic_outputs.contains(&satpoint.outpoint),
-      "runic outpoints may not be sent by satpoint"
-    );
-
-    let change = [wallet.get_change_address()?, wallet.get_change_address()?];
-
-    let postage = if let Some(postage) = postage {
-      Target::ExactPostage(postage)
-    } else {
-      Target::Postage
-    };
-
-    Ok(
-      TransactionBuilder::new(
-        satpoint,
-        wallet.inscriptions().clone(),
-        wallet.utxos().clone(),
-        wallet.locked_utxos().clone().into_keys().collect(),
-        runic_outputs,
-        destination.clone(),
-        change,
-        fee_rate,
-        postage,
-      )
-      .build_transaction()?,
+    transfer.send(
+      &wallet,
+      self.dry_run,
+      address,
+      self.postage,
+      self.fee_rate,
     )
-  }
-
-  fn create_unsigned_send_runes_transaction(
-    wallet: &Wallet,
-    destination: Address,
-    spaced_rune: SpacedRune,
-    decimal: Decimal,
-    postage: Amount,
-    fee_rate: FeeRate,
-  ) -> Result<Transaction> {
-    ensure!(
-      wallet.has_rune_index(),
-      "sending runes with `ord send` requires index created with `--index-runes` flag",
-    );
-
-    wallet.lock_non_cardinal_outputs()?;
-
-    let (id, entry, _parent) = wallet
-      .get_rune(spaced_rune.rune)?
-      .with_context(|| format!("rune `{}` has not been etched", spaced_rune.rune))?;
-
-    let amount = decimal.to_integer(entry.divisibility)?;
-
-    let inscribed_outputs = wallet
-      .inscriptions()
-      .keys()
-      .map(|satpoint| satpoint.outpoint)
-      .collect::<HashSet<OutPoint>>();
-
-    let balances = wallet
-      .get_runic_outputs()?
-      .into_iter()
-      .filter(|output| !inscribed_outputs.contains(output))
-      .map(|output| {
-        wallet.get_runes_balances_in_output(&output).map(|balance| {
-          (
-            output,
-            balance
-              .into_iter()
-              .map(|(spaced_rune, pile)| (spaced_rune.rune, pile))
-              .collect(),
-          )
-        })
-      })
-      .collect::<Result<BTreeMap<OutPoint, BTreeMap<Rune, Pile>>>>()?;
-
-    let mut inputs = Vec::new();
-    let mut input_rune_balances: BTreeMap<Rune, u128> = BTreeMap::new();
-
-    for (output, runes) in balances {
-      if let Some(balance) = runes.get(&spaced_rune.rune) {
-        if balance.amount > 0 {
-          *input_rune_balances.entry(spaced_rune.rune).or_default() += balance.amount;
-
-          inputs.push(output);
-        }
-      }
-
-      if input_rune_balances
-        .get(&spaced_rune.rune)
-        .cloned()
-        .unwrap_or_default()
-        >= amount
-      {
-        break;
-      }
-    }
-
-    let input_rune_balance = input_rune_balances
-      .get(&spaced_rune.rune)
-      .cloned()
-      .unwrap_or_default();
-
-    let needs_runes_change_output = input_rune_balance > amount || input_rune_balances.len() > 1;
-
-    ensure! {
-      input_rune_balance >= amount,
-      "insufficient `{}` balance, only {} in wallet",
-      spaced_rune,
-      Pile {
-        amount: input_rune_balance,
-        divisibility: entry.divisibility,
-        symbol: entry.symbol
-      },
-    }
-
-    let runestone = Runestone {
-      edicts: vec![Edict {
-        amount,
-        id,
-        output: 2,
-      }],
-      ..default()
-    };
-
-    let unfunded_transaction = Transaction {
-      version: 2,
-      lock_time: LockTime::ZERO,
-      input: inputs
-        .into_iter()
-        .map(|previous_output| TxIn {
-          previous_output,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::MAX,
-          witness: Witness::new(),
-        })
-        .collect(),
-      output: if needs_runes_change_output {
-        vec![
-          TxOut {
-            script_pubkey: runestone.encipher(),
-            value: 0,
-          },
-          TxOut {
-            script_pubkey: wallet.get_change_address()?.script_pubkey(),
-            value: postage.to_sat(),
-          },
-          TxOut {
-            script_pubkey: destination.script_pubkey(),
-            value: postage.to_sat(),
-          },
-        ]
-      } else {
-        vec![TxOut {
-          script_pubkey: destination.script_pubkey(),
-          value: postage.to_sat(),
-        }]
-      },
-    };
-
-    let unsigned_transaction =
-      fund_raw_transaction(wallet.bitcoin_client(), fee_rate, &unfunded_transaction)?;
-
-    let unsigned_transaction = consensus::encode::deserialize(&unsigned_transaction)?;
-
-    if needs_runes_change_output {
-      assert_eq!(
-        Runestone::decipher(&unsigned_transaction),
-        Some(Artifact::Runestone(runestone)),
-      );
-    }
-
-    Ok(unsigned_transaction)
   }
 }

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -1,10 +1,12 @@
-use crate::wallet::transfer::amount_tranfer::AmountTransfer;
-use crate::wallet::transfer::inscription_transfer::InscriptionTransfer;
-use crate::wallet::transfer::rune_transfer::RuneTransfer;
-use crate::wallet::transfer::sat_transfer::SatTransfer;
-use crate::wallet::transfer::satpoint_transfer::SatPointTransfer;
-use crate::wallet::transfer::Transfer;
-use {super::*, crate::outgoing::Outgoing};
+use {
+  super::*,
+  crate::outgoing::Outgoing,
+  crate::wallet::transfer::{
+    amount_tranfer::AmountTransfer, inscription_transfer::InscriptionTransfer,
+    rune_transfer::RuneTransfer, sat_transfer::SatTransfer, satpoint_transfer::SatPointTransfer,
+    Transfer,
+  },
+};
 
 #[derive(Debug, Parser)]
 pub(crate) struct Send {

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -47,6 +47,6 @@ impl Send {
       Outgoing::SatPoint(satpoint) => Box::new(SatPointTransfer { satpoint }),
       Outgoing::Sat(sat) => Box::new(SatTransfer { sat }),
     };
-    transfer.send(&wallet, self.dry_run, address, self.postage, self.fee_rate)
+    transfer.execute(&wallet, self.dry_run, address, self.postage, self.fee_rate)
   }
 }

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -1,10 +1,10 @@
-use {super::*, crate::outgoing::Outgoing};
 use crate::wallet::transfer::amount_tranfer::AmountTransfer;
 use crate::wallet::transfer::inscription_transfer::InscriptionTransfer;
 use crate::wallet::transfer::rune_transfer::RuneTransfer;
 use crate::wallet::transfer::sat_transfer::SatTransfer;
 use crate::wallet::transfer::satpoint_transfer::SatPointTransfer;
 use crate::wallet::transfer::Transfer;
+use {super::*, crate::outgoing::Outgoing};
 
 #[derive(Debug, Parser)]
 pub(crate) struct Send {
@@ -37,39 +37,15 @@ impl Send {
       .require_network(wallet.chain().network())?;
 
     let transfer: Box<dyn Transfer> = match self.outgoing {
-      Outgoing::Amount(amount) => {
-        Box::new(AmountTransfer{
-          amount
-        })
-      }
-      Outgoing::Rune { decimal, rune } => {
-        Box::new(RuneTransfer {
-          decimal,
-          spaced_rune: rune,
-        })
-      },
-      Outgoing::InscriptionId(id) => {
-        Box::new(InscriptionTransfer {
-          id
-        })
-      },
-      Outgoing::SatPoint(satpoint) => {
-        Box::new(SatPointTransfer {
-          satpoint
-        })
-      },
-      Outgoing::Sat(sat) => {
-        Box::new(SatTransfer {
-          sat
-        })
-      },
+      Outgoing::Amount(amount) => Box::new(AmountTransfer { amount }),
+      Outgoing::Rune { decimal, rune } => Box::new(RuneTransfer {
+        decimal,
+        spaced_rune: rune,
+      }),
+      Outgoing::InscriptionId(id) => Box::new(InscriptionTransfer { id }),
+      Outgoing::SatPoint(satpoint) => Box::new(SatPointTransfer { satpoint }),
+      Outgoing::Sat(sat) => Box::new(SatTransfer { sat }),
     };
-    transfer.send(
-      &wallet,
-      self.dry_run,
-      address,
-      self.postage,
-      self.fee_rate,
-    )
+    transfer.send(&wallet, self.dry_run, address, self.postage, self.fee_rate)
   }
 }

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -35,7 +35,6 @@ impl Send {
       .address
       .clone()
       .require_network(wallet.chain().network())?;
-
     let transfer: Box<dyn Transfer> = match self.outgoing {
       Outgoing::Amount(amount) => Box::new(AmountTransfer { amount }),
       Outgoing::Rune { decimal, rune } => Box::new(RuneTransfer {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -21,9 +21,9 @@ use {
 };
 
 pub mod batch;
-pub mod transfer;
 pub mod entry;
 pub mod transaction_builder;
+pub mod transfer;
 pub mod wallet_constructor;
 const SCHEMA_VERSION: u64 = 1;
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -21,10 +21,10 @@ use {
 };
 
 pub mod batch;
+pub mod transfer;
 pub mod entry;
 pub mod transaction_builder;
 pub mod wallet_constructor;
-
 const SCHEMA_VERSION: u64 = 1;
 
 define_table! { RUNE_TO_ETCHING, u128, EtchingEntryValue }

--- a/src/wallet/transfer.rs
+++ b/src/wallet/transfer.rs
@@ -1,0 +1,121 @@
+pub(crate) mod rune_transfer;
+pub(crate) mod inscription_transfer;
+pub(crate) mod satpoint_transfer;
+pub(crate) mod sat_transfer;
+pub(crate) mod amount_tranfer;
+
+use {super::*, crate::outgoing::Outgoing, base64::Engine, bitcoin::psbt::Psbt};
+use crate::subcommand::wallet::send::Output;
+
+pub(crate) trait Transfer{
+    fn get_outgoing(&self) -> Outgoing;
+    fn create_unsigned_transaction(&self,
+                                   wallet: &Wallet,
+                                   destination: Address,
+                                   postage: Option<Amount>,
+                                   fee_rate: FeeRate) -> Result<Transaction>;
+    fn send(&self, wallet: &Wallet,
+            dry_run: bool, destination: Address,
+            postage: Option<Amount>,
+            fee_rate: FeeRate) -> SubcommandResult {
+        let unsigned_transaction = self.create_unsigned_transaction(wallet, destination, postage, fee_rate)?;
+
+        let unspent_outputs = wallet.utxos();
+
+        let (txid, psbt) = if dry_run {
+            let psbt = wallet
+                .bitcoin_client()
+                .wallet_process_psbt(
+                    &base64::engine::general_purpose::STANDARD
+                        .encode(Psbt::from_unsigned_tx(unsigned_transaction.clone())?.serialize()),
+                    Some(false),
+                    None,
+                    None,
+                )?
+                .psbt;
+
+            (unsigned_transaction.txid(), psbt)
+        } else {
+            let psbt = wallet
+                .bitcoin_client()
+                .wallet_process_psbt(
+                    &base64::engine::general_purpose::STANDARD
+                        .encode(Psbt::from_unsigned_tx(unsigned_transaction.clone())?.serialize()),
+                    Some(true),
+                    None,
+                    None,
+                )?
+                .psbt;
+
+            let signed_tx = wallet
+                .bitcoin_client()
+                .finalize_psbt(&psbt, None)?
+                .hex
+                .ok_or_else(|| anyhow!("unable to sign transaction"))?;
+
+            (
+                wallet.bitcoin_client().send_raw_transaction(&signed_tx)?,
+                psbt,
+            )
+        };
+
+        let mut fee = 0;
+        for txin in unsigned_transaction.input.iter() {
+            let Some(txout) = unspent_outputs.get(&txin.previous_output) else {
+                panic!("input {} not found in utxos", txin.previous_output);
+            };
+            fee += txout.value;
+        }
+
+        for txout in unsigned_transaction.output.iter() {
+            fee = fee.checked_sub(txout.value).unwrap();
+        }
+
+        Ok(Some(Box::new(Output {
+            txid,
+            psbt,
+            outgoing: self.get_outgoing(),
+            fee,
+        })))
+    }
+
+    fn create_unsigned_send_satpoint_transaction(
+        &self,
+        wallet: &Wallet,
+        destination: Address,
+        satpoint: SatPoint,
+        postage: Option<Amount>,
+        fee_rate: FeeRate,
+    ) -> Result<Transaction> {
+        let runic_outputs = wallet.get_runic_outputs()?;
+
+        ensure!(
+      !runic_outputs.contains(&satpoint.outpoint),
+      "runic outpoints may not be sent by satpoint"
+    );
+
+        let change = [wallet.get_change_address()?, wallet.get_change_address()?];
+
+        let postage = if let Some(postage) = postage {
+            Target::ExactPostage(postage)
+        } else {
+            Target::Postage
+        };
+
+        Ok(
+            TransactionBuilder::new(
+                satpoint,
+                wallet.inscriptions().clone(),
+                wallet.utxos().clone(),
+                wallet.locked_utxos().clone().into_keys().collect(),
+                runic_outputs,
+                destination.clone(),
+                change,
+                fee_rate,
+                postage,
+            )
+                .build_transaction()?,
+        )
+    }
+
+}

--- a/src/wallet/transfer.rs
+++ b/src/wallet/transfer.rs
@@ -16,7 +16,7 @@ pub(crate) trait Transfer {
     postage: Option<Amount>,
     fee_rate: FeeRate,
   ) -> Result<Transaction>;
-  fn send(
+  fn execute(
     &self,
     wallet: &Wallet,
     dry_run: bool,

--- a/src/wallet/transfer.rs
+++ b/src/wallet/transfer.rs
@@ -1,121 +1,127 @@
-pub(crate) mod rune_transfer;
-pub(crate) mod inscription_transfer;
-pub(crate) mod satpoint_transfer;
-pub(crate) mod sat_transfer;
 pub(crate) mod amount_tranfer;
+pub(crate) mod inscription_transfer;
+pub(crate) mod rune_transfer;
+pub(crate) mod sat_transfer;
+pub(crate) mod satpoint_transfer;
 
-use {super::*, crate::outgoing::Outgoing, base64::Engine, bitcoin::psbt::Psbt};
 use crate::subcommand::wallet::send::Output;
+use {super::*, crate::outgoing::Outgoing, base64::Engine, bitcoin::psbt::Psbt};
 
-pub(crate) trait Transfer{
-    fn get_outgoing(&self) -> Outgoing;
-    fn create_unsigned_transaction(&self,
-                                   wallet: &Wallet,
-                                   destination: Address,
-                                   postage: Option<Amount>,
-                                   fee_rate: FeeRate) -> Result<Transaction>;
-    fn send(&self, wallet: &Wallet,
-            dry_run: bool, destination: Address,
-            postage: Option<Amount>,
-            fee_rate: FeeRate) -> SubcommandResult {
-        let unsigned_transaction = self.create_unsigned_transaction(wallet, destination, postage, fee_rate)?;
+pub(crate) trait Transfer {
+  fn get_outgoing(&self) -> Outgoing;
+  fn create_unsigned_transaction(
+    &self,
+    wallet: &Wallet,
+    destination: Address,
+    postage: Option<Amount>,
+    fee_rate: FeeRate,
+  ) -> Result<Transaction>;
+  fn send(
+    &self,
+    wallet: &Wallet,
+    dry_run: bool,
+    destination: Address,
+    postage: Option<Amount>,
+    fee_rate: FeeRate,
+  ) -> SubcommandResult {
+    let unsigned_transaction =
+      self.create_unsigned_transaction(wallet, destination, postage, fee_rate)?;
 
-        let unspent_outputs = wallet.utxos();
+    let unspent_outputs = wallet.utxos();
 
-        let (txid, psbt) = if dry_run {
-            let psbt = wallet
-                .bitcoin_client()
-                .wallet_process_psbt(
-                    &base64::engine::general_purpose::STANDARD
-                        .encode(Psbt::from_unsigned_tx(unsigned_transaction.clone())?.serialize()),
-                    Some(false),
-                    None,
-                    None,
-                )?
-                .psbt;
+    let (txid, psbt) = if dry_run {
+      let psbt = wallet
+        .bitcoin_client()
+        .wallet_process_psbt(
+          &base64::engine::general_purpose::STANDARD
+            .encode(Psbt::from_unsigned_tx(unsigned_transaction.clone())?.serialize()),
+          Some(false),
+          None,
+          None,
+        )?
+        .psbt;
 
-            (unsigned_transaction.txid(), psbt)
-        } else {
-            let psbt = wallet
-                .bitcoin_client()
-                .wallet_process_psbt(
-                    &base64::engine::general_purpose::STANDARD
-                        .encode(Psbt::from_unsigned_tx(unsigned_transaction.clone())?.serialize()),
-                    Some(true),
-                    None,
-                    None,
-                )?
-                .psbt;
+      (unsigned_transaction.txid(), psbt)
+    } else {
+      let psbt = wallet
+        .bitcoin_client()
+        .wallet_process_psbt(
+          &base64::engine::general_purpose::STANDARD
+            .encode(Psbt::from_unsigned_tx(unsigned_transaction.clone())?.serialize()),
+          Some(true),
+          None,
+          None,
+        )?
+        .psbt;
 
-            let signed_tx = wallet
-                .bitcoin_client()
-                .finalize_psbt(&psbt, None)?
-                .hex
-                .ok_or_else(|| anyhow!("unable to sign transaction"))?;
+      let signed_tx = wallet
+        .bitcoin_client()
+        .finalize_psbt(&psbt, None)?
+        .hex
+        .ok_or_else(|| anyhow!("unable to sign transaction"))?;
 
-            (
-                wallet.bitcoin_client().send_raw_transaction(&signed_tx)?,
-                psbt,
-            )
-        };
+      (
+        wallet.bitcoin_client().send_raw_transaction(&signed_tx)?,
+        psbt,
+      )
+    };
 
-        let mut fee = 0;
-        for txin in unsigned_transaction.input.iter() {
-            let Some(txout) = unspent_outputs.get(&txin.previous_output) else {
-                panic!("input {} not found in utxos", txin.previous_output);
-            };
-            fee += txout.value;
-        }
-
-        for txout in unsigned_transaction.output.iter() {
-            fee = fee.checked_sub(txout.value).unwrap();
-        }
-
-        Ok(Some(Box::new(Output {
-            txid,
-            psbt,
-            outgoing: self.get_outgoing(),
-            fee,
-        })))
+    let mut fee = 0;
+    for txin in unsigned_transaction.input.iter() {
+      let Some(txout) = unspent_outputs.get(&txin.previous_output) else {
+        panic!("input {} not found in utxos", txin.previous_output);
+      };
+      fee += txout.value;
     }
 
-    fn create_unsigned_send_satpoint_transaction(
-        &self,
-        wallet: &Wallet,
-        destination: Address,
-        satpoint: SatPoint,
-        postage: Option<Amount>,
-        fee_rate: FeeRate,
-    ) -> Result<Transaction> {
-        let runic_outputs = wallet.get_runic_outputs()?;
+    for txout in unsigned_transaction.output.iter() {
+      fee = fee.checked_sub(txout.value).unwrap();
+    }
 
-        ensure!(
+    Ok(Some(Box::new(Output {
+      txid,
+      psbt,
+      outgoing: self.get_outgoing(),
+      fee,
+    })))
+  }
+
+  fn create_unsigned_send_satpoint_transaction(
+    &self,
+    wallet: &Wallet,
+    destination: Address,
+    satpoint: SatPoint,
+    postage: Option<Amount>,
+    fee_rate: FeeRate,
+  ) -> Result<Transaction> {
+    let runic_outputs = wallet.get_runic_outputs()?;
+
+    ensure!(
       !runic_outputs.contains(&satpoint.outpoint),
       "runic outpoints may not be sent by satpoint"
     );
 
-        let change = [wallet.get_change_address()?, wallet.get_change_address()?];
+    let change = [wallet.get_change_address()?, wallet.get_change_address()?];
 
-        let postage = if let Some(postage) = postage {
-            Target::ExactPostage(postage)
-        } else {
-            Target::Postage
-        };
+    let postage = if let Some(postage) = postage {
+      Target::ExactPostage(postage)
+    } else {
+      Target::Postage
+    };
 
-        Ok(
-            TransactionBuilder::new(
-                satpoint,
-                wallet.inscriptions().clone(),
-                wallet.utxos().clone(),
-                wallet.locked_utxos().clone().into_keys().collect(),
-                runic_outputs,
-                destination.clone(),
-                change,
-                fee_rate,
-                postage,
-            )
-                .build_transaction()?,
-        )
-    }
-
+    Ok(
+      TransactionBuilder::new(
+        satpoint,
+        wallet.inscriptions().clone(),
+        wallet.utxos().clone(),
+        wallet.locked_utxos().clone().into_keys().collect(),
+        runic_outputs,
+        destination.clone(),
+        change,
+        fee_rate,
+        postage,
+      )
+      .build_transaction()?,
+    )
+  }
 }

--- a/src/wallet/transfer/amount_tranfer.rs
+++ b/src/wallet/transfer/amount_tranfer.rs
@@ -1,0 +1,32 @@
+use {crate::outgoing::Outgoing, super::*};
+
+pub(crate) struct AmountTransfer{
+    pub(crate) amount: Amount
+}
+impl Transfer for AmountTransfer {
+    fn get_outgoing(&self) -> Outgoing {
+        Outgoing::Amount(self.amount)
+    }
+
+    fn create_unsigned_transaction(&self, wallet: &Wallet, destination: Address, _postage: Option<Amount>, fee_rate: FeeRate) -> crate::Result<Transaction> {
+        wallet.lock_non_cardinal_outputs()?;
+
+        let unfunded_transaction = Transaction {
+            version: 2,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: vec![TxOut {
+                script_pubkey: destination.script_pubkey(),
+                value: self.amount.to_sat(),
+            }],
+        };
+
+        let unsigned_transaction = consensus::encode::deserialize(&fund_raw_transaction(
+            wallet.bitcoin_client(),
+            fee_rate,
+            &unfunded_transaction,
+        )?)?;
+
+        Ok(unsigned_transaction)
+    }
+}

--- a/src/wallet/transfer/amount_tranfer.rs
+++ b/src/wallet/transfer/amount_tranfer.rs
@@ -1,32 +1,38 @@
-use {crate::outgoing::Outgoing, super::*};
+use {super::*, crate::outgoing::Outgoing};
 
-pub(crate) struct AmountTransfer{
-    pub(crate) amount: Amount
+pub(crate) struct AmountTransfer {
+  pub(crate) amount: Amount,
 }
 impl Transfer for AmountTransfer {
-    fn get_outgoing(&self) -> Outgoing {
-        Outgoing::Amount(self.amount)
-    }
+  fn get_outgoing(&self) -> Outgoing {
+    Outgoing::Amount(self.amount)
+  }
 
-    fn create_unsigned_transaction(&self, wallet: &Wallet, destination: Address, _postage: Option<Amount>, fee_rate: FeeRate) -> crate::Result<Transaction> {
-        wallet.lock_non_cardinal_outputs()?;
+  fn create_unsigned_transaction(
+    &self,
+    wallet: &Wallet,
+    destination: Address,
+    _postage: Option<Amount>,
+    fee_rate: FeeRate,
+  ) -> crate::Result<Transaction> {
+    wallet.lock_non_cardinal_outputs()?;
 
-        let unfunded_transaction = Transaction {
-            version: 2,
-            lock_time: LockTime::ZERO,
-            input: Vec::new(),
-            output: vec![TxOut {
-                script_pubkey: destination.script_pubkey(),
-                value: self.amount.to_sat(),
-            }],
-        };
+    let unfunded_transaction = Transaction {
+      version: 2,
+      lock_time: LockTime::ZERO,
+      input: Vec::new(),
+      output: vec![TxOut {
+        script_pubkey: destination.script_pubkey(),
+        value: self.amount.to_sat(),
+      }],
+    };
 
-        let unsigned_transaction = consensus::encode::deserialize(&fund_raw_transaction(
-            wallet.bitcoin_client(),
-            fee_rate,
-            &unfunded_transaction,
-        )?)?;
+    let unsigned_transaction = consensus::encode::deserialize(&fund_raw_transaction(
+      wallet.bitcoin_client(),
+      fee_rate,
+      &unfunded_transaction,
+    )?)?;
 
-        Ok(unsigned_transaction)
-    }
+    Ok(unsigned_transaction)
+  }
 }

--- a/src/wallet/transfer/inscription_transfer.rs
+++ b/src/wallet/transfer/inscription_transfer.rs
@@ -1,0 +1,26 @@
+use {crate::outgoing::Outgoing, super::*};
+
+pub(crate) struct InscriptionTransfer{
+    pub(crate) id: InscriptionId
+}
+
+impl Transfer for InscriptionTransfer{
+    fn get_outgoing(&self) -> Outgoing {
+        Outgoing::InscriptionId(self.id)
+    }
+
+    fn create_unsigned_transaction(&self, wallet: &Wallet, destination: Address, postage: Option<Amount>, fee_rate: FeeRate) -> crate::Result<Transaction> {
+        let id = self.id;
+        let satpoint = wallet
+            .inscription_info()
+            .get(&id)
+            .ok_or_else(|| anyhow!("inscription {id} not found"))?
+            .satpoint;
+        for inscription_satpoint in wallet.inscriptions().keys() {
+            if satpoint == *inscription_satpoint {
+                bail!("inscriptions must be sent by inscription ID");
+            }
+        }
+        self.create_unsigned_send_satpoint_transaction(wallet, destination, satpoint, postage, fee_rate)
+    }
+}

--- a/src/wallet/transfer/inscription_transfer.rs
+++ b/src/wallet/transfer/inscription_transfer.rs
@@ -15,18 +15,13 @@ impl Transfer for InscriptionTransfer {
     destination: Address,
     postage: Option<Amount>,
     fee_rate: FeeRate,
-  ) -> crate::Result<Transaction> {
+  ) -> Result<Transaction> {
     let id = self.id;
     let satpoint = wallet
       .inscription_info()
       .get(&id)
       .ok_or_else(|| anyhow!("inscription {id} not found"))?
       .satpoint;
-    for inscription_satpoint in wallet.inscriptions().keys() {
-      if satpoint == *inscription_satpoint {
-        bail!("inscriptions must be sent by inscription ID");
-      }
-    }
     self.create_unsigned_send_satpoint_transaction(wallet, destination, satpoint, postage, fee_rate)
   }
 }

--- a/src/wallet/transfer/inscription_transfer.rs
+++ b/src/wallet/transfer/inscription_transfer.rs
@@ -1,26 +1,32 @@
-use {crate::outgoing::Outgoing, super::*};
+use {super::*, crate::outgoing::Outgoing};
 
-pub(crate) struct InscriptionTransfer{
-    pub(crate) id: InscriptionId
+pub(crate) struct InscriptionTransfer {
+  pub(crate) id: InscriptionId,
 }
 
-impl Transfer for InscriptionTransfer{
-    fn get_outgoing(&self) -> Outgoing {
-        Outgoing::InscriptionId(self.id)
-    }
+impl Transfer for InscriptionTransfer {
+  fn get_outgoing(&self) -> Outgoing {
+    Outgoing::InscriptionId(self.id)
+  }
 
-    fn create_unsigned_transaction(&self, wallet: &Wallet, destination: Address, postage: Option<Amount>, fee_rate: FeeRate) -> crate::Result<Transaction> {
-        let id = self.id;
-        let satpoint = wallet
-            .inscription_info()
-            .get(&id)
-            .ok_or_else(|| anyhow!("inscription {id} not found"))?
-            .satpoint;
-        for inscription_satpoint in wallet.inscriptions().keys() {
-            if satpoint == *inscription_satpoint {
-                bail!("inscriptions must be sent by inscription ID");
-            }
-        }
-        self.create_unsigned_send_satpoint_transaction(wallet, destination, satpoint, postage, fee_rate)
+  fn create_unsigned_transaction(
+    &self,
+    wallet: &Wallet,
+    destination: Address,
+    postage: Option<Amount>,
+    fee_rate: FeeRate,
+  ) -> crate::Result<Transaction> {
+    let id = self.id;
+    let satpoint = wallet
+      .inscription_info()
+      .get(&id)
+      .ok_or_else(|| anyhow!("inscription {id} not found"))?
+      .satpoint;
+    for inscription_satpoint in wallet.inscriptions().keys() {
+      if satpoint == *inscription_satpoint {
+        bail!("inscriptions must be sent by inscription ID");
+      }
     }
+    self.create_unsigned_send_satpoint_transaction(wallet, destination, satpoint, postage, fee_rate)
+  }
 }

--- a/src/wallet/transfer/rune_transfer.rs
+++ b/src/wallet/transfer/rune_transfer.rs
@@ -1,89 +1,94 @@
-use {crate::outgoing::Outgoing, super::*};
+use {super::*, crate::outgoing::Outgoing};
 
 pub(crate) struct RuneTransfer {
-    pub(crate) decimal: Decimal,
-    pub(crate) spaced_rune: SpacedRune
+  pub(crate) decimal: Decimal,
+  pub(crate) spaced_rune: SpacedRune,
 }
 
 impl Transfer for RuneTransfer {
-    fn get_outgoing(&self) -> Outgoing {
-        Outgoing::Rune {
-            decimal: self.decimal,
-            rune: self.spaced_rune
-        }
+  fn get_outgoing(&self) -> Outgoing {
+    Outgoing::Rune {
+      decimal: self.decimal,
+      rune: self.spaced_rune,
     }
+  }
 
-    fn create_unsigned_transaction(&self, wallet: &Wallet,
-                                   destination: Address,
-                                   postage: Option<Amount>,
-                                   fee_rate: FeeRate) -> Result<Transaction> {
-        ensure!(
+  fn create_unsigned_transaction(
+    &self,
+    wallet: &Wallet,
+    destination: Address,
+    postage: Option<Amount>,
+    fee_rate: FeeRate,
+  ) -> Result<Transaction> {
+    ensure!(
       wallet.has_rune_index(),
       "sending runes with `ord send` requires index created with `--index-runes` flag",
     );
-        let postage = postage.unwrap_or(TARGET_POSTAGE);
+    let postage = postage.unwrap_or(TARGET_POSTAGE);
 
-        wallet.lock_non_cardinal_outputs()?;
+    wallet.lock_non_cardinal_outputs()?;
 
-        let (id, entry, _parent) = wallet
-            .get_rune(self.spaced_rune.rune)?
-            .with_context(|| format!("rune `{}` has not been etched", self.spaced_rune.rune))?;
+    let (id, entry, _parent) = wallet
+      .get_rune(self.spaced_rune.rune)?
+      .with_context(|| format!("rune `{}` has not been etched", self.spaced_rune.rune))?;
 
-        let amount = self.decimal.to_integer(entry.divisibility)?;
+    let amount = self.decimal.to_integer(entry.divisibility)?;
 
-        let inscribed_outputs = wallet
-            .inscriptions()
-            .keys()
-            .map(|satpoint| satpoint.outpoint)
-            .collect::<HashSet<OutPoint>>();
+    let inscribed_outputs = wallet
+      .inscriptions()
+      .keys()
+      .map(|satpoint| satpoint.outpoint)
+      .collect::<HashSet<OutPoint>>();
 
-        let balances = wallet
-            .get_runic_outputs()?
-            .into_iter()
-            .filter(|output| !inscribed_outputs.contains(output))
-            .map(|output| {
-                wallet.get_runes_balances_in_output(&output).map(|balance| {
-                    (
-                        output,
-                        balance
-                            .into_iter()
-                            .map(|(spaced_rune, pile)| (spaced_rune.rune, pile))
-                            .collect(),
-                    )
-                })
-            })
-            .collect::<crate::Result<BTreeMap<OutPoint, BTreeMap<Rune, Pile>>>>()?;
+    let balances = wallet
+      .get_runic_outputs()?
+      .into_iter()
+      .filter(|output| !inscribed_outputs.contains(output))
+      .map(|output| {
+        wallet.get_runes_balances_in_output(&output).map(|balance| {
+          (
+            output,
+            balance
+              .into_iter()
+              .map(|(spaced_rune, pile)| (spaced_rune.rune, pile))
+              .collect(),
+          )
+        })
+      })
+      .collect::<crate::Result<BTreeMap<OutPoint, BTreeMap<Rune, Pile>>>>()?;
 
-        let mut inputs = Vec::new();
-        let mut input_rune_balances: BTreeMap<Rune, u128> = BTreeMap::new();
+    let mut inputs = Vec::new();
+    let mut input_rune_balances: BTreeMap<Rune, u128> = BTreeMap::new();
 
-        for (output, runes) in balances {
-            if let Some(balance) = runes.get(&self.spaced_rune.rune) {
-                if balance.amount > 0 {
-                    *input_rune_balances.entry(self.spaced_rune.rune).or_default() += balance.amount;
+    for (output, runes) in balances {
+      if let Some(balance) = runes.get(&self.spaced_rune.rune) {
+        if balance.amount > 0 {
+          *input_rune_balances
+            .entry(self.spaced_rune.rune)
+            .or_default() += balance.amount;
 
-                    inputs.push(output);
-                }
-            }
-
-            if input_rune_balances
-                .get(&self.spaced_rune.rune)
-                .cloned()
-                .unwrap_or_default()
-                >= amount
-            {
-                break;
-            }
+          inputs.push(output);
         }
+      }
 
-        let input_rune_balance = input_rune_balances
-            .get(&self.spaced_rune.rune)
-            .cloned()
-            .unwrap_or_default();
+      if input_rune_balances
+        .get(&self.spaced_rune.rune)
+        .cloned()
+        .unwrap_or_default()
+        >= amount
+      {
+        break;
+      }
+    }
 
-        let needs_runes_change_output = input_rune_balance > amount || input_rune_balances.len() > 1;
+    let input_rune_balance = input_rune_balances
+      .get(&self.spaced_rune.rune)
+      .cloned()
+      .unwrap_or_default();
 
-        ensure! {
+    let needs_runes_change_output = input_rune_balance > amount || input_rune_balances.len() > 1;
+
+    ensure! {
       input_rune_balance >= amount,
       "insufficient `{}` balance, only {} in wallet",
       self.spaced_rune,
@@ -94,62 +99,62 @@ impl Transfer for RuneTransfer {
       },
     }
 
-        let runestone = Runestone {
-            edicts: vec![Edict {
-                amount,
-                id,
-                output: 2,
-            }],
-            ..default()
-        };
+    let runestone = Runestone {
+      edicts: vec![Edict {
+        amount,
+        id,
+        output: 2,
+      }],
+      ..default()
+    };
 
-        let unfunded_transaction = Transaction {
-            version: 2,
-            lock_time: LockTime::ZERO,
-            input: inputs
-                .into_iter()
-                .map(|previous_output| TxIn {
-                    previous_output,
-                    script_sig: ScriptBuf::new(),
-                    sequence: Sequence::MAX,
-                    witness: Witness::new(),
-                })
-                .collect(),
-            output: if needs_runes_change_output {
-                vec![
-                    TxOut {
-                        script_pubkey: runestone.encipher(),
-                        value: 0,
-                    },
-                    TxOut {
-                        script_pubkey: wallet.get_change_address()?.script_pubkey(),
-                        value: postage.to_sat(),
-                    },
-                    TxOut {
-                        script_pubkey: destination.script_pubkey(),
-                        value: postage.to_sat(),
-                    },
-                ]
-            } else {
-                vec![TxOut {
-                    script_pubkey: destination.script_pubkey(),
-                    value: postage.to_sat(),
-                }]
-            },
-        };
+    let unfunded_transaction = Transaction {
+      version: 2,
+      lock_time: LockTime::ZERO,
+      input: inputs
+        .into_iter()
+        .map(|previous_output| TxIn {
+          previous_output,
+          script_sig: ScriptBuf::new(),
+          sequence: Sequence::MAX,
+          witness: Witness::new(),
+        })
+        .collect(),
+      output: if needs_runes_change_output {
+        vec![
+          TxOut {
+            script_pubkey: runestone.encipher(),
+            value: 0,
+          },
+          TxOut {
+            script_pubkey: wallet.get_change_address()?.script_pubkey(),
+            value: postage.to_sat(),
+          },
+          TxOut {
+            script_pubkey: destination.script_pubkey(),
+            value: postage.to_sat(),
+          },
+        ]
+      } else {
+        vec![TxOut {
+          script_pubkey: destination.script_pubkey(),
+          value: postage.to_sat(),
+        }]
+      },
+    };
 
-        let unsigned_transaction =
-            fund_raw_transaction(wallet.bitcoin_client(), fee_rate, &unfunded_transaction)?;
+    let unsigned_transaction =
+      fund_raw_transaction(wallet.bitcoin_client(), fee_rate, &unfunded_transaction)?;
 
-        let unsigned_transaction = consensus::encode::deserialize(&unsigned_transaction)?;
+    let unsigned_transaction = consensus::encode::deserialize(&unsigned_transaction)?;
 
-        if needs_runes_change_output {
-            assert_eq!(
+    if needs_runes_change_output {
+      assert_eq!(
         Runestone::decipher(&unsigned_transaction),
         Some(Artifact::Runestone(runestone)),
       );
-        }
-
-        Ok(unsigned_transaction)
     }
+
+    Ok(unsigned_transaction)
+  }
 }

--- a/src/wallet/transfer/rune_transfer.rs
+++ b/src/wallet/transfer/rune_transfer.rs
@@ -1,0 +1,155 @@
+use {crate::outgoing::Outgoing, super::*};
+
+pub(crate) struct RuneTransfer {
+    pub(crate) decimal: Decimal,
+    pub(crate) spaced_rune: SpacedRune
+}
+
+impl Transfer for RuneTransfer {
+    fn get_outgoing(&self) -> Outgoing {
+        Outgoing::Rune {
+            decimal: self.decimal,
+            rune: self.spaced_rune
+        }
+    }
+
+    fn create_unsigned_transaction(&self, wallet: &Wallet,
+                                   destination: Address,
+                                   postage: Option<Amount>,
+                                   fee_rate: FeeRate) -> Result<Transaction> {
+        ensure!(
+      wallet.has_rune_index(),
+      "sending runes with `ord send` requires index created with `--index-runes` flag",
+    );
+        let postage = postage.unwrap_or(TARGET_POSTAGE);
+
+        wallet.lock_non_cardinal_outputs()?;
+
+        let (id, entry, _parent) = wallet
+            .get_rune(self.spaced_rune.rune)?
+            .with_context(|| format!("rune `{}` has not been etched", self.spaced_rune.rune))?;
+
+        let amount = self.decimal.to_integer(entry.divisibility)?;
+
+        let inscribed_outputs = wallet
+            .inscriptions()
+            .keys()
+            .map(|satpoint| satpoint.outpoint)
+            .collect::<HashSet<OutPoint>>();
+
+        let balances = wallet
+            .get_runic_outputs()?
+            .into_iter()
+            .filter(|output| !inscribed_outputs.contains(output))
+            .map(|output| {
+                wallet.get_runes_balances_in_output(&output).map(|balance| {
+                    (
+                        output,
+                        balance
+                            .into_iter()
+                            .map(|(spaced_rune, pile)| (spaced_rune.rune, pile))
+                            .collect(),
+                    )
+                })
+            })
+            .collect::<crate::Result<BTreeMap<OutPoint, BTreeMap<Rune, Pile>>>>()?;
+
+        let mut inputs = Vec::new();
+        let mut input_rune_balances: BTreeMap<Rune, u128> = BTreeMap::new();
+
+        for (output, runes) in balances {
+            if let Some(balance) = runes.get(&self.spaced_rune.rune) {
+                if balance.amount > 0 {
+                    *input_rune_balances.entry(self.spaced_rune.rune).or_default() += balance.amount;
+
+                    inputs.push(output);
+                }
+            }
+
+            if input_rune_balances
+                .get(&self.spaced_rune.rune)
+                .cloned()
+                .unwrap_or_default()
+                >= amount
+            {
+                break;
+            }
+        }
+
+        let input_rune_balance = input_rune_balances
+            .get(&self.spaced_rune.rune)
+            .cloned()
+            .unwrap_or_default();
+
+        let needs_runes_change_output = input_rune_balance > amount || input_rune_balances.len() > 1;
+
+        ensure! {
+      input_rune_balance >= amount,
+      "insufficient `{}` balance, only {} in wallet",
+      self.spaced_rune,
+      Pile {
+        amount: input_rune_balance,
+        divisibility: entry.divisibility,
+        symbol: entry.symbol
+      },
+    }
+
+        let runestone = Runestone {
+            edicts: vec![Edict {
+                amount,
+                id,
+                output: 2,
+            }],
+            ..default()
+        };
+
+        let unfunded_transaction = Transaction {
+            version: 2,
+            lock_time: LockTime::ZERO,
+            input: inputs
+                .into_iter()
+                .map(|previous_output| TxIn {
+                    previous_output,
+                    script_sig: ScriptBuf::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
+                })
+                .collect(),
+            output: if needs_runes_change_output {
+                vec![
+                    TxOut {
+                        script_pubkey: runestone.encipher(),
+                        value: 0,
+                    },
+                    TxOut {
+                        script_pubkey: wallet.get_change_address()?.script_pubkey(),
+                        value: postage.to_sat(),
+                    },
+                    TxOut {
+                        script_pubkey: destination.script_pubkey(),
+                        value: postage.to_sat(),
+                    },
+                ]
+            } else {
+                vec![TxOut {
+                    script_pubkey: destination.script_pubkey(),
+                    value: postage.to_sat(),
+                }]
+            },
+        };
+
+        let unsigned_transaction =
+            fund_raw_transaction(wallet.bitcoin_client(), fee_rate, &unfunded_transaction)?;
+
+        let unsigned_transaction = consensus::encode::deserialize(&unsigned_transaction)?;
+
+        if needs_runes_change_output {
+            assert_eq!(
+        Runestone::decipher(&unsigned_transaction),
+        Some(Artifact::Runestone(runestone)),
+      );
+        }
+
+        Ok(unsigned_transaction)
+    }
+}

--- a/src/wallet/transfer/sat_transfer.rs
+++ b/src/wallet/transfer/sat_transfer.rs
@@ -1,15 +1,21 @@
-use {crate::outgoing::Outgoing, super::*};
+use {super::*, crate::outgoing::Outgoing};
 
 pub(crate) struct SatTransfer {
-    pub(crate) sat: Sat
+  pub(crate) sat: Sat,
 }
 
 impl Transfer for SatTransfer {
-    fn get_outgoing(&self) -> Outgoing {
-        Outgoing::Sat(self.sat)
-    }
-    fn create_unsigned_transaction(&self, wallet: &Wallet, destination: Address, postage: Option<Amount>, fee_rate: FeeRate) -> crate::Result<Transaction> {
-        let satpoint = wallet.find_sat_in_outputs(self.sat)?;
-        self.create_unsigned_send_satpoint_transaction(wallet, destination, satpoint, postage, fee_rate)
-    }
+  fn get_outgoing(&self) -> Outgoing {
+    Outgoing::Sat(self.sat)
+  }
+  fn create_unsigned_transaction(
+    &self,
+    wallet: &Wallet,
+    destination: Address,
+    postage: Option<Amount>,
+    fee_rate: FeeRate,
+  ) -> crate::Result<Transaction> {
+    let satpoint = wallet.find_sat_in_outputs(self.sat)?;
+    self.create_unsigned_send_satpoint_transaction(wallet, destination, satpoint, postage, fee_rate)
+  }
 }

--- a/src/wallet/transfer/sat_transfer.rs
+++ b/src/wallet/transfer/sat_transfer.rs
@@ -1,0 +1,15 @@
+use {crate::outgoing::Outgoing, super::*};
+
+pub(crate) struct SatTransfer {
+    pub(crate) sat: Sat
+}
+
+impl Transfer for SatTransfer {
+    fn get_outgoing(&self) -> Outgoing {
+        Outgoing::Sat(self.sat)
+    }
+    fn create_unsigned_transaction(&self, wallet: &Wallet, destination: Address, postage: Option<Amount>, fee_rate: FeeRate) -> crate::Result<Transaction> {
+        let satpoint = wallet.find_sat_in_outputs(self.sat)?;
+        self.create_unsigned_send_satpoint_transaction(wallet, destination, satpoint, postage, fee_rate)
+    }
+}

--- a/src/wallet/transfer/satpoint_transfer.rs
+++ b/src/wallet/transfer/satpoint_transfer.rs
@@ -1,15 +1,27 @@
-use {crate::outgoing::Outgoing, super::*};
+use {super::*, crate::outgoing::Outgoing};
 
 pub(crate) struct SatPointTransfer {
-    pub(crate) satpoint: SatPoint
+  pub(crate) satpoint: SatPoint,
 }
 
 impl Transfer for SatPointTransfer {
-    fn get_outgoing(&self) -> Outgoing {
-        Outgoing::SatPoint(self.satpoint)
-    }
+  fn get_outgoing(&self) -> Outgoing {
+    Outgoing::SatPoint(self.satpoint)
+  }
 
-    fn create_unsigned_transaction(&self, wallet: &Wallet, destination: Address, postage: Option<Amount>, fee_rate: FeeRate) -> crate::Result<Transaction> {
-        self.create_unsigned_send_satpoint_transaction(wallet, destination, self.satpoint, postage, fee_rate)
-    }
+  fn create_unsigned_transaction(
+    &self,
+    wallet: &Wallet,
+    destination: Address,
+    postage: Option<Amount>,
+    fee_rate: FeeRate,
+  ) -> crate::Result<Transaction> {
+    self.create_unsigned_send_satpoint_transaction(
+      wallet,
+      destination,
+      self.satpoint,
+      postage,
+      fee_rate,
+    )
+  }
 }

--- a/src/wallet/transfer/satpoint_transfer.rs
+++ b/src/wallet/transfer/satpoint_transfer.rs
@@ -1,0 +1,15 @@
+use {crate::outgoing::Outgoing, super::*};
+
+pub(crate) struct SatPointTransfer {
+    pub(crate) satpoint: SatPoint
+}
+
+impl Transfer for SatPointTransfer {
+    fn get_outgoing(&self) -> Outgoing {
+        Outgoing::SatPoint(self.satpoint)
+    }
+
+    fn create_unsigned_transaction(&self, wallet: &Wallet, destination: Address, postage: Option<Amount>, fee_rate: FeeRate) -> crate::Result<Transaction> {
+        self.create_unsigned_send_satpoint_transaction(wallet, destination, self.satpoint, postage, fee_rate)
+    }
+}

--- a/src/wallet/transfer/satpoint_transfer.rs
+++ b/src/wallet/transfer/satpoint_transfer.rs
@@ -15,7 +15,12 @@ impl Transfer for SatPointTransfer {
     destination: Address,
     postage: Option<Amount>,
     fee_rate: FeeRate,
-  ) -> crate::Result<Transaction> {
+  ) -> Result<Transaction> {
+    for inscription_satpoint in wallet.inscriptions().keys() {
+      if self.satpoint == *inscription_satpoint {
+        bail!("inscriptions must be sent by inscription ID");
+      }
+    }
     self.create_unsigned_send_satpoint_transaction(
       wallet,
       destination,


### PR DESCRIPTION
### Motivation
#### Catching bugs early for example: 
- If transfer trait has a fixed contract, bugs like this could be cought early by making sure that the postage is used for new transfer implementation - https://github.com/ordinals/ord/issues/3620
  
#### Code Quality
- More extensibility, for example, the most requested features in ordicord like `splitting rune` or `send to many` can have its own transfer trait implementation without bloating [send.rs](https://github.com/ordinals/ord/blob/master/src/subcommand/wallet/send.rs) file.
- Cleaner code, for example:
    - [`sending_inscription`](https://github.com/ordinals/ord/blob/b0435e8cc5718773e2b97c01a25a96dc5af01abe/src/subcommand/wallet/send.rs#L167) boolean can be moved out of the `create_unsigned_send_satpoint_transaction` method and to its trait implementation (not a big deal but just a bit cleaner code)
    - [send.rs](https://github.com/ordinals/ord/blob/9c903e43bc8388efb30b6ff4ce439f1325365c39/src/subcommand/wallet/send.rs) is now just 52 lines of code after the refactor and super readable ❤️ 