### PR TITLE
Add debugging tips to show full Rust backtrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ $ RUST_LOG=info cargo run server
 ```
 Set the
 `RUST_BACKTRACE` environment variable in order to turn on full rust tracktrace. For example, run
-the server abd turn on debugging and full backtrace:
+the server and turn on debugging and full backtrace:
 ```
 $ RUST_BACKTRACE=1 RUST_LOG=debug ord server
 ```

--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ the server and show `info`-level log messages and above:
 ```
 $ RUST_LOG=info cargo run server
 ```
+Set the
+`RUST_BACKTRACE` environment variable in order to turn on full rust tracktrace. For example, run
+the server abd turn on debugging and full backtrace:
+```
+$ RUST_BACKTRACE=1 RUST_LOG=debug ord server
+```
 
 New Releases
 ------------

--- a/README.md
+++ b/README.md
@@ -265,9 +265,10 @@ the server and show `info`-level log messages and above:
 ```
 $ RUST_LOG=info cargo run server
 ```
-Set the
-`RUST_BACKTRACE` environment variable in order to turn on full rust tracktrace. For example, run
-the server and turn on debugging and full backtrace:
+
+Set the `RUST_BACKTRACE` environment variable in order to turn on full rust
+backtrace. For example, run the server and turn on debugging and full backtrace:
+
 ```
 $ RUST_BACKTRACE=1 RUST_LOG=debug ord server
 ```


### PR DESCRIPTION
It was mentioned here by @casey https://github.com/ordinals/ord/issues/1471#issuecomment-1421615258 that this small tips in README could help a lot of folks.