### PR TITLE
added the --all flag on `ord wallet sats`

### DIFF
--- a/src/subcommand/wallet/sats.rs
+++ b/src/subcommand/wallet/sats.rs
@@ -49,7 +49,7 @@ impl Sats {
 
       let formatted_ranges: Vec<String> = ranges
         .iter()
-        .map(|range| format!("{} - {}", range.0, range.1))
+        .map(|range| format!("{}-{}", range.0, range.1))
         .collect();
 
       let result = format!("[{}]", formatted_ranges.join(", \n"));

--- a/src/subcommand/wallet/sats.rs
+++ b/src/subcommand/wallet/sats.rs
@@ -1,5 +1,4 @@
 use super::*;
-use clap::Parser;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Sats {

--- a/src/subcommand/wallet/sats.rs
+++ b/src/subcommand/wallet/sats.rs
@@ -30,10 +30,10 @@ pub struct OutputRare {
   pub rarity: Rarity,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct OutputAll {
-  pub ranges: BTreeMap<OutPoint, Vec<String>>,
-  pub rare: Vec<OutputRare>,
+  pub output: OutPoint,
+  pub ranges: Vec<String>,
 }
 
 impl Sats {
@@ -49,16 +49,14 @@ impl Sats {
       Ok(Some(Box::new(
         haystacks
           .into_iter()
-          .map(|(outpoint, ranges)| {
-            (
-              outpoint,
-              ranges
-                .into_iter()
-                .map(|range| format!("{}-{}", range.0, range.1))
-                .collect::<Vec<String>>(),
-            )
+          .map(|(outpoint, ranges)| OutputAll {
+            output: outpoint,
+            ranges: ranges
+              .into_iter()
+              .map(|range| format!("{}-{}", range.0, range.1))
+              .collect::<Vec<String>>(),
           })
-          .collect::<BTreeMap<OutPoint, Vec<String>>>(),
+          .collect::<Vec<OutputAll>>(),
       )))
     } else if let Some(path) = &self.tsv {
       let tsv = fs::read_to_string(path)

--- a/src/subcommand/wallet/sats.rs
+++ b/src/subcommand/wallet/sats.rs
@@ -10,7 +10,7 @@ pub(crate) struct Sats {
   tsv: Option<PathBuf>,
   #[arg(
     long,
-    help = "Display list of all sat ranges in wallet and special sats."
+    help = "Display list of all sat ranges in wallet"
   )]
   all: bool,
 }

--- a/src/subcommand/wallet/sats.rs
+++ b/src/subcommand/wallet/sats.rs
@@ -7,10 +7,7 @@ pub(crate) struct Sats {
     help = "Find satoshis listed in first column of tab-separated value file <TSV>."
   )]
   tsv: Option<PathBuf>,
-  #[arg(
-    long,
-    help = "Display list of all sat ranges in wallet"
-  )]
+  #[arg(long, help = "Display list of all sat ranges in wallet")]
   all: bool,
 }
 

--- a/tests/wallet/sats.rs
+++ b/tests/wallet/sats.rs
@@ -1,6 +1,6 @@
 use {
   super::*,
-  ord::subcommand::wallet::sats::{OutputRare, OutputTsv},
+  ord::subcommand::wallet::sats::{OutputAll, OutputRare, OutputTsv},
 };
 
 #[test]
@@ -93,4 +93,30 @@ fn sats_from_tsv_file_not_found() {
     .expected_exit_code(1)
     .stderr_regex("error: I/O error reading `.*`\n\nbecause:.*")
     .run_and_extract_stdout();
+}
+
+#[test]
+fn sats_all() {
+  let core = mockcore::spawn();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-sats"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let second_coinbase = core.mine_blocks(1)[0].txdata[0].txid();
+
+  let output = CommandBuilder::new("--index-sats wallet sats --all")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<BTreeMap<OutPoint, Vec<String>>>();
+
+  assert_eq!(
+    output,
+    vec![(
+      format!("{second_coinbase}:0").parse::<OutPoint>().unwrap(),
+      vec![format!("{}-{}", 50 * COIN_VALUE, 100 * COIN_VALUE)]
+    )]
+    .into_iter()
+    .collect()
+  );
 }

--- a/tests/wallet/sats.rs
+++ b/tests/wallet/sats.rs
@@ -108,15 +108,15 @@ fn sats_all() {
   let output = CommandBuilder::new("--index-sats wallet sats --all")
     .core(&core)
     .ord(&ord)
-    .run_and_deserialize_output::<BTreeMap<OutPoint, Vec<String>>>();
+    .run_and_deserialize_output::<Vec<OutputAll>>();
 
   assert_eq!(
     output,
-    vec![(
-      format!("{second_coinbase}:0").parse::<OutPoint>().unwrap(),
-      vec![format!("{}-{}", 50 * COIN_VALUE, 100 * COIN_VALUE)]
-    )]
+    vec![OutputAll {
+      output: format!("{second_coinbase}:0").parse::<OutPoint>().unwrap(),
+      ranges: vec![format!("{}-{}", 50 * COIN_VALUE, 100 * COIN_VALUE)],
+    }]
     .into_iter()
-    .collect()
+    .collect::<Vec<OutputAll>>()
   );
 }


### PR DESCRIPTION
further addressing #3792 

return all sat ranges in wallet, in addition to
the rare sats the command normally returns.