### PR TITLE
Fetch child inscriptions without using `getrawtransaction`

### DIFF
--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -40,6 +40,8 @@ The recursive endpoints are:
 - `/r/blocktime`: UNIX time stamp of latest block.
 - `/r/children/<INSCRIPTION_ID>`: the first 100 child inscription ids.
 - `/r/children/<INSCRIPTION_ID>/<PAGE>`: the set of 100 child inscription ids on `<PAGE>`.
+- `/r/children/<INSCRIPTION_ID>/inscriptions`: details of the first 100 child inscriptions.
+- `/r/children/<INSCRIPTION_ID>/inscriptions/<PAGE>`: details of the set of 100 child inscriptions on `<PAGE>`.
 - `/r/inscription/<INSCRIPTION_ID>`: information about an inscription
 - `/r/metadata/<INSCRIPTION_ID>`: JSON string containing the hex-encoded CBOR metadata.
 - `/r/sat/<SAT_NUMBER>`: the first 100 inscription ids on a sat.
@@ -127,6 +129,44 @@ Examples
    ],
    "more":false,
    "page":49
+}
+```
+
+- `/r/children/60bcf821240064a9c55225c4f01711b0ebbcab39aa3fafeefe4299ab158536fai0/inscriptions/49`:
+
+```json
+{
+  "inscriptions": [
+    {
+      "charms": [
+        "cursed"
+      ],
+      "fee": 44,
+      "height": 813929,
+      "id": "7cd66b8e3a63dcd2fada917119830286bca0637267709d6df1ca78d98a1b4487i4900",
+      "number": -223695,
+      "output": "dcaaeacf58faea0927468ea5a93f33b7d7447841e66f75db5a655d735510c518:0",
+      "sat": 1897135510683785,
+      "satpoint": "dcaaeacf58faea0927468ea5a93f33b7d7447841e66f75db5a655d735510c518:0:74188588",
+      "timestamp": 1698326262
+    },
+      ...
+    {
+      "charms": [
+        "cursed"
+      ],
+      "fee": 44,
+      "height": 813929,
+      "id": "7cd66b8e3a63dcd2fada917119830286bca0637267709d6df1ca78d98a1b4487i4936",
+      "number": -223731,
+      "output": "dcaaeacf58faea0927468ea5a93f33b7d7447841e66f75db5a655d735510c518:0",
+      "sat": 1897135510683821,
+      "satpoint": "dcaaeacf58faea0927468ea5a93f33b7d7447841e66f75db5a655d735510c518:0:74188624",
+      "timestamp": 1698326262
+    }
+  ],
+  "more": false,
+  "page": 49
 }
 ```
 

--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -142,7 +142,7 @@ percentile in sats/vB.
 
 ```json
 {
-  "inscriptions": [
+  "children": [
     {
       "charms": [
         "cursed"

--- a/src/api.rs
+++ b/src/api.rs
@@ -79,6 +79,13 @@ pub struct Children {
   pub page: usize,
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct ChildInscriptions {
+  pub inscriptions: Vec<ChildInscriptionRecursive>,
+  pub more: bool,
+  pub page: usize,
+}
+
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Inscription {
   pub address: Option<String>,
@@ -115,6 +122,19 @@ pub struct InscriptionRecursive {
   pub satpoint: SatPoint,
   pub timestamp: i64,
   pub value: Option<u64>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct ChildInscriptionRecursive {
+  pub charms: Vec<Charm>,
+  pub fee: u64,
+  pub height: u32,
+  pub id: InscriptionId,
+  pub number: i32,
+  pub output: OutPoint,
+  pub sat: Option<ordinals::Sat>,
+  pub satpoint: SatPoint,
+  pub timestamp: i64,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -82,7 +82,7 @@ pub struct Children {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChildInscriptions {
-  pub inscriptions: Vec<ChildInscriptionRecursive>,
+  pub children: Vec<ChildInscriptionRecursive>,
   pub more: bool,
   pub page: usize,
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -240,6 +240,14 @@ impl Server {
           "/r/children/:inscription_id/:page",
           get(Self::children_recursive_paginated),
         )
+        .route(
+          "/r/children/:inscription_id/inscriptions",
+          get(Self::child_inscriptions_recursive),
+        )
+        .route(
+          "/r/children/:inscription_id/inscriptions/:page",
+          get(Self::child_inscriptions_recursive_paginated),
+        )
         .route("/r/metadata/:inscription_id", get(Self::metadata))
         .route("/r/sat/:sat_number", get(Self::sat_inscriptions))
         .route(
@@ -1715,6 +1723,64 @@ impl Server {
         index.get_children_by_sequence_number_paginated(parent_sequence_number, 100, page)?;
 
       Ok(Json(api::Children { ids, more, page }).into_response())
+    })
+  }
+
+  async fn child_inscriptions_recursive(
+    Extension(index): Extension<Arc<Index>>,
+    Path(inscription_id): Path<InscriptionId>,
+  ) -> ServerResult {
+    Self::child_inscriptions_recursive_paginated(Extension(index), Path((inscription_id, 0))).await
+  }
+
+  async fn child_inscriptions_recursive_paginated(
+    Extension(index): Extension<Arc<Index>>,
+    Path((parent, page)): Path<(InscriptionId, usize)>,
+  ) -> ServerResult {
+    task::block_in_place(|| {
+      let parent_sequence_number = index
+        .get_inscription_entry(parent)?
+        .ok_or_not_found(|| format!("inscription {parent}"))?
+        .sequence_number;
+
+      let (ids, more) =
+        index.get_children_by_sequence_number_paginated(parent_sequence_number, 100, page)?;
+
+      let mut inscriptions = Vec::new();
+
+      for inscription_id in ids {
+        let entry = index
+          .get_inscription_entry(inscription_id)
+          .unwrap()
+          .unwrap();
+
+        let satpoint = index
+          .get_inscription_satpoint_by_id(inscription_id)
+          .ok()
+          .flatten()
+          .unwrap();
+
+        inscriptions.push(api::ChildInscriptionRecursive {
+          charms: Charm::charms(entry.charms),
+          fee: entry.fee,
+          height: entry.height,
+          id: inscription_id,
+          number: entry.inscription_number,
+          output: satpoint.outpoint,
+          sat: entry.sat,
+          satpoint,
+          timestamp: timestamp(entry.timestamp.into()).timestamp(),
+        });
+      }
+
+      Ok(
+        Json(api::ChildInscriptions {
+          inscriptions,
+          more,
+          page,
+        })
+        .into_response(),
+      )
     })
   }
 
@@ -5993,6 +6059,103 @@ next
     assert_eq!(children_json.ids[10], hundred_eleventh_child_inscription_id);
     assert!(!children_json.more);
     assert_eq!(children_json.page, 1);
+  }
+
+  #[test]
+  fn child_inscriptions_recursive_endpoint() {
+    let server = TestServer::builder().chain(Chain::Regtest).build();
+    server.mine_blocks(1);
+
+    let parent_txid = server.core.broadcast_tx(TransactionTemplate {
+      inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+      ..default()
+    });
+
+    let parent_inscription_id = InscriptionId {
+      txid: parent_txid,
+      index: 0,
+    };
+
+    server.assert_response(
+      format!("/r/children/{parent_inscription_id}/inscriptions"),
+      StatusCode::NOT_FOUND,
+      &format!("inscription {parent_inscription_id} not found"),
+    );
+
+    server.mine_blocks(1);
+
+    let child_inscriptions_json = server.get_json::<api::ChildInscriptions>(format!(
+      "/r/children/{parent_inscription_id}/inscriptions"
+    ));
+    assert_eq!(child_inscriptions_json.inscriptions.len(), 0);
+
+    let mut builder = script::Builder::new();
+    for _ in 0..111 {
+      builder = Inscription {
+        content_type: Some("text/plain".into()),
+        body: Some("hello".into()),
+        parents: vec![parent_inscription_id.value()],
+        unrecognized_even_field: false,
+        ..default()
+      }
+      .append_reveal_script_to_builder(builder);
+    }
+
+    let witness = Witness::from_slice(&[builder.into_bytes(), Vec::new()]);
+
+    let txid = server.core.broadcast_tx(TransactionTemplate {
+      inputs: &[(2, 0, 0, witness), (2, 1, 0, Default::default())],
+      ..default()
+    });
+
+    server.mine_blocks(1);
+
+    let first_child_inscription_id = InscriptionId { txid, index: 0 };
+    let hundredth_child_inscription_id = InscriptionId { txid, index: 99 };
+    let hundred_first_child_inscription_id = InscriptionId { txid, index: 100 };
+    let hundred_eleventh_child_inscription_id = InscriptionId { txid, index: 110 };
+
+    let child_inscriptions_json = server.get_json::<api::ChildInscriptions>(format!(
+      "/r/children/{parent_inscription_id}/inscriptions"
+    ));
+
+    assert_eq!(child_inscriptions_json.inscriptions.len(), 100);
+
+    assert_eq!(
+      child_inscriptions_json.inscriptions[0].id,
+      first_child_inscription_id
+    );
+    assert_eq!(child_inscriptions_json.inscriptions[0].number, 1); // parent is #0, 1st child is #1
+
+    assert_eq!(
+      child_inscriptions_json.inscriptions[99].id,
+      hundredth_child_inscription_id
+    );
+    assert_eq!(child_inscriptions_json.inscriptions[99].number, -99); // all but 1st child are cursed
+
+    assert!(child_inscriptions_json.more);
+    assert_eq!(child_inscriptions_json.page, 0);
+
+    let child_inscriptions_json = server.get_json::<api::ChildInscriptions>(format!(
+      "/r/children/{parent_inscription_id}/inscriptions/1"
+    ));
+
+    assert_eq!(child_inscriptions_json.inscriptions.len(), 11);
+
+    assert_eq!(
+      child_inscriptions_json.inscriptions[0].id,
+      hundred_first_child_inscription_id
+    );
+    assert_eq!(child_inscriptions_json.inscriptions[0].number, -100);
+
+    assert_eq!(
+      child_inscriptions_json.inscriptions[10].id,
+      hundred_eleventh_child_inscription_id
+    );
+    assert_eq!(child_inscriptions_json.inscriptions[10].number, -110);
+
+    assert!(!child_inscriptions_json.more);
+    assert_eq!(child_inscriptions_json.page, 1);
   }
 
   #[test]

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -6348,7 +6348,7 @@ next
     let child_inscriptions_json = server.get_json::<api::ChildInscriptions>(format!(
       "/r/children/{parent_inscription_id}/inscriptions"
     ));
-    assert_eq!(child_inscriptions_json.inscriptions.len(), 0);
+    assert_eq!(child_inscriptions_json.children.len(), 0);
 
     let mut builder = script::Builder::new();
     for _ in 0..111 {
@@ -6380,19 +6380,19 @@ next
       "/r/children/{parent_inscription_id}/inscriptions"
     ));
 
-    assert_eq!(child_inscriptions_json.inscriptions.len(), 100);
+    assert_eq!(child_inscriptions_json.children.len(), 100);
 
     assert_eq!(
-      child_inscriptions_json.inscriptions[0].id,
+      child_inscriptions_json.children[0].id,
       first_child_inscription_id
     );
-    assert_eq!(child_inscriptions_json.inscriptions[0].number, 1); // parent is #0, 1st child is #1
+    assert_eq!(child_inscriptions_json.children[0].number, 1); // parent is #0, 1st child is #1
 
     assert_eq!(
-      child_inscriptions_json.inscriptions[99].id,
+      child_inscriptions_json.children[99].id,
       hundredth_child_inscription_id
     );
-    assert_eq!(child_inscriptions_json.inscriptions[99].number, -99); // all but 1st child are cursed
+    assert_eq!(child_inscriptions_json.children[99].number, -99); // all but 1st child are cursed
 
     assert!(child_inscriptions_json.more);
     assert_eq!(child_inscriptions_json.page, 0);
@@ -6401,19 +6401,19 @@ next
       "/r/children/{parent_inscription_id}/inscriptions/1"
     ));
 
-    assert_eq!(child_inscriptions_json.inscriptions.len(), 11);
+    assert_eq!(child_inscriptions_json.children.len(), 11);
 
     assert_eq!(
-      child_inscriptions_json.inscriptions[0].id,
+      child_inscriptions_json.children[0].id,
       hundred_first_child_inscription_id
     );
-    assert_eq!(child_inscriptions_json.inscriptions[0].number, -100);
+    assert_eq!(child_inscriptions_json.children[0].number, -100);
 
     assert_eq!(
-      child_inscriptions_json.inscriptions[10].id,
+      child_inscriptions_json.children[10].id,
       hundred_eleventh_child_inscription_id
     );
-    assert_eq!(child_inscriptions_json.inscriptions[10].number, -110);
+    assert_eq!(child_inscriptions_json.children[10].number, -110);
 
     assert!(!child_inscriptions_json.more);
     assert_eq!(child_inscriptions_json.page, 1);


### PR DESCRIPTION
Add `/r/children/:inscription_id/inscriptions` endpoint.

In case #3761 is too heavy, this version avoids doing any `getrawtransaction` calls, at the cost of not returning the following fields: 
* content_type
* content_length
* delegate
* value

On my system this fetches the first 100 pizza ninja children in about 50 ms, compared to 7250 ms using the previous PR (#3761). That's about 150 times faster. Turns out fetching the raw transactions is kind of slow.