### PR TITLE
Display rune balances in address page

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -2233,24 +2233,38 @@ impl Index {
       .collect()
   }
 
-  pub(crate) fn get_rune_balances_for_outputs(&self, outputs: &Vec<OutPoint>) -> Result<Vec<(SpacedRune, u128)>> {
-    let outpoint_to_rune_balances = self.database.begin_read()?.open_table(OUTPOINT_TO_RUNE_BALANCES)?;
-    let id_to_rune_entry = self.database.begin_read()?.open_table(RUNE_ID_TO_RUNE_ENTRY)?;
-    let mut acc = Vec::new();
+  pub(crate) fn get_aggregated_rune_balances_for_outputs(
+    &self,
+    outputs: &Vec<OutPoint>,
+  ) -> Result<Vec<(SpacedRune, Decimal, Option<char>)>> {
+    let mut runes = BTreeMap::new();
 
     for output in outputs {
-      if let Some(value) = outpoint_to_rune_balances.get(&output.store())? {
-        // Convert the decoded rune balance to a SpacedRune Struct
-        let ((id, amount), _length) = Index::decode_rune_balance(&value.value()).unwrap();
-        let rune_entry = RuneEntry::load(id_to_rune_entry.get(id.store())?.unwrap().value()).spaced_rune;
-        acc.push((rune_entry, amount));
+      let rune_balances = self.get_rune_balances_for_output(*output)?;
 
+      for (spaced_rune, pile) in rune_balances {
+        runes
+          .entry(spaced_rune)
+          .and_modify(|(decimal, _symbol): &mut (Decimal, Option<char>)| {
+            assert_eq!(decimal.scale, pile.divisibility);
+            decimal.value += pile.amount;
+          })
+          .or_insert((
+            Decimal {
+              value: pile.amount,
+              scale: pile.divisibility,
+            },
+            pile.symbol,
+          ));
       }
     }
 
-    Ok(acc)
-
-
+    Ok(
+      runes
+        .into_iter()
+        .map(|(spaced_rune, (decimal, symbol))| (spaced_rune, decimal, symbol))
+        .collect(),
+    )
   }
 
   pub(crate) fn get_sat_balances_for_outputs(&self, outputs: &Vec<OutPoint>) -> Result<u64> {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -864,7 +864,7 @@ impl Server {
 
       let sat_balance = index.get_sat_balances_for_outputs(&outputs)?;
 
-      let runes_balances = index.get_rune_balances_for_outputs(&outputs)?;
+      let runes_balances = index.get_aggregated_rune_balances_for_outputs(&outputs)?;
 
       Ok(if accept_json {
         Json(outputs).into_response()
@@ -874,7 +874,6 @@ impl Server {
           outputs,
           sat_balance,
           runes_balances,
-
         }
         .page(server_config)
         .into_response()

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -864,6 +864,8 @@ impl Server {
 
       let sat_balance = index.get_sat_balances_for_outputs(&outputs)?;
 
+      let runes_balances = index.get_rune_balances_for_outputs(&outputs)?;
+
       Ok(if accept_json {
         Json(outputs).into_response()
       } else {
@@ -871,6 +873,8 @@ impl Server {
           address,
           outputs,
           sat_balance,
+          runes_balances,
+
         }
         .page(server_config)
         .into_response()

--- a/src/templates/address.rs
+++ b/src/templates/address.rs
@@ -35,7 +35,16 @@ mod tests {
           scale: 0,
           value: 20000,
         },
-        Some('R'),
+        Some('R')),(
+        SpacedRune {
+          rune: Rune::from_str("ANOTHERTEESTRUNE").unwrap(),
+          spacers: 0,
+        },
+        Decimal {
+          scale: 0,
+          value: 10000,
+        },
+        Some('F'),
       )],
     }
   }
@@ -58,7 +67,7 @@ mod tests {
   #[test]
   fn test_runes_balances_rendering() {
     let address_html = setup();
-    let expected_pattern = r#".*<dt>runes balances</dt>\n\s*<dd>TEEEEEEEEESTRUNE: 20000R</dd>.*"#;
+    let expected_pattern = r#".*<dt>runes balances</dt>\n\s*<dd><a class=monospace href=/rune/TEEEEEEEEESTRUNE>TEEEEEEEEESTRUNE</a>: 20000R</dd>\n\s*<dd><a class=monospace href=/rune/ANOTHERTEESTRUNE>ANOTHERTEESTRUNE</a>: 10000F</dd>.*"#;
     assert_regex_match!(address_html, expected_pattern);
   }
 

--- a/src/templates/address.rs
+++ b/src/templates/address.rs
@@ -26,26 +26,30 @@ mod tests {
         .unwrap(),
       outputs: vec![outpoint(1), outpoint(2)],
       sat_balance: 99,
-      runes_balances: vec![(
-        SpacedRune {
-          rune: Rune::from_str("TEEEEEEEEESTRUNE").unwrap(),
-          spacers: 0,
-        },
-        Decimal {
-          scale: 0,
-          value: 20000,
-        },
-        Some('R')),(
-        SpacedRune {
-          rune: Rune::from_str("ANOTHERTEESTRUNE").unwrap(),
-          spacers: 0,
-        },
-        Decimal {
-          scale: 0,
-          value: 10000,
-        },
-        Some('F'),
-      )],
+      runes_balances: vec![
+        (
+          SpacedRune {
+            rune: Rune::from_str("TEEEEEEEEESTRUNE").unwrap(),
+            spacers: 0,
+          },
+          Decimal {
+            scale: 0,
+            value: 20000,
+          },
+          Some('R'),
+        ),
+        (
+          SpacedRune {
+            rune: Rune::from_str("ANOTHERTEESTRUNE").unwrap(),
+            spacers: 0,
+          },
+          Decimal {
+            scale: 0,
+            value: 10000,
+          },
+          Some('F'),
+        ),
+      ],
     }
   }
 

--- a/src/templates/address.rs
+++ b/src/templates/address.rs
@@ -5,6 +5,7 @@ pub(crate) struct AddressHtml {
   pub(crate) address: Address,
   pub(crate) outputs: Vec<OutPoint>,
   pub(crate) sat_balance: u64,
+  pub(crate) runes_balances: Vec<(SpacedRune, u128)>
 }
 
 impl PageContent for AddressHtml {
@@ -17,32 +18,48 @@ impl PageContent for AddressHtml {
 mod tests {
   use super::*;
 
-  #[test]
-  fn display() {
-    assert_regex_match!(
+  fn setup() -> AddressHtml {
       AddressHtml {
-        address: Address::from_str(
-          "bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8"
-        )
-        .unwrap()
-        .require_network(Network::Bitcoin)
-        .unwrap(),
-        outputs: vec![outpoint(1), outpoint(2)],
-        sat_balance: 99,
-      },
-      "<h1>Address bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8</h1>
-<dl>
-  <dt>sat balance</dt>
-  <dd>99</dd>
-  <dt>outputs</dt>
-  <dd>
-    <ul>
-      <li><a class=monospace href=/output/1{64}:1>1{64}:1</a></li>
-      <li><a class=monospace href=/output/2{64}:2>2{64}:2</a></li>
-    </ul>
-  </dd>
-</dl>.*"
-        .unindent()
-    );
+      address: Address::from_str(
+        "bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8"
+      )
+      .unwrap()
+      .require_network(Network::Bitcoin)
+      .unwrap(),
+      outputs: vec![outpoint(1), outpoint(2)],
+      sat_balance: 99,
+      runes_balances: vec![(SpacedRune {
+        rune: Rune::from_str("TEEEEEEEEESTRUNE").unwrap(),
+        spacers: 0
+      }, 20000)],
+    }
+  }
+
+#[test]
+  fn test_address_rendering() {
+      let address_html = setup();
+      let expected_pattern = r#".*<h1>Address bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8</h1>.*"#;
+      assert_regex_match!(address_html, expected_pattern);
+  }
+
+  #[test]
+  fn test_sat_balance_rendering() {
+      let address_html = setup();
+      let expected_pattern = r#".*<dt>sat balance</dt>\n\s*<dd>99</dd>.*"#;
+      assert_regex_match!(address_html, expected_pattern);
+  }
+
+  #[test]
+  fn test_runes_balances_rendering() {
+      let address_html = setup();
+      let expected_pattern = r#".*<dt>runes balances</dt>\n\s*<dd>TEEEEEEEEESTRUNE: 20000</dd>.*"#;
+      assert_regex_match!(address_html, expected_pattern);
+  }
+
+  #[test]
+  fn test_outputs_rendering() {
+      let address_html = setup();
+      let expected_pattern = r#".*<dt>outputs</dt>\n\s*<dd>\n\s*<ul>\n\s*<li><a class=monospace href=/output/1{64}:1>1{64}:1</a></li>\n\s*<li><a class=monospace href=/output/2{64}:2>2{64}:2</a></li>\n\s*</ul>\n\s*</dd>.*"#;
+      assert_regex_match!(address_html, expected_pattern);
   }
 }

--- a/src/templates/address.rs
+++ b/src/templates/address.rs
@@ -5,7 +5,7 @@ pub(crate) struct AddressHtml {
   pub(crate) address: Address,
   pub(crate) outputs: Vec<OutPoint>,
   pub(crate) sat_balance: u64,
-  pub(crate) runes_balances: Vec<(SpacedRune, u128)>
+  pub(crate) runes_balances: Vec<(SpacedRune, Decimal, Option<char>)>,
 }
 
 impl PageContent for AddressHtml {
@@ -19,47 +19,53 @@ mod tests {
   use super::*;
 
   fn setup() -> AddressHtml {
-      AddressHtml {
-      address: Address::from_str(
-        "bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8"
-      )
-      .unwrap()
-      .require_network(Network::Bitcoin)
-      .unwrap(),
+    AddressHtml {
+      address: Address::from_str("bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8")
+        .unwrap()
+        .require_network(Network::Bitcoin)
+        .unwrap(),
       outputs: vec![outpoint(1), outpoint(2)],
       sat_balance: 99,
-      runes_balances: vec![(SpacedRune {
-        rune: Rune::from_str("TEEEEEEEEESTRUNE").unwrap(),
-        spacers: 0
-      }, 20000)],
+      runes_balances: vec![(
+        SpacedRune {
+          rune: Rune::from_str("TEEEEEEEEESTRUNE").unwrap(),
+          spacers: 0,
+        },
+        Decimal {
+          scale: 0,
+          value: 20000,
+        },
+        Some('R'),
+      )],
     }
   }
 
-#[test]
+  #[test]
   fn test_address_rendering() {
-      let address_html = setup();
-      let expected_pattern = r#".*<h1>Address bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8</h1>.*"#;
-      assert_regex_match!(address_html, expected_pattern);
+    let address_html = setup();
+    let expected_pattern =
+      r#".*<h1>Address bc1phuq0vkls6w926zdaem6x9n02z2gg7j2xfudgwddyey7uyquarlgsh40ev8</h1>.*"#;
+    assert_regex_match!(address_html, expected_pattern);
   }
 
   #[test]
   fn test_sat_balance_rendering() {
-      let address_html = setup();
-      let expected_pattern = r#".*<dt>sat balance</dt>\n\s*<dd>99</dd>.*"#;
-      assert_regex_match!(address_html, expected_pattern);
+    let address_html = setup();
+    let expected_pattern = r#".*<dt>sat balance</dt>\n\s*<dd>99</dd>.*"#;
+    assert_regex_match!(address_html, expected_pattern);
   }
 
   #[test]
   fn test_runes_balances_rendering() {
-      let address_html = setup();
-      let expected_pattern = r#".*<dt>runes balances</dt>\n\s*<dd>TEEEEEEEEESTRUNE: 20000</dd>.*"#;
-      assert_regex_match!(address_html, expected_pattern);
+    let address_html = setup();
+    let expected_pattern = r#".*<dt>runes balances</dt>\n\s*<dd>TEEEEEEEEESTRUNE: 20000R</dd>.*"#;
+    assert_regex_match!(address_html, expected_pattern);
   }
 
   #[test]
   fn test_outputs_rendering() {
-      let address_html = setup();
-      let expected_pattern = r#".*<dt>outputs</dt>\n\s*<dd>\n\s*<ul>\n\s*<li><a class=monospace href=/output/1{64}:1>1{64}:1</a></li>\n\s*<li><a class=monospace href=/output/2{64}:2>2{64}:2</a></li>\n\s*</ul>\n\s*</dd>.*"#;
-      assert_regex_match!(address_html, expected_pattern);
+    let address_html = setup();
+    let expected_pattern = r#".*<dt>outputs</dt>\n\s*<dd>\n\s*<ul>\n\s*<li><a class=monospace href=/output/1{64}:1>1{64}:1</a></li>\n\s*<li><a class=monospace href=/output/2{64}:2>2{64}:2</a></li>\n\s*</ul>\n\s*</dd>.*"#;
+    assert_regex_match!(address_html, expected_pattern);
   }
 }

--- a/templates/address.html
+++ b/templates/address.html
@@ -5,7 +5,7 @@
   <dt>runes balances</dt>
 %% for (rune, decimal, symbol) in self.runes_balances.iter() {
 %% if let Some(symbol) = symbol {
-  <dd>{{ rune }}: {{ decimal }}{{ symbol }}</dd>
+  <dd><a class=monospace href=/rune/{{ rune }}>{{ rune }}</a>: {{ decimal }}{{ symbol }}</dd>
 %% } else {
   <dd>{{ rune }}: {{ decimal }}</dd>
 %% }

--- a/templates/address.html
+++ b/templates/address.html
@@ -3,15 +3,19 @@
   <dt>sat balance</dt>
   <dd>{{ self.sat_balance }}</dd>
   <dt>runes balances</dt>
-  %% for (rune, amount) in self.runes_balances.iter() {
-  <dd>{{ rune }}: {{ amount }}</dd>
-  %% }
+%% for (rune, decimal, symbol) in self.runes_balances.iter() {
+%% if let Some(symbol) = symbol {
+  <dd>{{ rune }}: {{ decimal }}{{ symbol }}</dd>
+%% } else {
+  <dd>{{ rune }}: {{ decimal }}</dd>
+%% }
+%% }
   <dt>outputs</dt>
   <dd>
     <ul>
-    %% for output in self.outputs.iter() {
-          <li><a class=monospace href=/output/{{ output }}>{{ output }}</a></li>
-    %% }
+%% for output in self.outputs.iter() {
+      <li><a class=monospace href=/output/{{ output }}>{{ output }}</a></li>
+%% }
     </ul>
   </dd>
 </dl>

--- a/templates/address.html
+++ b/templates/address.html
@@ -2,12 +2,16 @@
 <dl>
   <dt>sat balance</dt>
   <dd>{{ self.sat_balance }}</dd>
+  <dt>runes balances</dt>
+  %% for (rune, amount) in self.runes_balances.iter() {
+  <dd>{{ rune }}: {{ amount }}</dd>
+  %% }
   <dt>outputs</dt>
   <dd>
     <ul>
-%% for output in self.outputs.iter() {
-      <li><a class=monospace href=/output/{{ output }}>{{ output }}</a></li>
-%% }
+    %% for output in self.outputs.iter() {
+          <li><a class=monospace href=/output/{{ output }}>{{ output }}</a></li>
+    %% }
     </ul>
   </dd>
 </dl>

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -101,7 +101,7 @@ fn address_page_shows_multiple_runes() {
   create_wallet(&core, &ord);
 
   etch(&core, &ord, Rune(RUNE));
-  etch(&core, &ord, Rune(RUNE+1));
+  etch(&core, &ord, Rune(RUNE + 1));
 
   let address = "bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw";
 
@@ -118,7 +118,7 @@ fn address_page_shows_multiple_runes() {
 
   CommandBuilder::new(format!(
     "--chain regtest --index-runes wallet send --fee-rate 1 {address} 1000:{}",
-    Rune(RUNE+1)
+    Rune(RUNE + 1)
   ))
   .core(&core)
   .ord(&ord)
@@ -129,10 +129,12 @@ fn address_page_shows_multiple_runes() {
 
   ord.assert_response_regex(
     format!("/address/{address}"),
-    format!(".*<dd>.*{}.*: 1000¢</dd>.*<dd>.*{}.*: 1000¢</dd>.*", Rune(RUNE), Rune(RUNE+1)),
+    format!(
+      ".*<dd>.*{}.*: 1000¢</dd>.*<dd>.*{}.*: 1000¢</dd>.*",
+      Rune(RUNE),
+      Rune(RUNE + 1)
+    ),
   );
-
-
 }
 
 #[test]
@@ -173,7 +175,6 @@ fn address_page_shows_aggregated_runes_balance() {
     format!("/address/{address}"),
     format!(".*<dd>.*{}.*: 500¢</dd>.*", Rune(RUNE)),
   );
-
 }
 
 #[test]

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -64,7 +64,7 @@ fn address_page_shows_outputs_and_sat_balance() {
 }
 
 #[test]
-fn address_page_shows_runes_balances() {
+fn address_page_shows_single_rune() {
   let core = mockcore::builder().network(Network::Regtest).build();
   let ord =
     TestServer::spawn_with_args(&core, &["--index-runes", "--index-addresses", "--regtest"]);
@@ -88,8 +88,92 @@ fn address_page_shows_runes_balances() {
 
   ord.assert_response_regex(
     format!("/address/{address}"),
-    format!(".*<dd>{}: 1000¢</dd>.*", Rune(RUNE)),
+    format!(".*<dd>.*{}.*: 1000¢</dd>.*", Rune(RUNE)),
   );
+}
+
+#[test]
+fn address_page_shows_multiple_runes() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+  let ord =
+    TestServer::spawn_with_args(&core, &["--index-runes", "--index-addresses", "--regtest"]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+  etch(&core, &ord, Rune(RUNE+1));
+
+  let address = "bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw";
+
+  CommandBuilder::new(format!(
+    "--chain regtest --index-runes wallet send --fee-rate 1 {address} 1000:{}",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .stdout_regex(".*")
+  .run_and_deserialize_output::<Output>();
+
+  core.mine_blocks(6);
+
+  CommandBuilder::new(format!(
+    "--chain regtest --index-runes wallet send --fee-rate 1 {address} 1000:{}",
+    Rune(RUNE+1)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .stdout_regex(".*")
+  .run_and_deserialize_output::<Output>();
+
+  core.mine_blocks(6);
+
+  ord.assert_response_regex(
+    format!("/address/{address}"),
+    format!(".*<dd>.*{}.*: 1000¢</dd>.*<dd>.*{}.*: 1000¢</dd>.*", Rune(RUNE), Rune(RUNE+1)),
+  );
+
+
+}
+
+#[test]
+fn address_page_shows_aggregated_runes_balance() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+  let ord =
+    TestServer::spawn_with_args(&core, &["--index-runes", "--index-addresses", "--regtest"]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+
+  let address = "bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw";
+
+  CommandBuilder::new(format!(
+    "--chain regtest --index-runes wallet send --fee-rate 1 {address} 250:{}",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .stdout_regex(".*")
+  .run_and_deserialize_output::<Output>();
+
+  core.mine_blocks(6);
+
+  CommandBuilder::new(format!(
+    "--chain regtest --index-runes wallet send --fee-rate 1 {address} 250:{}",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .stdout_regex(".*")
+  .run_and_deserialize_output::<Output>();
+
+  core.mine_blocks(6);
+
+  ord.assert_response_regex(
+    format!("/address/{address}"),
+    format!(".*<dd>.*{}.*: 500¢</dd>.*", Rune(RUNE)),
+  );
+
 }
 
 #[test]

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -63,6 +63,35 @@ fn address_page_shows_outputs_and_sat_balance() {
   );
 }
 
+
+#[test]
+fn address_page_shows_runes_balances2(){
+  let core = mockcore::builder().network(Network::Regtest).build();
+  let ord = TestServer::spawn_with_args(&core,  &["--index-runes", "--regtest"]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE)).id;
+  CommandBuilder::new(format!(
+    "--chain regtest --index-runes wallet send --fee-rate 1 bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 1000:{}", Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .stdout_regex(".*")
+  .run_and_deserialize_output::<Output>();
+
+  core.mine_blocks(1);
+  core.mine_blocks(6);
+
+  ord.assert_response_regex(
+    format!("/address/bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw"),
+    format!(
+      ".*<dd>{}: 1000</dd>.*",
+      Rune(RUNE)
+    ),
+  );
+}
+
 #[test]
 fn inscription_page() {
   let core = mockcore::spawn();

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -63,32 +63,32 @@ fn address_page_shows_outputs_and_sat_balance() {
   );
 }
 
-
 #[test]
-fn address_page_shows_runes_balances2(){
+fn address_page_shows_runes_balances() {
   let core = mockcore::builder().network(Network::Regtest).build();
-  let ord = TestServer::spawn_with_args(&core,  &["--index-runes", "--regtest"]);
+  let ord =
+    TestServer::spawn_with_args(&core, &["--index-runes", "--index-addresses", "--regtest"]);
 
   create_wallet(&core, &ord);
 
-  etch(&core, &ord, Rune(RUNE)).id;
+  etch(&core, &ord, Rune(RUNE));
+
+  let address = "bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw";
+
   CommandBuilder::new(format!(
-    "--chain regtest --index-runes wallet send --fee-rate 1 bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 1000:{}", Rune(RUNE)
+    "--chain regtest --index-runes wallet send --fee-rate 1 {address} 1000:{}",
+    Rune(RUNE)
   ))
   .core(&core)
   .ord(&ord)
   .stdout_regex(".*")
   .run_and_deserialize_output::<Output>();
 
-  core.mine_blocks(1);
   core.mine_blocks(6);
 
   ord.assert_response_regex(
-    format!("/address/bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw"),
-    format!(
-      ".*<dd>{}: 1000</dd>.*",
-      Rune(RUNE)
-    ),
+    format!("/address/{address}"),
+    format!(".*<dd>{}: 1000¢</dd>.*", Rune(RUNE)),
   );
 }
 


### PR DESCRIPTION
Hi! First ever public pull request 🙏  Please feedback is welcome

Referencing issue #3809 to add more information to address page. I also refactored the tests on templates/address.rs so that different categories of address information are tested separately. 

Unfortunately, I'm not able to get the integration at tests/server.rs to work; it seems to be that rune commands are not compatible with the mockcore::spawn() handle, hence it is necessary to enforce the transaction on regtest; however I get a 404 error when requesting pages with a regtest address format; so the test currently always fails. 