### PR TITLE
Add decode api

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3,9 +3,12 @@ use {
   serde_hex::{SerHex, Strict},
 };
 
-pub use crate::templates::{
-  BlocksHtml as Blocks, RuneHtml as Rune, RunesHtml as Runes, StatusHtml as Status,
-  TransactionHtml as Transaction,
+pub use crate::{
+  subcommand::decode::RawOutput as Decode,
+  templates::{
+    BlocksHtml as Blocks, RuneHtml as Rune, RunesHtml as Runes, StatusHtml as Status,
+    TransactionHtml as Transaction,
+  },
 };
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -191,10 +194,4 @@ pub struct SatInscriptions {
   pub ids: Vec<InscriptionId>,
   pub more: bool,
   pub page: u64,
-}
-
-#[derive(Serialize, Eq, PartialEq, Deserialize, Debug)]
-pub struct RawOutput {
-  pub inscriptions: Vec<ParsedEnvelope>,
-  pub runestone: Option<Artifact>,
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -262,7 +262,7 @@ impl Server {
         .route("/static/*path", get(Self::static_asset))
         .route("/status", get(Self::status))
         .route("/tx/:txid", get(Self::transaction))
-        .route("/decode/:txid", get(Self::decode_tx))
+        .route("/decode/:txid", get(Self::decode))
         .route("/update", get(Self::update))
         .fallback(Self::fallback)
         .layer(Extension(index))
@@ -915,7 +915,7 @@ impl Server {
     })
   }
 
-  async fn decode_tx(
+  async fn decode(
     Extension(index): Extension<Arc<Index>>,
     Path(txid): Path<Txid>,
     AcceptJson(accept_json): AcceptJson,
@@ -929,7 +929,7 @@ impl Server {
       let runestone = Runestone::decipher(&transaction);
 
       Ok(if accept_json {
-        Json(api::RawOutput {
+        Json(api::Decode {
           inscriptions,
           runestone,
         })

--- a/tests/json_api.rs
+++ b/tests/json_api.rs
@@ -745,8 +745,8 @@ fn get_decode_tx() {
   assert_eq!(response.status(), StatusCode::OK);
 
   assert_eq!(
-    serde_json::from_str::<api::RawOutput>(&response.text().unwrap()).unwrap(),
-    api::RawOutput {
+    serde_json::from_str::<api::Decode>(&response.text().unwrap()).unwrap(),
+    api::Decode {
       inscriptions,
       runestone,
     }


### PR DESCRIPTION
Based on the issue https://github.com/ordinals/ord/issues/3676, I have added an API named "decode" to parse the OP_RETURN in transactions (tx).