### PR TITLE
Address index

### DIFF
--- a/deploy/ord.service
+++ b/deploy/ord.service
@@ -13,6 +13,7 @@ ExecStart=/usr/local/bin/ord \
   --chain ${CHAIN} \
   --config-dir /var/lib/ord \
   --datadir /var/lib/ord \
+  --index-addresses \
   --index-runes \
   --index-sats \
   server \

--- a/ord.yaml
+++ b/ord.yaml
@@ -18,6 +18,7 @@ hidden:
 - 6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0
 - 703e5f7c49d82aab99e605af306b9a30e991e57d42f982908a962a81ac439832i0
 index: /var/lib/ord/index.redb
+index_addresses: true
 index_cache_size: 1000000000
 index_runes: true
 index_sats: true

--- a/src/index.rs
+++ b/src/index.rs
@@ -53,7 +53,7 @@ const SCHEMA_VERSION: u64 = 25;
 define_multimap_table! { SATPOINT_TO_SEQUENCE_NUMBER, &SatPointValue, u32 }
 define_multimap_table! { SAT_TO_SEQUENCE_NUMBER, u64, u32 }
 define_multimap_table! { SEQUENCE_NUMBER_TO_CHILDREN, u32, u32 }
-define_multimap_table! { SCRIPT_PUBKEY_TO_OUTPOINT, &[u8], &OutPointValue }
+define_multimap_table! { SCRIPT_PUBKEY_TO_OUTPOINT, &[u8], OutPointValue }
 define_table! { CONTENT_TYPE_TO_COUNT, Option<&[u8]>, u64 }
 define_table! { HEIGHT_TO_BLOCK_HEADER, u32, &HeaderValue }
 define_table! { HEIGHT_TO_LAST_SEQUENCE_NUMBER, u32, u32 }
@@ -299,6 +299,7 @@ impl Index {
 
         tx.open_multimap_table(SATPOINT_TO_SEQUENCE_NUMBER)?;
         tx.open_multimap_table(SAT_TO_SEQUENCE_NUMBER)?;
+        tx.open_multimap_table(SCRIPT_PUBKEY_TO_OUTPOINT)?;
         tx.open_multimap_table(SEQUENCE_NUMBER_TO_CHILDREN)?;
         tx.open_table(CONTENT_TYPE_TO_COUNT)?;
         tx.open_table(HEIGHT_TO_BLOCK_HEADER)?;
@@ -407,6 +408,7 @@ impl Index {
     let index_sats;
     let index_spent_sats;
     let index_transactions;
+    // let index_addresses;
 
     {
       let tx = database.begin_read()?;

--- a/src/index.rs
+++ b/src/index.rs
@@ -2,7 +2,7 @@ use {
   self::{
     entry::{
       Entry, HeaderValue, InscriptionEntry, InscriptionEntryValue, InscriptionIdValue,
-      OutPointValue, RuneEntryValue, RuneIdValue, SatPointValue, SatRange, TxidValue,
+      OutPointValue, RuneEntryValue, RuneIdValue, SatPointValue, SatRange, TxOutValue, TxidValue,
     },
     event::Event,
     lot::Lot,
@@ -62,7 +62,7 @@ define_table! { INSCRIPTION_ID_TO_SEQUENCE_NUMBER, InscriptionIdValue, u32 }
 define_table! { INSCRIPTION_NUMBER_TO_SEQUENCE_NUMBER, i32, u32 }
 define_table! { OUTPOINT_TO_RUNE_BALANCES, &OutPointValue, &[u8] }
 define_table! { OUTPOINT_TO_SAT_RANGES, &OutPointValue, &[u8] }
-define_table! { OUTPOINT_TO_VALUE, &OutPointValue, u64}
+define_table! { OUTPOINT_TO_TXOUT, &OutPointValue, TxOutValue }
 define_table! { RUNE_ID_TO_RUNE_ENTRY, RuneIdValue, RuneEntryValue }
 define_table! { RUNE_TO_RUNE_ID, u128, RuneIdValue }
 define_table! { SAT_TO_SATPOINT, u64, &SatPointValue }
@@ -310,7 +310,7 @@ impl Index {
         tx.open_table(INSCRIPTION_ID_TO_SEQUENCE_NUMBER)?;
         tx.open_table(INSCRIPTION_NUMBER_TO_SEQUENCE_NUMBER)?;
         tx.open_table(OUTPOINT_TO_RUNE_BALANCES)?;
-        tx.open_table(OUTPOINT_TO_VALUE)?;
+        tx.open_table(OUTPOINT_TO_TXOUT)?;
         tx.open_table(RUNE_ID_TO_RUNE_ENTRY)?;
         tx.open_table(RUNE_TO_RUNE_ID)?;
         tx.open_table(SAT_TO_SATPOINT)?;
@@ -462,7 +462,7 @@ impl Index {
       self
         .database
         .begin_read()?
-        .open_table(OUTPOINT_TO_VALUE)?
+        .open_table(OUTPOINT_TO_TXOUT)?
         .get(&output.store())?
         .is_some(),
     )

--- a/src/index.rs
+++ b/src/index.rs
@@ -6302,12 +6302,15 @@ mod tests {
 
   #[test]
   fn output_addresses_are_updated() {
-    let context = Context::builder().arg("--index-addresses").build();
+    let context = Context::builder()
+      .arg("--index-addresses")
+      .arg("--index-sats")
+      .build();
 
-    context.mine_blocks(1);
+    context.mine_blocks(2);
 
     let txid = context.core.broadcast_tx(TransactionTemplate {
-      inputs: &[(1, 0, 0, Witness::new())],
+      inputs: &[(1, 0, 0, Witness::new()), (2, 0, 0, Witness::new())],
       ..Default::default()
     });
 
@@ -6331,7 +6334,7 @@ mod tests {
     );
 
     let txid = context.core.broadcast_tx(TransactionTemplate {
-      inputs: &[(2, 1, 0, Witness::new())],
+      inputs: &[(3, 1, 0, Witness::new())],
       p2tr: true,
       ..Default::default()
     });

--- a/src/index.rs
+++ b/src/index.rs
@@ -53,6 +53,7 @@ const SCHEMA_VERSION: u64 = 25;
 define_multimap_table! { SATPOINT_TO_SEQUENCE_NUMBER, &SatPointValue, u32 }
 define_multimap_table! { SAT_TO_SEQUENCE_NUMBER, u64, u32 }
 define_multimap_table! { SEQUENCE_NUMBER_TO_CHILDREN, u32, u32 }
+define_multimap_table! { SCRIPT_PUBKEY_TO_OUTPOINT, &[u8], &OutPointValue }
 define_table! { CONTENT_TYPE_TO_COUNT, Option<&[u8]>, u64 }
 define_table! { HEIGHT_TO_BLOCK_HEADER, u32, &HeaderValue }
 define_table! { HEIGHT_TO_LAST_SEQUENCE_NUMBER, u32, u32 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -2215,9 +2215,9 @@ impl Index {
   }
 
   pub(crate) fn get_address_info(&self, address: &Address) -> Result<Vec<OutPoint>> {
-    let rtx = self.database.begin_read()?;
-
-    rtx
+    self
+      .database
+      .begin_read()?
       .open_multimap_table(SCRIPT_PUBKEY_TO_OUTPOINT)?
       .get(address.script_pubkey().as_bytes())?
       .map(|result| {
@@ -2225,7 +2225,7 @@ impl Index {
           .map_err(|err| anyhow!(err.to_string()))
           .map(|value| OutPoint::load(value.value()))
       })
-      .collect::<Result<Vec<_>>>()
+      .collect()
   }
 
   pub(crate) fn get_output_info(&self, output: OutPoint) -> Result<Option<(api::Output, TxOut)>> {

--- a/src/index.rs
+++ b/src/index.rs
@@ -2221,7 +2221,7 @@ impl Index {
       .get(address.script_pubkey().as_bytes())?
       .map(|result| {
         result
-          .map_err(|err| anyhow!(err.to_string()))
+          .map_err(|err| anyhow!(err))
           .map(|value| OutPoint::load(value.value()))
       })
       .collect()

--- a/src/index.rs
+++ b/src/index.rs
@@ -988,7 +988,7 @@ impl Index {
     Ok(((id, balance), len))
   }
 
-  pub(crate) fn get_rune_balances_for_outpoint(
+  pub(crate) fn get_rune_balances_for_output(
     &self,
     outpoint: OutPoint,
   ) -> Result<BTreeMap<SpacedRune, Pile>> {
@@ -1520,7 +1520,7 @@ impl Index {
     )
   }
 
-  pub(crate) fn get_inscriptions_on_output(
+  pub(crate) fn get_inscriptions_for_output(
     &self,
     outpoint: OutPoint,
   ) -> Result<Vec<InscriptionId>> {
@@ -2261,9 +2261,9 @@ impl Index {
       txout
     };
 
-    let inscriptions = self.get_inscriptions_on_output(outpoint)?;
+    let inscriptions = self.get_inscriptions_for_output(outpoint)?;
 
-    let runes = self.get_rune_balances_for_outpoint(outpoint)?;
+    let runes = self.get_rune_balances_for_output(outpoint)?;
 
     let spent = self.is_output_spent(outpoint)?;
 
@@ -3413,7 +3413,7 @@ mod tests {
       assert_eq!(
         context
           .index
-          .get_inscriptions_on_output(OutPoint { txid, vout: 0 })
+          .get_inscriptions_for_output(OutPoint { txid, vout: 0 })
           .unwrap(),
         []
       );
@@ -3423,7 +3423,7 @@ mod tests {
       assert_eq!(
         context
           .index
-          .get_inscriptions_on_output(OutPoint { txid, vout: 0 })
+          .get_inscriptions_for_output(OutPoint { txid, vout: 0 })
           .unwrap(),
         [inscription_id]
       );
@@ -3438,7 +3438,7 @@ mod tests {
       assert_eq!(
         context
           .index
-          .get_inscriptions_on_output(OutPoint { txid, vout: 0 })
+          .get_inscriptions_for_output(OutPoint { txid, vout: 0 })
           .unwrap(),
         []
       );
@@ -3446,7 +3446,7 @@ mod tests {
       assert_eq!(
         context
           .index
-          .get_inscriptions_on_output(OutPoint {
+          .get_inscriptions_for_output(OutPoint {
             txid: send_id,
             vout: 0,
           })
@@ -3476,7 +3476,7 @@ mod tests {
       assert_eq!(
         context
           .index
-          .get_inscriptions_on_output(OutPoint {
+          .get_inscriptions_for_output(OutPoint {
             txid: first,
             vout: 0
           })

--- a/src/index.rs
+++ b/src/index.rs
@@ -518,7 +518,7 @@ impl Index {
     content_type_counts.sort_by_key(|(_content_type, count)| Reverse(*count));
 
     Ok(StatusHtml {
-      address_index: statistic(Statistic::IndexAddresses)? != 0,
+      address_index: self.has_address_index(),
       blessed_inscriptions,
       chain: self.settings.chain(),
       content_type_counts,
@@ -531,9 +531,9 @@ impl Index {
         self.settings.chain().network(),
         Height(next_height),
       ),
-      rune_index: statistic(Statistic::IndexRunes)? != 0,
+      rune_index: self.has_rune_index(),
       runes: statistic(Statistic::Runes)?,
-      sat_index: statistic(Statistic::IndexSats)? != 0,
+      sat_index: self.has_sat_index(),
       started: self.started,
       transaction_index: statistic(Statistic::IndexTransactions)? != 0,
       unrecoverably_reorged: self.unrecoverably_reorged.load(atomic::Ordering::Relaxed),
@@ -1654,7 +1654,6 @@ impl Index {
     Ok(
       outpoint != OutPoint::null()
         && outpoint != self.settings.chain().genesis_coinbase_outpoint()
-        // If we are not addresses this table does not always get built
         && if self.settings.index_addresses() {
           self
             .database

--- a/src/index.rs
+++ b/src/index.rs
@@ -2227,12 +2227,12 @@ impl Index {
       .collect()
   }
 
-  pub(crate) fn get_output_info(&self, output: OutPoint) -> Result<Option<(api::Output, TxOut)>> {
-    let sat_ranges = self.list(output)?;
+  pub(crate) fn get_output_info(&self, outpoint: OutPoint) -> Result<Option<(api::Output, TxOut)>> {
+    let sat_ranges = self.list(outpoint)?;
 
     let indexed;
 
-    let txout = if output == OutPoint::null() || output == unbound_outpoint() {
+    let txout = if outpoint == OutPoint::null() || outpoint == unbound_outpoint() {
       let mut value = 0;
 
       if let Some(ranges) = &sat_ranges {
@@ -2248,30 +2248,30 @@ impl Index {
         script_pubkey: ScriptBuf::new(),
       }
     } else {
-      indexed = self.contains_output(&output)?;
+      indexed = self.contains_output(&outpoint)?;
 
-      let Some(tx) = self.get_transaction(output.txid)? else {
+      let Some(tx) = self.get_transaction(outpoint.txid)? else {
         return Ok(None);
       };
 
-      let Some(txout) = tx.output.into_iter().nth(output.vout as usize) else {
+      let Some(txout) = tx.output.into_iter().nth(outpoint.vout as usize) else {
         return Ok(None);
       };
 
       txout
     };
 
-    let inscriptions = self.get_inscriptions_on_output(output)?;
+    let inscriptions = self.get_inscriptions_on_output(outpoint)?;
 
-    let runes = self.get_rune_balances_for_outpoint(output)?;
+    let runes = self.get_rune_balances_for_outpoint(outpoint)?;
 
-    let spent = self.is_output_spent(output)?;
+    let spent = self.is_output_spent(outpoint)?;
 
     Ok(Some((
       api::Output::new(
         self.settings.chain(),
         inscriptions,
-        output,
+        outpoint,
         txout.clone(),
         indexed,
         runes,

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -224,6 +224,7 @@ impl Entry for RuneEntry {
         offset,
       }),
       timestamp,
+
       turbo,
     }
   }
@@ -423,6 +424,26 @@ impl Entry for OutPoint {
   }
 }
 
+pub(super) type TxOutValue = (
+  u64,     // value
+  Vec<u8>, // script_pubkey
+);
+
+impl Entry for TxOut {
+  type Value = TxOutValue;
+
+  fn load(value: Self::Value) -> Self {
+    Self {
+      value: value.0,
+      script_pubkey: ScriptBuf::from_bytes(value.1),
+    }
+  }
+
+  fn store(self) -> Self::Value {
+    (self.value, self.script_pubkey.to_bytes())
+  }
+}
+
 pub(super) type SatPointValue = [u8; 44];
 
 impl Entry for SatPoint {
@@ -483,6 +504,19 @@ impl Entry for Txid {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn txout_entry() {
+    let txout = TxOut {
+      value: u64::MAX,
+      script_pubkey: ScriptBuf::new(),
+    };
+
+    let value = (u64::MAX, Vec::new());
+
+    assert_eq!(txout.clone().store(), value);
+    assert_eq!(TxOut::load(value), txout);
+  }
 
   #[test]
   fn inscription_entry() {

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -224,7 +224,6 @@ impl Entry for RuneEntry {
         offset,
       }),
       timestamp,
-
       turbo,
     }
   }

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -508,10 +508,10 @@ mod tests {
   fn txout_entry() {
     let txout = TxOut {
       value: u64::MAX,
-      script_pubkey: ScriptBuf::new(),
+      script_pubkey: change(0).script_pubkey(),
     };
 
-    let value = (u64::MAX, Vec::new());
+    let value = (u64::MAX, change(0).script_pubkey().to_bytes());
 
     assert_eq!(txout.clone().store(), value);
     assert_eq!(TxOut::load(value), txout);

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -380,6 +380,7 @@ impl<'index> Updater<'index> {
       wtx.open_table(INSCRIPTION_NUMBER_TO_SEQUENCE_NUMBER)?;
     let mut sat_to_sequence_number = wtx.open_multimap_table(SAT_TO_SEQUENCE_NUMBER)?;
     let mut satpoint_to_sequence_number = wtx.open_multimap_table(SATPOINT_TO_SEQUENCE_NUMBER)?;
+    let mut script_pubkey_to_outpoint = wtx.open_multimap_table(SCRIPT_PUBKEY_TO_OUTPOINT)?;
     let mut sequence_number_to_children = wtx.open_multimap_table(SEQUENCE_NUMBER_TO_CHILDREN)?;
     let mut sequence_number_to_inscription_entry =
       wtx.open_table(SEQUENCE_NUMBER_TO_INSCRIPTION_ENTRY)?;
@@ -435,6 +436,7 @@ impl<'index> Updater<'index> {
       reward: Height(self.height).subsidy(),
       sat_to_sequence_number: &mut sat_to_sequence_number,
       satpoint_to_sequence_number: &mut satpoint_to_sequence_number,
+      script_pubkey_to_outpoint: &mut script_pubkey_to_outpoint,
       sequence_number_to_children: &mut sequence_number_to_children,
       sequence_number_to_entry: &mut sequence_number_to_inscription_entry,
       sequence_number_to_satpoint: &mut sequence_number_to_satpoint,

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -818,6 +818,8 @@ impl<'index> Updater<'index> {
     }
 
     {
+      log::info!("Flushing utxo cache with {} entries", utxo_cache.len());
+
       let mut outpoint_to_txout = wtx.open_table(OUTPOINT_TO_TXOUT)?;
 
       for (outpoint, txout) in utxo_cache {

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -655,7 +655,6 @@ impl<'index> Updater<'index> {
     outpoint_to_txout: &mut Table<&OutPointValue, TxOutValue>,
   ) -> Result {
     for txin in &tx.input {
-      log::debug!("Inside input iterator: {:?}", txin);
       let output = txin.previous_output;
       if output.is_null() {
         continue;
@@ -663,27 +662,22 @@ impl<'index> Updater<'index> {
 
       // multi-level cache for UTXO set to get to the script pubkey
       let txout = if let Some(txout) = utxo_cache.get(&txin.previous_output) {
-        log::debug!("Inside utxo cache {:?}", txout);
         txout.clone() // TODO
       } else if let Some(value) = outpoint_to_txout.get(&txin.previous_output.store())? {
-        log::debug!("Inside utxo table");
         TxOut::load(value.value())
       } else {
-        log::debug!("Inside tx fetcher");
         self
           .index
           .client
           .get_raw_transaction(&output.txid, None)?
           .output[output.vout as usize]
-          .clone()
+          .clone() // TODO
       };
-      log::debug!("Inside input iterator: {:?}", txout);
 
       script_pubkey_to_outpoint.remove(&txout.script_pubkey.as_bytes(), output.store())?;
     }
 
     for (vout, txout) in tx.output.iter().enumerate() {
-      log::debug!("Inside output iterator: {:?}", txout);
       script_pubkey_to_outpoint.insert(
         txout.script_pubkey.as_bytes(),
         OutPoint {
@@ -694,7 +688,6 @@ impl<'index> Updater<'index> {
       )?;
     }
 
-    log::info!("Finished");
     Ok(())
   }
 

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -631,7 +631,7 @@ impl<'index> Updater<'index> {
     if self.index.index_addresses {
       let mut script_pubkey_to_outpoint = wtx.open_multimap_table(SCRIPT_PUBKEY_TO_OUTPOINT)?;
       for (tx, txid) in &block.txdata {
-        self.index_transaction_addresses(&tx, &txid, &mut script_pubkey_to_outpoint)?;
+        self.index_transaction_addresses(tx, txid, &mut script_pubkey_to_outpoint)?;
       }
     };
 
@@ -665,8 +665,8 @@ impl<'index> Updater<'index> {
       script_pubkey_to_outpoint.insert(
         txout.script_pubkey.as_bytes(),
         OutPoint {
-          txid: txid.clone(),
-          vout: vout.try_into().unwrap(), // TODO
+          txid: *txid,
+          vout: vout.try_into().unwrap(),
         }
         .store(),
       )?;

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -656,14 +656,8 @@ impl<'index> Updater<'index> {
       let outpoints = script_pubkey_to_outpoint.get(&txin.script_sig.as_bytes())?;
 
       for result in outpoints.into_iter() {
-        let outpoint =  result?;
-
-
-
-
+        let outpoint = result?;
       }
-
-
     }
 
     for (vout, txout) in tx.output.iter().enumerate() {

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -414,6 +414,7 @@ impl<'index> Updater<'index> {
           utxo_cache,
           &mut script_pubkey_to_outpoint,
           &mut outpoint_to_txout,
+          index_inscriptions,
         )?;
       }
     };
@@ -686,6 +687,7 @@ impl<'index> Updater<'index> {
     utxo_cache: &mut HashMap<OutPoint, TxOut>,
     script_pubkey_to_outpoint: &mut MultimapTable<&[u8], OutPointValue>,
     outpoint_to_txout: &mut Table<&OutPointValue, TxOutValue>,
+    index_inscriptions: bool,
   ) -> Result {
     for txin in &tx.input {
       let output = txin.previous_output;
@@ -706,6 +708,12 @@ impl<'index> Updater<'index> {
           )
         })?
       };
+
+      // We remove these values in the InscriptionUpdater only when indexing inscriptions
+      if !index_inscriptions {
+        utxo_cache.remove(&output);
+        outpoint_to_txout.remove(&output.store())?;
+      }
 
       script_pubkey_to_outpoint.remove(&txout.script_pubkey.as_bytes(), output.store())?;
     }

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -313,13 +313,15 @@ impl<'a, 'tx> InscriptionUpdater<'a, 'tx> {
 
       output_value = end;
 
-      self.utxo_cache.insert(
-        OutPoint {
+      self
+        .utxo_cache
+        .entry(OutPoint {
           vout: vout.try_into().unwrap(),
           txid,
-        },
-        txout.clone(), // TODO
-      );
+        })
+        .or_insert(
+          txout.clone(), // TODO
+        );
     }
 
     for (new_satpoint, mut flotsam) in new_locations.into_iter() {

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -57,7 +57,6 @@ pub(super) struct InscriptionUpdater<'a, 'tx> {
   pub(super) transaction_buffer: Vec<u8>,
   pub(super) transaction_id_to_transaction: &'a mut Table<'tx, &'static TxidValue, &'static [u8]>,
   pub(super) sat_to_sequence_number: &'a mut MultimapTable<'tx, u64, u32>,
-  pub(super) script_pubkey_to_outpoint: &'a mut MultimapTable<'tx, &'static [u8], OutPointValue>,
   pub(super) satpoint_to_sequence_number: &'a mut MultimapTable<'tx, &'static SatPointValue, u32>,
   pub(super) sequence_number_to_children: &'a mut MultimapTable<'tx, u32, u32>,
   pub(super) sequence_number_to_entry: &'a mut Table<'tx, u32, InscriptionEntryValue>,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -57,6 +57,7 @@ pub(super) struct InscriptionUpdater<'a, 'tx> {
   pub(super) transaction_buffer: Vec<u8>,
   pub(super) transaction_id_to_transaction: &'a mut Table<'tx, &'static TxidValue, &'static [u8]>,
   pub(super) sat_to_sequence_number: &'a mut MultimapTable<'tx, u64, u32>,
+  pub(super) script_pubkey_to_outpoint: &'a mut MultimapTable<'tx, &'static [u8], OutPointValue>,
   pub(super) satpoint_to_sequence_number: &'a mut MultimapTable<'tx, &'static SatPointValue, u32>,
   pub(super) sequence_number_to_children: &'a mut MultimapTable<'tx, u32, u32>,
   pub(super) sequence_number_to_entry: &'a mut Table<'tx, u32, InscriptionEntryValue>,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -64,7 +64,7 @@ pub(super) struct InscriptionUpdater<'a, 'tx> {
   pub(super) timestamp: u32,
   pub(super) unbound_inscriptions: u64,
   pub(super) utxo_cache: &'a mut HashMap<OutPoint, TxOut>,
-  pub(super) utxo_receiver: &'a mut Receiver<TxOut>,
+  pub(super) txout_receiver: &'a mut Receiver<TxOut>,
 }
 
 impl<'a, 'tx> InscriptionUpdater<'a, 'tx> {
@@ -122,7 +122,7 @@ impl<'a, 'tx> InscriptionUpdater<'a, 'tx> {
       {
         TxOut::load(value.value())
       } else {
-        self.utxo_receiver.blocking_recv().ok_or_else(|| {
+        self.txout_receiver.blocking_recv().ok_or_else(|| {
           anyhow!(
             "failed to get transaction for {}",
             txin.previous_output.txid

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -122,9 +122,9 @@ impl<'a, 'tx> InscriptionUpdater<'a, 'tx> {
       {
         TxOut::load(value.value())
       } else {
-        self.txout_receiver.blocking_recv().map_err(|_| {
+        self.txout_receiver.blocking_recv().map_err(|err| {
           anyhow!(
-            "failed to get transaction for {}",
+            "failed to get transaction for {}: {err}",
             txin.previous_output.txid
           )
         })?
@@ -313,13 +313,13 @@ impl<'a, 'tx> InscriptionUpdater<'a, 'tx> {
 
       output_value = end;
 
-      self
-        .utxo_cache
-        .entry(OutPoint {
+      self.utxo_cache.insert(
+        OutPoint {
           vout: vout.try_into().unwrap(),
           txid,
-        })
-        .or_insert(txout.clone());
+        },
+        txout.clone(),
+      );
     }
 
     for (new_satpoint, mut flotsam) in new_locations.into_iter() {

--- a/src/index/updater/rune_updater.rs
+++ b/src/index/updater/rune_updater.rs
@@ -4,7 +4,7 @@ pub(super) struct RuneUpdater<'a, 'tx, 'client> {
   pub(super) block_time: u32,
   pub(super) burned: HashMap<RuneId, Lot>,
   pub(super) client: &'client Client,
-  pub(super) event_sender: Option<&'a Sender<Event>>,
+  pub(super) event_sender: Option<&'a mpsc::Sender<Event>>,
   pub(super) height: u32,
   pub(super) id_to_entry: &'a mut Table<'tx, RuneIdValue, RuneEntryValue>,
   pub(super) inscription_id_to_sequence_number: &'a Table<'tx, InscriptionIdValue, u32>,

--- a/src/options.rs
+++ b/src/options.rs
@@ -47,10 +47,7 @@ pub struct Options {
   pub(crate) height_limit: Option<u32>,
   #[arg(long, help = "Use index at <INDEX>.")]
   pub(crate) index: Option<PathBuf>,
-  #[arg(
-    long,
-    help = "Track addresses of all outputs."
-  )]
+  #[arg(long, help = "Track addresses of all outputs.")]
   pub(crate) index_addresses: bool,
   #[arg(
     long,

--- a/src/options.rs
+++ b/src/options.rs
@@ -49,6 +49,11 @@ pub struct Options {
   pub(crate) index: Option<PathBuf>,
   #[arg(
     long,
+    help = "Track addresses of all outputs."
+  )]
+  pub(crate) index_addresses: bool,
+  #[arg(
+    long,
     help = "Set index cache size to <INDEX_CACHE_SIZE> bytes. [default: 1/4 available RAM]"
   )]
   pub(crate) index_cache_size: Option<usize>,

--- a/src/options.rs
+++ b/src/options.rs
@@ -47,7 +47,7 @@ pub struct Options {
   pub(crate) height_limit: Option<u32>,
   #[arg(long, help = "Use index at <INDEX>.")]
   pub(crate) index: Option<PathBuf>,
-  #[arg(long, help = "Track addresses of all outputs.")]
+  #[arg(long, help = "Track unspent output addresses.")]
   pub(crate) index_addresses: bool,
   #[arg(
     long,

--- a/src/re.rs
+++ b/src/re.rs
@@ -5,6 +5,9 @@ fn re(s: &'static str) -> Regex {
 }
 
 lazy_static! {
+  pub(crate) static ref ADDRESS: Regex = re(
+    r"((bc1p|tb1p|bcrt1p)[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{58}|(bc1|tb1|bcrt1)[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{39,59}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})"
+  );
   pub(crate) static ref HASH: Regex = re(r"[[:xdigit:]]{64}");
   pub(crate) static ref INSCRIPTION_ID: Regex = re(r"[[:xdigit:]]{64}i\d+");
   pub(crate) static ref INSCRIPTION_NUMBER: Regex = re(r"-?[0-9]+");

--- a/src/re.rs
+++ b/src/re.rs
@@ -6,7 +6,7 @@ fn re(s: &'static str) -> Regex {
 
 lazy_static! {
   pub(crate) static ref ADDRESS: Regex = re(
-    r"((bc1p|tb1p|bcrt1p)[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{58}|(bc1|tb1|bcrt1)[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{39,59}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})"
+    r"((bc1p|tb1p|bcrt1p|bc1q|tb1q|bcrt1q)[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{39,59}|[123][a-km-zA-HJ-NP-Z1-9]{25,34})"
   );
   pub(crate) static ref HASH: Regex = re(r"[[:xdigit:]]{64}");
   pub(crate) static ref INSCRIPTION_ID: Regex = re(r"[[:xdigit:]]{64}i\d+");

--- a/src/re.rs
+++ b/src/re.rs
@@ -6,7 +6,7 @@ fn re(s: &'static str) -> Regex {
 
 lazy_static! {
   pub(crate) static ref ADDRESS: Regex = re(
-    r"((bc1p|tb1p|bcrt1p|bc1q|tb1q|bcrt1q)[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{39,59}|[123][a-km-zA-HJ-NP-Z1-9]{25,34})"
+    r"((bc1|tb1|bcrt1)[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{39,60}|[123][a-km-zA-HJ-NP-Z1-9]{25,34})"
   );
   pub(crate) static ref HASH: Regex = re(r"[[:xdigit:]]{64}");
   pub(crate) static ref INSCRIPTION_ID: Regex = re(r"[[:xdigit:]]{64}i\d+");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -18,6 +18,7 @@ pub struct Settings {
   height_limit: Option<u32>,
   hidden: Option<HashSet<InscriptionId>>,
   index: Option<PathBuf>,
+  index_addresses: bool,
   index_cache_size: Option<usize>,
   index_runes: bool,
   index_sats: bool,
@@ -133,6 +134,7 @@ impl Settings {
           .collect(),
       ),
       index: self.index.or(source.index),
+      index_addresses: self.index_addresses || source.index_addresses,
       index_cache_size: self.index_cache_size.or(source.index_cache_size),
       index_runes: self.index_runes || source.index_runes,
       index_sats: self.index_sats || source.index_sats,
@@ -168,6 +170,7 @@ impl Settings {
       height_limit: options.height_limit,
       hidden: None,
       index: options.index,
+      index_addresses: options.index_addresses,
       index_cache_size: options.index_cache_size,
       index_runes: options.index_runes,
       index_sats: options.index_sats,
@@ -247,6 +250,7 @@ impl Settings {
       height_limit: get_u32("HEIGHT_LIMIT")?,
       hidden: inscriptions("HIDDEN")?,
       index: get_path("INDEX"),
+      index_addresses: get_bool("INDEX_ADDRESSES"),
       index_cache_size: get_usize("INDEX_CACHE_SIZE")?,
       index_runes: get_bool("INDEX_RUNES"),
       index_sats: get_bool("INDEX_SATS"),
@@ -277,6 +281,7 @@ impl Settings {
       height_limit: None,
       hidden: None,
       index: None,
+      index_addresses: true,
       index_cache_size: None,
       index_runes: true,
       index_sats: true,
@@ -350,6 +355,7 @@ impl Settings {
       height_limit: self.height_limit,
       hidden: self.hidden,
       index: Some(index),
+      index_addresses: self.index_addresses,
       index_cache_size: Some(match self.index_cache_size {
         Some(index_cache_size) => index_cache_size,
         None => {
@@ -510,6 +516,10 @@ impl Settings {
 
   pub(crate) fn index(&self) -> &Path {
     self.index.as_ref().unwrap()
+  }
+
+  pub(crate) fn index_addresses(&self) -> bool {
+    self.index_addresses
   }
 
   pub(crate) fn index_inscriptions(&self) -> bool {
@@ -1003,6 +1013,7 @@ mod tests {
       ("HIDDEN", "6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0 703e5f7c49d82aab99e605af306b9a30e991e57d42f982908a962a81ac439832i0"),
       ("INDEX", "index"),
       ("INDEX_CACHE_SIZE", "4"),
+      ("INDEX_ADDRESSES", "1"),
       ("INDEX_RUNES", "1"),
       ("INDEX_SATS", "1"),
       ("INDEX_SPENT_SATS", "1"),
@@ -1046,6 +1057,7 @@ mod tests {
           .collect()
         ),
         index: Some("index".into()),
+        index_addresses: true,
         index_cache_size: Some(4),
         index_runes: true,
         index_sats: true,
@@ -1079,6 +1091,7 @@ mod tests {
           "--datadir=/data/dir",
           "--first-inscription-height=2",
           "--height-limit=3",
+          "--index-addresses",
           "--index-cache-size=4",
           "--index-runes",
           "--index-sats",
@@ -1108,6 +1121,7 @@ mod tests {
         height_limit: Some(3),
         hidden: None,
         index: Some("index".into()),
+        index_addresses: true,
         index_cache_size: Some(4),
         index_runes: true,
         index_sats: true,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1065,7 +1065,9 @@ impl Server {
     task::block_in_place(|| {
       let query = query.trim();
 
-      if re::HASH.is_match(query) {
+      if re::ADDRESS.is_match(query) {
+        Ok(Redirect::to(&format!("/address/{query}")))
+      } else if re::HASH.is_match(query) {
         if index.block_header(query.parse().unwrap())?.is_some() {
           Ok(Redirect::to(&format!("/block/{query}")))
         } else {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -6,9 +6,9 @@ use {
   },
   super::*,
   crate::templates::{
-    BlockHtml, BlocksHtml, ChildrenHtml, ClockSvg, CollectionsHtml, HomeHtml, InputHtml,
-    InscriptionHtml, InscriptionsBlockHtml, InscriptionsHtml, OutputHtml, PageContent, PageHtml,
-    ParentsHtml, PreviewAudioHtml, PreviewCodeHtml, PreviewFontHtml, PreviewImageHtml,
+    AddressHtml, BlockHtml, BlocksHtml, ChildrenHtml, ClockSvg, CollectionsHtml, HomeHtml,
+    InputHtml, InscriptionHtml, InscriptionsBlockHtml, InscriptionsHtml, OutputHtml, PageContent,
+    PageHtml, ParentsHtml, PreviewAudioHtml, PreviewCodeHtml, PreviewFontHtml, PreviewImageHtml,
     PreviewMarkdownHtml, PreviewModelHtml, PreviewPdfHtml, PreviewTextHtml, PreviewUnknownHtml,
     PreviewVideoHtml, RangeHtml, RareTxt, RuneHtml, RunesHtml, SatHtml, TransactionHtml,
   },
@@ -180,6 +180,7 @@ impl Server {
 
       let router = Router::new()
         .route("/", get(Self::home))
+        .route("/address/:address", get(Self::address))
         .route("/block/:query", get(Self::block))
         .route("/blockcount", get(Self::block_count))
         .route("/blockhash", get(Self::block_hash))
@@ -820,6 +821,35 @@ impl Server {
 
   async fn install_script() -> Redirect {
     Redirect::to("https://raw.githubusercontent.com/ordinals/ord/master/install.sh")
+  }
+
+  async fn address(
+    Extension(server_config): Extension<Arc<ServerConfig>>,
+    Extension(index): Extension<Arc<Index>>,
+    Path(address): Path<Address<NetworkUnchecked>>,
+    AcceptJson(accept_json): AcceptJson,
+  ) -> ServerResult {
+    task::block_in_place(|| {
+      if !index.has_address_index() {
+        return Err(ServerError::NotFound(
+          "this server has no address index".to_string(),
+        ));
+      }
+
+      let address = address
+        .require_network(server_config.chain.network())
+        .map_err(|err| ServerError::BadRequest(err.to_string()))?;
+
+      let outputs = index.get_address_info(&address)?;
+
+      Ok(if accept_json {
+        Json(outputs).into_response()
+      } else {
+        AddressHtml { address, outputs }
+          .page(server_config)
+          .into_response()
+      })
+    })
   }
 
   async fn block(
@@ -3325,6 +3355,8 @@ mod tests {
   <dt>version</dt>
   <dd>.*</dd>
   <dt>unrecoverably reorged</dt>
+  <dd>false</dd>
+  <dt>address index</dt>
   <dd>false</dd>
   <dt>rune index</dt>
   <dd>false</dd>

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -841,7 +841,9 @@ impl Server {
         .require_network(server_config.chain.network())
         .map_err(|err| ServerError::BadRequest(err.to_string()))?;
 
-      let outputs = index.get_address_info(&address)?;
+      let mut outputs = index.get_address_info(&address)?;
+
+      outputs.sort();
 
       Ok(if accept_json {
         Json(outputs).into_response()

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1091,9 +1091,7 @@ impl Server {
     task::block_in_place(|| {
       let query = query.trim();
 
-      if re::ADDRESS.is_match(query) {
-        Ok(Redirect::to(&format!("/address/{query}")))
-      } else if re::HASH.is_match(query) {
+      if re::HASH.is_match(query) {
         if index.block_header(query.parse().unwrap())?.is_some() {
           Ok(Redirect::to(&format!("/block/{query}")))
         } else {
@@ -1113,6 +1111,8 @@ impl Server {
         let rune = index.get_rune_by_id(id)?.ok_or_not_found(|| "rune ID")?;
 
         Ok(Redirect::to(&format!("/rune/{rune}")))
+      } else if re::ADDRESS.is_match(query) {
+        Ok(Redirect::to(&format!("/address/{query}")))
       } else {
         Ok(Redirect::to(&format!("/sat/{query}")))
       }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -2,6 +2,7 @@ use {super::*, boilerplate::Boilerplate};
 
 pub(crate) use {
   crate::subcommand::server::ServerConfig,
+  address::AddressHtml,
   block::BlockHtml,
   children::ChildrenHtml,
   clock::ClockSvg,
@@ -29,6 +30,7 @@ pub use {
   transaction::TransactionHtml,
 };
 
+pub mod address;
 pub mod block;
 pub mod blocks;
 mod children;

--- a/src/templates/address.rs
+++ b/src/templates/address.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+#[derive(Boilerplate)]
+pub(crate) struct AddressHtml {
+  pub(crate) address: Address,
+  pub(crate) outputs: Vec<OutPoint>,
+}
+
+impl PageContent for AddressHtml {
+  fn title(&self) -> String {
+    format!("Address {}", self.address)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn display() {
+    assert_regex_match!(
+      AddressHtml {
+        address: Address::from_str(
+          "bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8"
+        )
+        .unwrap()
+        .require_network(Network::Bitcoin)
+        .unwrap(),
+        outputs: vec![outpoint(1), outpoint(2)],
+      },
+      "<h1>Address bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8</h1>
+<h2>Outputs</h2>
+<ul>
+  <li><a href=/output/1{64}:1>1{64}:1</a></li>
+  <li><a href=/output/2{64}:2>2{64}:2</a></li>
+</ul>.*"
+        .unindent()
+    );
+  }
+}

--- a/src/templates/address.rs
+++ b/src/templates/address.rs
@@ -31,8 +31,8 @@ mod tests {
       "<h1>Address bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8</h1>
 <h2>Outputs</h2>
 <ul>
-  <li><a href=/output/1{64}:1>1{64}:1</a></li>
-  <li><a href=/output/2{64}:2>2{64}:2</a></li>
+  <li><a class=monospace href=/output/1{64}:1>1{64}:1</a></li>
+  <li><a class=monospace href=/output/2{64}:2>2{64}:2</a></li>
 </ul>.*"
         .unindent()
     );

--- a/src/templates/status.rs
+++ b/src/templates/status.rs
@@ -2,6 +2,7 @@ use super::*;
 
 #[derive(Boilerplate, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StatusHtml {
+  pub address_index: bool,
   pub blessed_inscriptions: u64,
   pub chain: Chain,
   pub content_type_counts: Vec<(Option<Vec<u8>>, u64)>,

--- a/templates/address.html
+++ b/templates/address.html
@@ -1,0 +1,7 @@
+<h1>Address {{ self.address }}</h1>
+<h2>Outputs</h2>
+<ul>
+%% for output in self.outputs.iter() {
+  <li><a href=/output/{{ output }}>{{ output }}</a></li>
+%% }
+</ul>

--- a/templates/address.html
+++ b/templates/address.html
@@ -2,6 +2,6 @@
 <h2>Outputs</h2>
 <ul>
 %% for output in self.outputs.iter() {
-  <li><a href=/output/{{ output }}>{{ output }}</a></li>
+  <li><a class=monospace href=/output/{{ output }}>{{ output }}</a></li>
 %% }
 </ul>

--- a/templates/status.html
+++ b/templates/status.html
@@ -28,6 +28,8 @@
   <dd>{{ env!("CARGO_PKG_VERSION") }}</dd>
   <dt>unrecoverably reorged</dt>
   <dd>{{ self.unrecoverably_reorged }}</dd>
+  <dt>address index</dt>
+  <dd>{{ self.address_index }}</dd>
   <dt>rune index</dt>
   <dd>{{ self.rune_index }}</dd>
   <dt>sat index</dt>

--- a/tests/json_api.rs
+++ b/tests/json_api.rs
@@ -488,6 +488,7 @@ fn get_status() {
   pretty_assert_eq!(
     status_json,
     api::Status {
+      address_index: false,
       blessed_inscriptions: 1,
       chain: Chain::Regtest,
       content_type_counts: vec![(Some("text/plain;charset=utf-8".into()), 1)],

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -35,6 +35,35 @@ fn run() {
 }
 
 #[test]
+fn address_page_shows_outputs() {
+  let core = mockcore::spawn();
+  let ord = TestServer::spawn_with_args(&core, &["--index-addresses"]);
+
+  create_wallet(&core, &ord);
+  core.mine_blocks(1);
+
+  let address = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+  let send = CommandBuilder::new(format!("wallet send --fee-rate 13.3 {address} 2btc"))
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  ord.assert_response_regex(
+    format!("/address/{address}"),
+    format!(
+      ".*<h1>Address {address}</h1>.*<a href=/output/{}.*",
+      OutPoint {
+        txid: send.txid,
+        vout: 0
+      }
+    ),
+  );
+}
+
+#[test]
 fn inscription_page() {
   let core = mockcore::spawn();
   let ord = TestServer::spawn(&core);

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -54,7 +54,7 @@ fn address_page_shows_outputs() {
   ord.assert_response_regex(
     format!("/address/{address}"),
     format!(
-      ".*<h1>Address {address}</h1>.*<a href=/output/{}.*",
+      ".*<h1>Address {address}</h1>.*<a class=monospace href=/output/{}.*",
       OutPoint {
         txid: send.txid,
         vout: 0

--- a/tests/settings.rs
+++ b/tests/settings.rs
@@ -21,6 +21,7 @@ fn default() {
   "height_limit": null,
   "hidden": \[\],
   "index": ".*index\.redb",
+  "index_addresses": false,
   "index_cache_size": \d+,
   "index_runes": false,
   "index_sats": false,


### PR DESCRIPTION
This is a very crude address index, to make this production ready we have to either add an `OUTPOINT_TO_TXOUT` table, or adapt the value cache and fetcher to also get the script pubkey in addition to the output value.

Some more considerations:

- At the moment the table stores the bytes of the script_pubkey as the key. Probably smarter to use the hash of the script_pubkey so that it is of fixed size. Look up would then go Address -> ScriptPukey -> Hash(ScriptPubkey): `SCRIPT_PUBKEY_HASH_TO_OUTPOINT`
- Reuse the `TRANSACTION_ID_TO_TRANSACTION` table. 