### PR TITLE
Add typed errors with `snafu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,6 +2305,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "sha3",
+ "snafu",
  "sysinfo",
  "tempfile",
  "tokio",
@@ -3205,6 +3206,27 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snafu"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418b8136fec49956eba89be7da2847ec1909df92a9ae4178b5ff0ff092c8d95e"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a4812a669da00d17d8266a0439eddcacbc88b17f732f927e52eeb9d196f7fb5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ serde_json = { version = "1.0.81", features = ["preserve_order"] }
 serde_with = "3.7.0"
 serde_yaml = "0.9.17"
 sha3 = "0.10.8"
+snafu = "0.8.3"
 sysinfo = "0.30.3"
 tempfile = "3.2.0"
 tokio = { version = "1.17.0", features = ["rt-multi-thread"] }

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -20,29 +20,30 @@ pub(crate) struct Arguments {
 }
 
 impl Arguments {
-  pub(crate) fn run(self) -> SubcommandResult {
+  pub(crate) fn run(self) -> Result<Option<Box<dyn subcommand::Output>>, OrdError> {
     let mut env: BTreeMap<String, String> = BTreeMap::new();
 
-    for (var, value) in env::vars_os() {
-      let Some(var) = var.to_str() else {
+    for (variable, value) in env::vars_os() {
+      let Some(variable) = variable.to_str() else {
         continue;
       };
 
-      let Some(key) = var.strip_prefix("ORD_") else {
+      let Some(key) = variable.strip_prefix("ORD_") else {
         continue;
       };
 
       env.insert(
         key.into(),
-        value.into_string().map_err(|value| {
-          anyhow!(
-            "environment variable `{var}` not valid unicode: `{}`",
-            value.to_string_lossy()
-          )
-        })?,
+        value
+          .into_string()
+          .map_err(|value| OrdError::EnvVarUnicode {
+            backtrace: Backtrace::capture(),
+            value,
+            variable: variable.into(),
+          })?,
       );
     }
 
-    self.subcommand.run(Settings::load(self.options)?)
+    Ok(self.subcommand.run(Settings::load(self.options)?)?)
   }
 }

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -20,7 +20,7 @@ pub(crate) struct Arguments {
 }
 
 impl Arguments {
-  pub(crate) fn run(self) -> Result<Option<Box<dyn subcommand::Output>>, OrdError> {
+  pub(crate) fn run(self) -> SnafuResult<Option<Box<dyn subcommand::Output>>> {
     let mut env: BTreeMap<String, String> = BTreeMap::new();
 
     for (variable, value) in env::vars_os() {
@@ -36,7 +36,7 @@ impl Arguments {
         key.into(),
         value
           .into_string()
-          .map_err(|value| OrdError::EnvVarUnicode {
+          .map_err(|value| SnafuError::EnvVarUnicode {
             backtrace: Backtrace::capture(),
             value,
             variable: variable.into(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)), visibility(pub(crate)))]
-pub(crate) enum OrdError {
+pub(crate) enum SnafuError {
   #[snafu(display("{err}"))]
   Anyhow { err: anyhow::Error },
   #[snafu(display("environment variable `{variable}` not valid unicode: `{}`", value.to_string_lossy()))]
@@ -19,8 +19,8 @@ pub(crate) enum OrdError {
   },
 }
 
-impl From<Error> for OrdError {
-  fn from(err: Error) -> OrdError {
+impl From<Error> for SnafuError {
+  fn from(err: Error) -> SnafuError {
     Self::Anyhow { err }
   }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,66 @@
+use super::*;
+
+#[derive(Debug, Snafu)]
+#[snafu(context(suffix(false)), visibility(pub(crate)))]
+pub(crate) enum OrdError {
+  #[snafu(display("{err}"))]
+  Anyhow { err: anyhow::Error },
+  #[snafu(display("environment variable `{variable}` not valid unicode: `{}`", value.to_string_lossy()))]
+  EnvVarUnicode {
+    backtrace: Backtrace,
+    value: OsString,
+    variable: String,
+  },
+  #[snafu(display("I/O error at `{}`", path.display()))]
+  Io {
+    backtrace: Backtrace,
+    path: PathBuf,
+    source: io::Error,
+  },
+}
+
+impl From<Error> for OrdError {
+  fn from(err: Error) -> OrdError {
+    Self::Anyhow { err }
+  }
+}
+
+/// We currently use `anyhow` for error handling but are migrating to typed
+/// errors using `snafu`. This trait exists to provide access to
+/// `snafu::ResultExt::{context, with_context}`, which are otherwise shadowed
+/// by `anhow::Context::{context, with_context}`. Once the migration is
+/// complete, this trait can be deleted, and `snafu::ResultExt` used directly.
+pub(crate) trait ResultExt<T, E>: Sized {
+  fn snafu_context<C, E2>(self, context: C) -> Result<T, E2>
+  where
+    C: snafu::IntoError<E2, Source = E>,
+    E2: std::error::Error + snafu::ErrorCompat;
+
+  #[allow(unused)]
+  fn with_snafu_context<F, C, E2>(self, context: F) -> Result<T, E2>
+  where
+    F: FnOnce(&mut E) -> C,
+    C: snafu::IntoError<E2, Source = E>,
+    E2: std::error::Error + snafu::ErrorCompat;
+}
+
+impl<T, E> ResultExt<T, E> for std::result::Result<T, E> {
+  fn snafu_context<C, E2>(self, context: C) -> Result<T, E2>
+  where
+    C: snafu::IntoError<E2, Source = E>,
+    E2: std::error::Error + snafu::ErrorCompat,
+  {
+    use snafu::ResultExt;
+    self.context(context)
+  }
+
+  fn with_snafu_context<F, C, E2>(self, context: F) -> Result<T, E2>
+  where
+    F: FnOnce(&mut E) -> C,
+    C: snafu::IntoError<E2, Source = E>,
+    E2: std::error::Error + snafu::ErrorCompat,
+  {
+    use snafu::ResultExt;
+    self.with_context(context)
+  }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -215,12 +215,9 @@ impl Index {
 
     let path = settings.index().to_owned();
 
-    if let Err(err) = fs::create_dir_all(path.parent().unwrap()) {
-      bail!(
-        "failed to create data dir `{}`: {err}",
-        path.parent().unwrap().display()
-      );
-    }
+    let data_dir = path.parent().unwrap();
+
+    fs::create_dir_all(data_dir).snafu_context(error::Io { path: data_dir })?;
 
     let index_cache_size = settings.index_cache_size();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ pub fn main() {
             eprintln!("because:");
           }
 
-          eprintln!("    - {err}");
+          eprintln!("- {err}");
         }
 
         if let Some(backtrace) = err.backtrace() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ use {
   chrono::{DateTime, TimeZone, Utc},
   ciborium::Value,
   clap::{ArgGroup, Parser},
-  error::{OrdError, ResultExt},
+  error::{ResultExt, SnafuError},
   html_escaper::{Escape, Trusted},
   http::HeaderMap,
   lazy_static::lazy_static,
@@ -127,6 +127,7 @@ pub mod templates;
 pub mod wallet;
 
 type Result<T = (), E = Error> = std::result::Result<T, E>;
+type SnafuResult<T = (), E = SnafuError> = std::result::Result<T, E>;
 
 const TARGET_POSTAGE: Amount = Amount::from_sat(10_000);
 
@@ -266,7 +267,7 @@ pub fn main() {
     Err(err) => {
       eprintln!("error: {err}");
 
-      if let OrdError::Anyhow { err } = err {
+      if let SnafuError::Anyhow { err } = err {
         for (i, err) in err.chain().skip(1).enumerate() {
           if i == 0 {
             eprintln!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ pub fn main() {
             eprintln!("because:");
           }
 
-          eprintln!("    - {err}");
+          eprintln!("- {err}");
         }
 
         if env::var_os("RUST_BACKTRACE")

--- a/tests/settings.rs
+++ b/tests/settings.rs
@@ -65,7 +65,7 @@ fn config_invalid_error_message() {
   fs::write(&config, "foo").unwrap();
 
   CommandBuilder::new(format!("--config {} settings", config.to_str().unwrap()))
-    .stderr_regex("error: failed to deserialize config file `.*ord.yaml`\nbecause:.*")
+    .stderr_regex("error: failed to deserialize config file `.*ord.yaml`\n\nbecause:.*")
     .expected_exit_code(1)
     .run_and_extract_stdout();
 }
@@ -77,7 +77,7 @@ fn config_not_found_error_message() {
   let config = tempdir.path().join("ord.yaml");
 
   CommandBuilder::new(format!("--config {} settings", config.to_str().unwrap()))
-    .stderr_regex("error: failed to open config file `.*ord.yaml`\nbecause:.*")
+    .stderr_regex("error: failed to open config file `.*ord.yaml`\n\nbecause:.*")
     .expected_exit_code(1)
     .run_and_extract_stdout();
 }

--- a/tests/wallet/sats.rs
+++ b/tests/wallet/sats.rs
@@ -91,6 +91,6 @@ fn sats_from_tsv_file_not_found() {
     .core(&core)
     .ord(&ord)
     .expected_exit_code(1)
-    .stderr_regex("error: I/O error reading `.*`\nbecause: .*\n")
+    .stderr_regex("error: I/O error reading `.*`\n\nbecause:.*")
     .run_and_extract_stdout();
 }


### PR DESCRIPTION
This migrates a couple error sites over to `snafu`, a library for typed errors. `snafu` has a nice system of context selectors, which makes it easy to attach context to an underlying error.

This only migrates two error sites, and leaves migration of other error sites to future PRs.

@raphjaph @cryptoni9n 