### PR TITLE
Add delegate value to inscription endpoint

### DIFF
--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -143,6 +143,7 @@ percentile in sats/vB.
   "charms": [],
   "content_type": "image/png",
   "content_length": 144037,
+  "delegate": null,
   "fee": 36352,
   "height": 209,
   "id": "3bd72a7ef68776c9429961e43043ff65efa7fb2d8bb407386a9e3b19f149bc36i0",

--- a/src/api.rs
+++ b/src/api.rs
@@ -103,6 +103,8 @@ pub struct InscriptionRecursive {
   pub charms: Vec<Charm>,
   pub content_type: Option<String>,
   pub content_length: Option<usize>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub delegate: Option<InscriptionId>,
   pub fee: u64,
   pub height: u32,
   pub id: InscriptionId,

--- a/src/api.rs
+++ b/src/api.rs
@@ -103,7 +103,6 @@ pub struct InscriptionRecursive {
   pub charms: Vec<Charm>,
   pub content_type: Option<String>,
   pub content_length: Option<usize>,
-  #[serde(skip_serializing_if = "Option::is_none")]
   pub delegate: Option<InscriptionId>,
   pub fee: u64,
   pub height: u32,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -984,6 +984,7 @@ impl Server {
           charms: Charm::charms(entry.charms),
           content_type: inscription.content_type().map(|s| s.to_string()),
           content_length: inscription.content_length(),
+          delegate: inscription.delegate(),
           fee: entry.fee,
           height: entry.height,
           id: inscription_id,
@@ -6090,6 +6091,13 @@ next
     server.assert_response(format!("/content/{id}"), StatusCode::OK, "foo");
 
     server.assert_response(format!("/preview/{id}"), StatusCode::OK, "foo");
+
+    assert_eq!(
+      server
+        .get_json::<api::InscriptionRecursive>(format!("/r/inscription/{id}"))
+        .delegate,
+      Some(delegate)
+    );
   }
 
   #[test]

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -313,6 +313,7 @@ fn recursive_inscription_endpoint() {
       charms: vec![Charm::Coin, Charm::Uncommon],
       content_type: Some("text/plain;charset=utf-8".to_string()),
       content_length: Some(3),
+      delegate: None,
       fee: 138,
       height: 2,
       id: inscription.id,


### PR DESCRIPTION
Add the delegate ID to the `/inscription/[id]` endpoint. If there is no delegate then the response doesn't include that field.