### PR TITLE
Update list.rs to include inscription and rune info

### DIFF
--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -2,14 +2,21 @@ use super::*;
 
 #[derive(Debug, Parser)]
 pub(crate) struct List {
-  #[arg(help = "List sats in <OUTPOINT>.")]
+  #[arg(help = "List information for <OUTPOINT>.")]
   outpoint: OutPoint,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Output {
-  pub list: api::Output,
-  pub ranges: Option<Vec<Range>>,
+  pub address: Option<Address<NetworkUnchecked>>,
+  pub indexed: bool,
+  pub inscriptions: Vec<InscriptionId>,
+  pub runes: BTreeMap<SpacedRune, Pile>,
+  pub sat_ranges: Option<Vec<Range>>,
+  pub script_pubkey: String,
+  pub spent: bool,
+  pub transaction: String,
+  pub value: u64,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -37,16 +44,21 @@ impl List {
       "output not found"
     }
 
-    let ranges = index.list(self.outpoint)?;
-
     let (list, _txout) = match index.get_output_info(self.outpoint)? {
       Some((output, txout)) => (output, txout),
       None => return Ok(None),
     };
 
     Ok(Some(Box::new(Output {
-      ranges: ranges.map(output_ranges),
-      list,
+      address: list.address,
+      indexed: list.indexed,
+      inscriptions: list.inscriptions,
+      runes: list.runes,
+      sat_ranges: list.sat_ranges.map(output_ranges),
+      script_pubkey: list.script_pubkey,
+      spent: list.spent,
+      transaction: list.transaction,
+      value: list.value,
     })))
   }
 }

--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -40,7 +40,6 @@ impl List {
 
     let ranges = index.list(self.outpoint)?;
 
-    //let list = index.get_output_info(self.outpoint)?;
     let (list, _txout) = match index.get_output_info(self.outpoint)? {
       Some((output, txout)) => (output, txout),
       None => return Ok(None),

--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -8,7 +8,6 @@ pub(crate) struct List {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Output {
-  //pub list: Option<(api::Output, TxOut)>,
   pub list: api::Output,
   pub ranges: Option<Vec<Range>>,
 }

--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -44,10 +44,10 @@ impl List {
     let (list, _txout) = match index.get_output_info(self.outpoint)? {
       Some((output, txout)) => (output, txout),
       None => return Ok(None),
-  };
+    };
 
     Ok(Some(Box::new(Output {
-      ranges: ranges.map(output_ranges),   
+      ranges: ranges.map(output_ranges),
       list,
     })))
   }

--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -8,18 +8,19 @@ pub(crate) struct List {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Output {
+  //pub list: Option<(api::Output, TxOut)>,
+  pub list: api::Output,
   pub ranges: Option<Vec<Range>>,
-  pub spent: bool,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Range {
-  pub end: u64,
+  pub start: u64,
   pub name: String,
   pub offset: u64,
   pub rarity: Rarity,
+  pub end: u64,
   pub size: u64,
-  pub start: u64,
 }
 
 impl List {
@@ -39,11 +40,15 @@ impl List {
 
     let ranges = index.list(self.outpoint)?;
 
-    let spent = index.is_output_spent(self.outpoint)?;
+    //let list = index.get_output_info(self.outpoint)?;
+    let (list, _txout) = match index.get_output_info(self.outpoint)? {
+      Some((output, txout)) => (output, txout),
+      None => return Ok(None),
+  };
 
     Ok(Some(Box::new(Output {
-      spent,
-      ranges: ranges.map(output_ranges),
+      ranges: ranges.map(output_ranges),   
+      list,
     })))
   }
 }

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -29,7 +29,7 @@ fn output_found() {
               inscriptions: vec![],
               runes: BTreeMap::new(),
               sat_ranges: Some(vec![(0, 5000000000)]),
-              script_pubkey: "OP_PUSHBYTES_65 04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f OP_CHECKSIG".to_string(), // Updated to match actual output
+              script_pubkey: "OP_PUSHBYTES_65 04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f OP_CHECKSIG".to_string(),
               spent: false,
               transaction: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string(),
               value: 5000000000,

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -23,7 +23,17 @@ fn output_found() {
         size: 50 * COIN_VALUE,
         start: 0,
       }]),
-      spent: false,
+      list: api::Output {
+        address: None, 
+        indexed: false,
+        inscriptions: vec![], 
+        runes: BTreeMap::new(), 
+        sat_ranges: Some(vec![(0, 5000000000)]), 
+        script_pubkey: "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac".to_string(),
+        spent: false,
+        transaction: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string(),
+        value: 5000000000,
+      } 
     }
   );
 }

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -25,7 +25,7 @@ fn output_found() {
           }]),
           list: api::Output {
               address: None,
-              indexed: true, // Updated to match actual output
+              indexed: true,
               inscriptions: vec![],
               runes: BTreeMap::new(),
               sat_ranges: Some(vec![(0, 5000000000)]),

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -13,28 +13,25 @@ fn output_found() {
   .run_and_deserialize_output::<Output>();
 
   assert_eq!(
-      output,
-      Output {
-          ranges: Some(vec![Range {
-              end: 50 * COIN_VALUE,
-              name: "nvtdijuwxlp".into(),
-              offset: 0,
-              rarity: "mythic".parse().unwrap(),
-              size: 50 * COIN_VALUE,
-              start: 0,
-          }]),
-          list: api::Output {
-              address: None,
-              indexed: true,
-              inscriptions: vec![],
-              runes: BTreeMap::new(),
-              sat_ranges: Some(vec![(0, 5000000000)]),
-              script_pubkey: "OP_PUSHBYTES_65 04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f OP_CHECKSIG".to_string(),
-              spent: false,
-              transaction: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string(),
-              value: 5000000000,
-          }
-      }
+    output,
+    Output {
+      address: None,
+      indexed: true,
+      inscriptions: vec![],
+      runes: BTreeMap::new(),
+      sat_ranges: Some(vec![Range {
+        end: 50 * COIN_VALUE,
+        name: "nvtdijuwxlp".into(),
+        offset: 0,
+        rarity: "mythic".parse().unwrap(),
+        size: 50 * COIN_VALUE,
+        start: 0,
+       }]),
+      script_pubkey: "OP_PUSHBYTES_65 04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f OP_CHECKSIG".to_string(),
+      spent: false,
+      transaction: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string(),
+      value: 5000000000,
+    }
   );
 }
 

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -24,16 +24,16 @@ fn output_found() {
         start: 0,
       }]),
       list: api::Output {
-        address: None, 
+        address: None,
         indexed: false,
-        inscriptions: vec![], 
-        runes: BTreeMap::new(), 
-        sat_ranges: Some(vec![(0, 5000000000)]), 
+        inscriptions: vec![],
+        runes: BTreeMap::new(),
+        sat_ranges: Some(vec![(0, 5000000000)]),
         script_pubkey: "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac".to_string(),
         spent: false,
         transaction: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string(),
         value: 5000000000,
-      } 
+      }
     }
   );
 }

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -42,7 +42,7 @@ use {
 fn output_found() {
   let core = mockcore::spawn();
   let output = CommandBuilder::new(
-      "--index-sats list 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0",
+    "--index-sats list 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0",
   )
   .core(&core)
   .run_and_deserialize_output::<Output>();
@@ -72,7 +72,6 @@ fn output_found() {
       }
   );
 }
-
 
 #[test]
 fn output_not_found() {

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -3,40 +3,76 @@ use {
   ord::subcommand::list::{Output, Range},
 };
 
+// #[test]
+// fn output_found() {
+//   let core = mockcore::spawn();
+//   let output = CommandBuilder::new(
+//     "--index-sats list 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0",
+//   )
+//   .core(&core)
+//   .run_and_deserialize_output::<Output>();
+
+//   assert_eq!(
+//     output,
+//     Output {
+//       ranges: Some(vec![Range {
+//         end: 50 * COIN_VALUE,
+//         name: "nvtdijuwxlp".into(),
+//         offset: 0,
+//         rarity: "mythic".parse().unwrap(),
+//         size: 50 * COIN_VALUE,
+//         start: 0,
+//       }]),
+//       list: api::Output {
+//         address: None,
+//         indexed: false,
+//         inscriptions: vec![],
+//         runes: BTreeMap::new(),
+//         sat_ranges: Some(vec![(0, 5000000000)]),
+//         script_pubkey: "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac".to_string(),
+//         spent: false,
+//         transaction: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string(),
+//         value: 5000000000,
+//       }
+//     }
+//   );
+// }
+
 #[test]
 fn output_found() {
   let core = mockcore::spawn();
   let output = CommandBuilder::new(
-    "--index-sats list 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0",
+      "--index-sats list 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0",
   )
   .core(&core)
   .run_and_deserialize_output::<Output>();
 
   assert_eq!(
-    output,
-    Output {
-      ranges: Some(vec![Range {
-        end: 50 * COIN_VALUE,
-        name: "nvtdijuwxlp".into(),
-        offset: 0,
-        rarity: "mythic".parse().unwrap(),
-        size: 50 * COIN_VALUE,
-        start: 0,
-      }]),
-      list: api::Output {
-        address: None,
-        indexed: false,
-        inscriptions: vec![],
-        runes: BTreeMap::new(),
-        sat_ranges: Some(vec![(0, 5000000000)]),
-        script_pubkey: "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac".to_string(),
-        spent: false,
-        transaction: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string(),
-        value: 5000000000,
+      output,
+      Output {
+          ranges: Some(vec![Range {
+              end: 50 * COIN_VALUE,
+              name: "nvtdijuwxlp".into(),
+              offset: 0,
+              rarity: "mythic".parse().unwrap(),
+              size: 50 * COIN_VALUE,
+              start: 0,
+          }]),
+          list: api::Output {
+              address: None,
+              indexed: true, // Updated to match actual output
+              inscriptions: vec![],
+              runes: BTreeMap::new(),
+              sat_ranges: Some(vec![(0, 5000000000)]),
+              script_pubkey: "OP_PUSHBYTES_65 04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f OP_CHECKSIG".to_string(), // Updated to match actual output
+              spent: false,
+              transaction: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string(),
+              value: 5000000000,
+          }
       }
-    }
   );
 }
+
 
 #[test]
 fn output_not_found() {

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -3,41 +3,6 @@ use {
   ord::subcommand::list::{Output, Range},
 };
 
-// #[test]
-// fn output_found() {
-//   let core = mockcore::spawn();
-//   let output = CommandBuilder::new(
-//     "--index-sats list 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0",
-//   )
-//   .core(&core)
-//   .run_and_deserialize_output::<Output>();
-
-//   assert_eq!(
-//     output,
-//     Output {
-//       ranges: Some(vec![Range {
-//         end: 50 * COIN_VALUE,
-//         name: "nvtdijuwxlp".into(),
-//         offset: 0,
-//         rarity: "mythic".parse().unwrap(),
-//         size: 50 * COIN_VALUE,
-//         start: 0,
-//       }]),
-//       list: api::Output {
-//         address: None,
-//         indexed: false,
-//         inscriptions: vec![],
-//         runes: BTreeMap::new(),
-//         sat_ranges: Some(vec![(0, 5000000000)]),
-//         script_pubkey: "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac".to_string(),
-//         spent: false,
-//         transaction: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string(),
-//         value: 5000000000,
-//       }
-//     }
-//   );
-// }
-
 #[test]
 fn output_found() {
   let core = mockcore::spawn();


### PR DESCRIPTION
fixes #3701 - I've added the `/output/<OUTPOINT>` fields to the `ord list` command into a section called "list'.  I also reordered the fields in the pre-existing "ranges" section to make more logical sense.  There is a small amount of redundancy now with the list.sat_ranges vs ranges.start & end, and list.value vs ranges.size.  I figure that this is acceptable and better than changing the pre-existing ranges section, as some users may already be reliant upon those fields - but let me know if not and if further formatting or changes would be better.