### PR TITLE
Add sat ranges to output

### DIFF
--- a/src/subcommand/wallet.rs
+++ b/src/subcommand/wallet.rs
@@ -62,7 +62,7 @@ pub(crate) enum Subcommand {
   #[command(about = "Mint a rune")]
   Mint(mint::Mint),
   #[command(about = "List all unspent outputs in wallet")]
-  Outputs,
+  Outputs(outputs::Outputs),
   #[command(about = "List pending etchings")]
   Pending(pending::Pending),
   #[command(about = "Generate receive address")]
@@ -113,7 +113,7 @@ impl WalletCommand {
       Subcommand::Inscriptions => inscriptions::run(wallet),
       Subcommand::Label => label::run(wallet),
       Subcommand::Mint(mint) => mint.run(wallet),
-      Subcommand::Outputs => outputs::run(wallet),
+      Subcommand::Outputs(outputs) => outputs.run(wallet),
       Subcommand::Pending(pending) => pending.run(wallet),
       Subcommand::Receive(receive) => receive.run(wallet),
       Subcommand::Resume(resume) => resume.run(wallet),

--- a/src/subcommand/wallet/label.rs
+++ b/src/subcommand/wallet/label.rs
@@ -23,7 +23,7 @@ struct Line {
 pub(crate) fn run(wallet: Wallet) -> SubcommandResult {
   let mut lines: Vec<Line> = Vec::new();
 
-  let sat_ranges = wallet.get_output_sat_ranges()?;
+  let sat_ranges = wallet.get_wallet_sat_ranges()?;
 
   let mut inscriptions_by_output: BTreeMap<OutPoint, BTreeMap<u64, Vec<InscriptionId>>> =
     BTreeMap::new();

--- a/src/subcommand/wallet/outputs.rs
+++ b/src/subcommand/wallet/outputs.rs
@@ -26,7 +26,7 @@ pub(crate) fn run(wallet: Wallet) -> SubcommandResult {
             .collect::<Vec<_>>()
             .join(", "),
         ),
-        Err(e) => Some(format!("Error: {}", e.to_string())),
+        Err(e) => Some(format!("Error: {}", e)),
       }
     } else {
       None

--- a/src/subcommand/wallet/outputs.rs
+++ b/src/subcommand/wallet/outputs.rs
@@ -16,13 +16,12 @@ pub(crate) fn run(wallet: Wallet) -> SubcommandResult {
         Ok(sat_ranges) => Some(
           sat_ranges
             .into_iter()
-            .map(|(_, ranges)| {
+            .flat_map(|(_, ranges)| {
               ranges
                 .into_iter()
                 .map(|(start, end)| format!("{}-{}", start, end))
                 .collect::<Vec<_>>()
             })
-            .flatten()
             .collect::<Vec<_>>()
             .join(", "),
         ),

--- a/src/subcommand/wallet/outputs.rs
+++ b/src/subcommand/wallet/outputs.rs
@@ -4,16 +4,40 @@ use super::*;
 pub struct Output {
   pub output: OutPoint,
   pub amount: u64,
+  pub sat_ranges: Option<String>,
 }
 
 pub(crate) fn run(wallet: Wallet) -> SubcommandResult {
   let mut outputs = Vec::new();
   for (output, txout) in wallet.utxos() {
+    // Check if the wallet has a sat index
+    let sat_ranges = if wallet.has_sat_index() {
+      match wallet.get_output_sat_range(output) {
+        Ok(sat_ranges) => Some(
+          sat_ranges
+            .into_iter()
+            .map(|(_, ranges)| {
+              ranges
+                .into_iter()
+                .map(|(start, end)| format!("{}-{}", start, end))
+                .collect::<Vec<_>>()
+            })
+            .flatten()
+            .collect::<Vec<_>>()
+            .join(", "),
+        ),
+        Err(e) => Some(format!("Error: {}", e.to_string())), // Optionally, handle errors differently
+      }
+    } else {
+      None
+    };
+
+    // Push the formatted output into the outputs vector
     outputs.push(Output {
       output: *output,
       amount: txout.value,
+      sat_ranges,
     });
   }
-
   Ok(Some(Box::new(outputs)))
 }

--- a/src/subcommand/wallet/outputs.rs
+++ b/src/subcommand/wallet/outputs.rs
@@ -26,13 +26,12 @@ pub(crate) fn run(wallet: Wallet) -> SubcommandResult {
             .collect::<Vec<_>>()
             .join(", "),
         ),
-        Err(e) => Some(format!("Error: {}", e.to_string())), // Optionally, handle errors differently
+        Err(e) => Some(format!("Error: {}", e.to_string())),
       }
     } else {
       None
     };
 
-    // Push the formatted output into the outputs vector
     outputs.push(Output {
       output: *output,
       amount: txout.value,

--- a/src/subcommand/wallet/sats.rs
+++ b/src/subcommand/wallet/sats.rs
@@ -30,7 +30,7 @@ impl Sats {
       "sats requires index created with `--index-sats` flag"
     );
 
-    let haystacks = wallet.get_output_sat_ranges()?;
+    let haystacks = wallet.get_wallet_sat_ranges()?;
 
     if let Some(path) = &self.tsv {
       let tsv = fs::read_to_string(path)

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -72,7 +72,7 @@ pub(crate) struct Wallet {
 }
 
 impl Wallet {
-  pub(crate) fn get_output_sat_ranges(&self) -> Result<Vec<(OutPoint, Vec<(u64, u64)>)>> {
+  pub(crate) fn get_wallet_sat_ranges(&self) -> Result<Vec<(OutPoint, Vec<(u64, u64)>)>> {
     ensure!(
       self.has_sat_index,
       "ord index must be built with `--index-sats` to use `--sat`"
@@ -90,10 +90,7 @@ impl Wallet {
     Ok(output_sat_ranges)
   }
 
-  pub(crate) fn get_output_sat_range(
-    &self,
-    output: &OutPoint,
-  ) -> Result<Vec<(OutPoint, Vec<(u64, u64)>)>> {
+  pub(crate) fn get_output_sat_ranges(&self, output: &OutPoint) -> Result<Vec<(u64, u64)>> {
     ensure!(
       self.has_sat_index,
       "ord index must be built with `--index-sats` to see sat ranges"
@@ -101,8 +98,7 @@ impl Wallet {
 
     if let Some(info) = self.output_info.get(output) {
       if let Some(sat_ranges) = &info.sat_ranges {
-        // Return the sat ranges for the specific output
-        Ok(vec![(*output, sat_ranges.clone())])
+        Ok(sat_ranges.clone())
       } else {
         bail!("output {output} in wallet but is spent according to ord server");
       }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -90,6 +90,27 @@ impl Wallet {
     Ok(output_sat_ranges)
   }
 
+  pub(crate) fn get_output_sat_range(
+    &self,
+    output: &OutPoint,
+  ) -> Result<Vec<(OutPoint, Vec<(u64, u64)>)>> {
+    ensure!(
+      self.has_sat_index,
+      "ord index must be built with `--index-sats` to see sat ranges"
+    );
+
+    if let Some(info) = self.output_info.get(output) {
+      if let Some(sat_ranges) = &info.sat_ranges {
+        // Return the sat ranges for the specific output
+        Ok(vec![(*output, sat_ranges.clone())])
+      } else {
+        bail!("output {output} in wallet but is spent according to ord server");
+      }
+    } else {
+      bail!("output {output} not found in wallet");
+    }
+  }
+
   pub(crate) fn find_sat_in_outputs(&self, sat: Sat) -> Result<SatPoint> {
     ensure!(
       self.has_sat_index,

--- a/tests/wallet/outputs.rs
+++ b/tests/wallet/outputs.rs
@@ -66,3 +66,25 @@ fn outputs_includes_unbound_outputs() {
   assert_eq!(output[0].output, outpoint);
   assert_eq!(output[0].amount, amount);
 }
+
+#[test]
+fn outputs_includes_sat_ranges() {
+  let core = mockcore::spawn();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-sats"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let coinbase_tx = &core.mine_blocks_with_subsidy(1, 1_000_000)[0].txdata[0];
+  let outpoint = OutPoint::new(coinbase_tx.txid(), 0);
+  let amount = coinbase_tx.output[0].value;
+
+  let output = CommandBuilder::new("wallet outputs")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Vec<Output>>();
+
+  assert_eq!(output[0].output, outpoint);
+  assert_eq!(output[0].amount, amount);
+  assert_eq!(output[0].sat_ranges, vec!["5000000000-5001000000"]);
+}

--- a/tests/wallet/outputs.rs
+++ b/tests/wallet/outputs.rs
@@ -79,7 +79,7 @@ fn outputs_includes_sat_ranges() {
   let outpoint = OutPoint::new(coinbase_tx.txid(), 0);
   let amount = coinbase_tx.output[0].value;
 
-  let output = CommandBuilder::new("wallet outputs")
+  let output = CommandBuilder::new("wallet outputs --ranges")
     .core(&core)
     .ord(&ord)
     .run_and_deserialize_output::<Vec<Output>>();


### PR DESCRIPTION
partially addresses #3792 by adding the sat ranges to the `ord wallet output` command.  My feeling is that the sat ranges are information about the outputs, so this is a good place for this information.  

Next, I'll add the --all flag  so that `ord wallet sats --all` will return all sat ranges, and `ord wallet sats` without a flag will continue to only show rare sats (as it does today).  

The description for the command says `List wallet satoshis` - but what do we want this output to look like?  Should it simply be a list of sat ranges with no reference to the outputs, or anything else?  Would something like the mock-up below be acceptable? or do we want to display more info?

> `ord wallet sats --all`
[1111111111111111-1111111111111112, 1111111111111113-1111111111111114, 1111111111111115-1111111111111116, 1111111111111117-1111111111111118, 1111111111111119-1111111111111120, 1111111111111121-1111111111111122]