### PR TITLE
List all Bitcoin Core wallets

### DIFF
--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -16,6 +16,7 @@ pub mod supply;
 pub mod teleburn;
 pub mod traits;
 pub mod wallet;
+pub mod wallets;
 
 #[derive(Debug, Parser)]
 pub(crate) enum Subcommand {
@@ -51,6 +52,8 @@ pub(crate) enum Subcommand {
   Traits(traits::Traits),
   #[command(about = "Wallet commands")]
   Wallet(wallet::WalletCommand),
+  #[command(about = "List all Bitcoin Core wallets")]
+  Wallets,
 }
 
 impl Subcommand {
@@ -77,6 +80,7 @@ impl Subcommand {
       Self::Teleburn(teleburn) => teleburn.run(),
       Self::Traits(traits) => traits.run(),
       Self::Wallet(wallet) => wallet.run(settings),
+      Self::Wallets => wallets::run(settings),
     }
   }
 }

--- a/src/subcommand/wallets.rs
+++ b/src/subcommand/wallets.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+pub(crate) fn run(settings: Settings) -> SubcommandResult {
+  Ok(Some(Box::new(
+    settings.bitcoin_rpc_client(None)?.list_wallet_dir()?,
+  )))
+}


### PR DESCRIPTION
This basically just wraps `bitcoin-cli listwalletdir`. In order to filter by if it is an ordinals wallet we would have to load all wallets and then check the descriptor. This can take a while so I haven't implemented it here. I think we could add `--ordinals-only` that does this this.