### PR TITLE
premine percentage and supply fields update for rune.html

### DIFF
--- a/templates/rune.html
+++ b/templates/rune.html
@@ -50,12 +50,35 @@
 %% } else {
   <dd>no</dd>
 %% }
-  <dt>supply</dt>
+  <dt>current supply</dt>
   <dd>{{ self.entry.pile(self.entry.supply()) }}</dd>
+  %% if let Some(terms) = self.entry.terms {
+    %% if let Some(symbol) = self.entry.symbol {
+      <dt>maximum supply</dt>
+      <dd>{{ (terms.cap.unwrap_or_default() * terms.amount.unwrap_or_default()) + self.entry.premine }}{{ symbol }}</dd>
+    %% } } else {
+      <dt>maximum supply</dt>
+      <dd>Unable to calculate maximum supply</dd>
+      %% }
+  %% if let Some(terms) = self.entry.terms {
+    %% if let Some(symbol) = self.entry.symbol {
+      <dt>supply progress</dt>
+  <dd>{{ self.entry.pile(self.entry.supply()) }} of {{ (terms.cap.unwrap_or_default() * terms.amount.unwrap_or_default()) + self.entry.premine }}{{ symbol }} </dd>
+  %% } } else {
+    <dt>supply progress</dt>
+    <dd>Unable to calculate supply progress</dd>
+    %% }
   <dt>premine</dt>
   <dd>{{ self.entry.pile(self.entry.premine) }}</dd>
-  <dt>premine percentage</dt>
+  <dt>premine percentage of current supply</dt>
   <dd>{{ Decimal { value: ((self.entry.premine as f64 / self.entry.supply() as f64) * 10000.0) as u128, scale: 2 } }}%</dd>
+  %% if let Some(terms) = self.entry.terms {
+  <dt>premine percentage of maximum supply</dt>
+  <dd>{{ Decimal { value: ((self.entry.premine as f64 / ((terms.cap.unwrap_or_default() as f64 * terms.amount.unwrap_or_default() as f64) + self.entry.premine as f64)) * 10000.0) as u128, scale: 2 } }}%</dd>
+  %% } else {
+    <dt>premine percentage of maximum supply</dt>
+    <dd>Unable to calculate premine percentage of maximum supply</dd>
+  %% }
   <dt>burned</dt>
   <dd>{{ self.entry.pile(self.entry.burned) }}</dd>
   <dt>divisibility</dt>


### PR DESCRIPTION
presents options to fix #3630

* this is my first attempt at making any sort of real changes using Rust.  I am still in the very early stages of learning Rust and so I wanted to add a disclaimer that these changes were not done with much proficiency - there are probably smarter and better ways to have made them.  I am eager to learn so please provide feedback on what I can do better.  I don't think that all of these fields are necessary for the rune page, but I wanted to display them all so that they could be reviewed and a final decision as to which to keep can be made while considering all possibilities.

changes made:
 - renamed `supply` to `current supply`
 - added `maximum supply` field
 - renamed `premine percentage` to`premine percentage of current supply`
 - added `premine percentage of maximum supply` formula