### PR TITLE
Use Hash(ScriptPubKey) for address index

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -48,7 +48,7 @@ mod updater;
 #[cfg(test)]
 pub(crate) mod testing;
 
-const SCHEMA_VERSION: u64 = 26;
+const SCHEMA_VERSION: u64 = 27;
 
 define_multimap_table! { SATPOINT_TO_SEQUENCE_NUMBER, &SatPointValue, u32 }
 define_multimap_table! { SAT_TO_SEQUENCE_NUMBER, u64, u32 }


### PR DESCRIPTION
I'm just gonna run this and see if it either makes indexing faster or the table smaller.

I'm using SHA256 but alternatives include:
- SipHash
- BLAKE3
- SHA-3
