### PR TITLE
Fix typo in mint.rs

### DIFF
--- a/src/subcommand/wallet/mint.rs
+++ b/src/subcommand/wallet/mint.rs
@@ -53,7 +53,7 @@ impl Mint {
     };
 
     ensure!(
-      destination.script_pubkey().dust_value() < postage,
+      destination.script_pubkey().dust_value() <= postage,
       "postage below dust limit of {}sat",
       destination.script_pubkey().dust_value().to_sat()
     );


### PR DESCRIPTION
Postage should be allowed to be equal to the dust limit, just not smaller than it.