### PR TITLE
suppress-sat_ranges-by-default

### DIFF
--- a/src/subcommand/wallet/outputs.rs
+++ b/src/subcommand/wallet/outputs.rs
@@ -10,7 +10,8 @@ pub(crate) struct Outputs {
 pub struct Output {
   pub output: OutPoint,
   pub amount: u64,
-  pub sat_ranges: Vec<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub sat_ranges: Option<Vec<String>>,
 }
 
 impl Outputs {
@@ -18,13 +19,15 @@ impl Outputs {
     let mut outputs = Vec::new();
     for (output, txout) in wallet.utxos() {
       let sat_ranges = if wallet.has_sat_index() && self.ranges {
-        wallet
-          .get_output_sat_ranges(output)?
-          .into_iter()
-          .map(|(start, end)| format!("{start}-{end}"))
-          .collect()
+        Some(
+          wallet
+            .get_output_sat_ranges(output)?
+            .into_iter()
+            .map(|(start, end)| format!("{start}-{end}"))
+            .collect(),
+        )
       } else {
-        Vec::new()
+        None
       };
 
       outputs.push(Output {

--- a/tests/wallet/outputs.rs
+++ b/tests/wallet/outputs.rs
@@ -19,6 +19,7 @@ fn outputs() {
 
   assert_eq!(output[0].output, outpoint);
   assert_eq!(output[0].amount, amount);
+  assert!(output[0].sat_ranges.is_none());
 }
 
 #[test]
@@ -42,6 +43,7 @@ fn outputs_includes_locked_outputs() {
 
   assert_eq!(output[0].output, outpoint);
   assert_eq!(output[0].amount, amount);
+  assert!(output[0].sat_ranges.is_none());
 }
 
 #[test]
@@ -65,6 +67,7 @@ fn outputs_includes_unbound_outputs() {
 
   assert_eq!(output[0].output, outpoint);
   assert_eq!(output[0].amount, amount);
+  assert!(output[0].sat_ranges.is_none());
 }
 
 #[test]
@@ -86,5 +89,8 @@ fn outputs_includes_sat_ranges() {
 
   assert_eq!(output[0].output, outpoint);
   assert_eq!(output[0].amount, amount);
-  assert_eq!(output[0].sat_ranges, vec!["5000000000-5001000000"]);
+  assert_eq!(
+    output[0].sat_ranges,
+    Some(vec!["5000000000-5001000000".to_string()])
+  );
 }


### PR DESCRIPTION
#3817 introduced #3865 where `ord wallet outputs` would display the sat_ranges: field with an empty set for each output if it was run without the `--ranges` flag.  This fixes it so that the sat_ranges: field only appears when the command is run with the `--ranges` flag.