### PR TITLE
fix panic in ord env shutdown

### DIFF
--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -4,9 +4,7 @@ struct KillOnDrop(process::Child);
 
 impl Drop for KillOnDrop {
   fn drop(&mut self) {
-    let _ = Command::new("kill")
-      .arg(self.0.id().to_string())
-      .status();
+    let _ = Command::new("kill").arg(self.0.id().to_string()).status();
 
     let _ = self.0.kill();
 

--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -4,12 +4,13 @@ struct KillOnDrop(process::Child);
 
 impl Drop for KillOnDrop {
   fn drop(&mut self) {
-    assert!(Command::new("kill")
+    let _ = Command::new("kill")
       .arg(self.0.id().to_string())
-      .status()
-      .unwrap()
-      .success());
-    self.0.wait().unwrap();
+      .status();
+
+    let _ = self.0.kill();
+
+    let _ = self.0.wait();
   }
 }
 


### PR DESCRIPTION
fixes #3460;  this panic was still occurring in 0.18.5 on my Windows machine.  I was able to test this change there and it fixes the issue by allowing for shutdown without panic.