### PR TITLE
Start indexing at the appropriate block

### DIFF
--- a/ord.yaml
+++ b/ord.yaml
@@ -12,7 +12,6 @@ config: /var/lib/ord/ord.yaml
 config_dir: /var/lib/ord
 cookie_file: /var/lib/bitcoin/.cookie
 data_dir: /var/lib/ord
-first_inscription_height: 100
 height_limit: 1000
 hidden:
 - 6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -71,7 +71,7 @@ impl<'index> Updater<'index> {
       Some(progress_bar)
     };
 
-    let rx = Self::fetch_blocks_from(self.index, self.height, self.index.index_sats)?;
+    let rx = Self::fetch_blocks_from(self.index, self.height)?;
 
     let (mut output_sender, mut txout_receiver) = Self::spawn_fetcher(self.index)?;
 
@@ -153,15 +153,14 @@ impl<'index> Updater<'index> {
   fn fetch_blocks_from(
     index: &Index,
     mut height: u32,
-    index_sats: bool,
   ) -> Result<std::sync::mpsc::Receiver<BlockData>> {
     let (tx, rx) = std::sync::mpsc::sync_channel(32);
+
+    let first_index_height = index.first_index_height;
 
     let height_limit = index.height_limit;
 
     let client = index.settings.bitcoin_rpc_client(None)?;
-
-    let first_inscription_height = index.settings.first_inscription_height();
 
     thread::spawn(move || loop {
       if let Some(height_limit) = height_limit {
@@ -170,7 +169,7 @@ impl<'index> Updater<'index> {
         }
       }
 
-      match Self::get_block_with_retries(&client, height, index_sats, first_inscription_height) {
+      match Self::get_block_with_retries(&client, height, first_index_height) {
         Ok(Some(block)) => {
           if let Err(err) = tx.send(block.into()) {
             log::info!("Block receiver disconnected: {err}");
@@ -192,8 +191,7 @@ impl<'index> Updater<'index> {
   fn get_block_with_retries(
     client: &Client,
     height: u32,
-    index_sats: bool,
-    first_inscription_height: u32,
+    first_index_height: u32,
   ) -> Result<Option<Block>> {
     let mut errors = 0;
     loop {
@@ -203,7 +201,7 @@ impl<'index> Updater<'index> {
         .and_then(|option| {
           option
             .map(|hash| {
-              if index_sats || height >= first_inscription_height {
+              if height >= first_index_height {
                 Ok(client.get_block(&hash)?)
               } else {
                 Ok(Block {
@@ -437,7 +435,7 @@ impl<'index> Updater<'index> {
       );
     }
 
-    if !self.index.index_sats {
+    if !self.index.have_full_utxo_index() {
       // Send all missing input outpoints to be fetched
       let txids = block
         .txdata
@@ -562,7 +560,7 @@ impl<'index> Updater<'index> {
 
               entry.value().to_buf()
             } else {
-              assert!(!self.index.index_sats);
+              assert!(!self.index.have_full_utxo_index());
               let txout = txout_receiver.blocking_recv().map_err(|err| {
                 anyhow!(
                   "failed to get transaction for {}: {err}",

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -161,7 +161,7 @@ impl<'index> Updater<'index> {
 
     let client = index.settings.bitcoin_rpc_client(None)?;
 
-    let first_inscription_height = index.first_inscription_height;
+    let first_inscription_height = index.settings.first_inscription_height();
 
     thread::spawn(move || loop {
       if let Some(height_limit) = height_limit {
@@ -425,8 +425,8 @@ impl<'index> Updater<'index> {
       wtx.open_table(SEQUENCE_NUMBER_TO_INSCRIPTION_ENTRY)?;
     let mut transaction_id_to_transaction = wtx.open_table(TRANSACTION_ID_TO_TRANSACTION)?;
 
-    let index_inscriptions =
-      self.height >= self.index.first_inscription_height && self.index.index_inscriptions;
+    let index_inscriptions = self.height >= self.index.settings.first_inscription_height()
+      && self.index.index_inscriptions;
 
     // If the receiver still has inputs something went wrong in the last
     // block and we shouldn't recover from this and commit the last block

--- a/src/options.rs
+++ b/src/options.rs
@@ -38,11 +38,6 @@ pub struct Options {
   pub(crate) cookie_file: Option<PathBuf>,
   #[arg(long, alias = "datadir", help = "Store index in <DATA_DIR>.")]
   pub(crate) data_dir: Option<PathBuf>,
-  #[arg(
-    long,
-    help = "Don't look for inscriptions below <FIRST_INSCRIPTION_HEIGHT>."
-  )]
-  pub(crate) first_inscription_height: Option<u32>,
   #[arg(long, help = "Limit index to <HEIGHT_LIMIT> blocks.")]
   pub(crate) height_limit: Option<u32>,
   #[arg(long, help = "Use index at <INDEX>.")]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,7 +14,6 @@ pub struct Settings {
   config_dir: Option<PathBuf>,
   cookie_file: Option<PathBuf>,
   data_dir: Option<PathBuf>,
-  first_inscription_height: Option<u32>,
   height_limit: Option<u32>,
   hidden: Option<HashSet<InscriptionId>>,
   http_port: Option<u16>,
@@ -120,9 +119,6 @@ impl Settings {
       config_dir: self.config_dir.or(source.config_dir),
       cookie_file: self.cookie_file.or(source.cookie_file),
       data_dir: self.data_dir.or(source.data_dir),
-      first_inscription_height: self
-        .first_inscription_height
-        .or(source.first_inscription_height),
       height_limit: self.height_limit.or(source.height_limit),
       hidden: Some(
         self
@@ -166,7 +162,6 @@ impl Settings {
       config_dir: options.config_dir,
       cookie_file: options.cookie_file,
       data_dir: options.data_dir,
-      first_inscription_height: options.first_inscription_height,
       height_limit: options.height_limit,
       hidden: None,
       http_port: None,
@@ -255,7 +250,6 @@ impl Settings {
       config_dir: get_path("CONFIG_DIR"),
       cookie_file: get_path("COOKIE_FILE"),
       data_dir: get_path("DATA_DIR"),
-      first_inscription_height: get_u32("FIRST_INSCRIPTION_HEIGHT")?,
       height_limit: get_u32("HEIGHT_LIMIT")?,
       hidden: inscriptions("HIDDEN")?,
       http_port: get_u16("HTTP_PORT")?,
@@ -286,7 +280,6 @@ impl Settings {
       config_dir: None,
       cookie_file: None,
       data_dir: Some(dir.into()),
-      first_inscription_height: None,
       height_limit: None,
       hidden: None,
       http_port: None,
@@ -354,13 +347,6 @@ impl Settings {
       config_dir: None,
       cookie_file: Some(cookie_file),
       data_dir: Some(data_dir),
-      first_inscription_height: Some(if self.integration_test {
-        0
-      } else {
-        self
-          .first_inscription_height
-          .unwrap_or_else(|| chain.first_inscription_height())
-      }),
       height_limit: self.height_limit,
       hidden: self.hidden,
       http_port: self.http_port,
@@ -516,7 +502,11 @@ impl Settings {
   }
 
   pub fn first_inscription_height(&self) -> u32 {
-    self.first_inscription_height.unwrap()
+    if self.integration_test {
+      0
+    } else {
+      self.chain.unwrap().first_inscription_height()
+    }
   }
 
   pub fn first_rune_height(&self) -> u32 {
@@ -1021,7 +1011,6 @@ mod tests {
       ("CONFIG_DIR", "config dir"),
       ("COOKIE_FILE", "cookie file"),
       ("DATA_DIR", "/data/dir"),
-      ("FIRST_INSCRIPTION_HEIGHT", "2"),
       ("HEIGHT_LIMIT", "3"),
       ("HIDDEN", "6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0 703e5f7c49d82aab99e605af306b9a30e991e57d42f982908a962a81ac439832i0"),
     ("HTTP_PORT", "8080"),
@@ -1055,7 +1044,6 @@ mod tests {
         config_dir: Some("config dir".into()),
         cookie_file: Some("cookie file".into()),
         data_dir: Some("/data/dir".into()),
-        first_inscription_height: Some(2),
         height_limit: Some(3),
         hidden: Some(
           vec![
@@ -1102,7 +1090,6 @@ mod tests {
           "--config-dir=config dir",
           "--cookie-file=cookie file",
           "--datadir=/data/dir",
-          "--first-inscription-height=2",
           "--height-limit=3",
           "--index-addresses",
           "--index-cache-size=4",
@@ -1129,7 +1116,6 @@ mod tests {
         config_dir: Some("config dir".into()),
         cookie_file: Some("cookie file".into()),
         data_dir: Some("/data/dir".into()),
-        first_inscription_height: Some(2),
         height_limit: Some(3),
         hidden: None,
         http_port: None,

--- a/tests/json_api.rs
+++ b/tests/json_api.rs
@@ -235,11 +235,7 @@ fn get_inscriptions() {
 fn get_inscriptions_in_block() {
   let core = mockcore::spawn();
 
-  let ord = TestServer::spawn_with_server_args(
-    &core,
-    &["--index-sats", "--first-inscription-height", "0"],
-    &[],
-  );
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-sats"], &[]);
 
   create_wallet(&core, &ord);
 

--- a/tests/settings.rs
+++ b/tests/settings.rs
@@ -17,7 +17,6 @@ fn default() {
   "config_dir": null,
   "cookie_file": ".*\.cookie",
   "data_dir": ".*",
-  "first_inscription_height": 767430,
   "height_limit": null,
   "hidden": \[\],
   "http_port": null,


### PR DESCRIPTION
When using --index-sats or --index-addresses, we need to index all blocks, but --index-inscriptions only needs blocks starting from 767430, and --index-runes can start at 840000.  The existing code for this is tricky and also wrong -- it incorrectly skips early blocks when using --index-addresses but not --index-sats, and it unnecessarily processes blocks from 767430 to 840000 when using --index-runes but not --index-inscriptions.

Replace the old code with a single, correct calculation of which block to start at.  This speeds up building a runes-only index by about 4x.