### PR TITLE
fix rune links for runes with default currency symbol on /address page

### DIFF
--- a/templates/address.html
+++ b/templates/address.html
@@ -15,7 +15,7 @@
 %% if let Some(symbol) = symbol {
   <dd><a class=monospace href=/rune/{{ rune }}>{{ rune }}</a>: {{ decimal }}{{ symbol }}</dd>
 %% } else {
-  <dd>{{ rune }}: {{ decimal }}</dd>
+  <dd><a class=monospace href=/rune/{{ rune }}>{{ rune }}</a>: {{ decimal }}¤</dd>
 %% }
 %% }
   <dt>outputs</dt>


### PR DESCRIPTION
partially addresses #3846 by fixing the linking/display for runes that have the default currency symbol.  runes with default currency symbol will now be linked and show the symbol on the /address page.