### PR TITLE
Remove dependency on `ord-bitcoincore-rpc` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoincore-rpc"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6c0ee9354e3dac217db4cb1dd31941073a87fe53c86bcf3eb2b8bc97f00a08"
+dependencies = [
+ "bitcoin-private",
+ "bitcoincore-rpc-json",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bitcoincore-rpc-json"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d30ce6f40fb0a2e8d98522796219282504b7a4b14e2b4c26139a7bea6aec6586"
+dependencies = [
+ "bitcoin",
+ "bitcoin-private",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,6 +2219,7 @@ dependencies = [
  "base64 0.22.1",
  "bip39",
  "bitcoin",
+ "bitcoincore-rpc",
  "boilerplate",
  "brotli",
  "chrono",
@@ -2219,7 +2246,6 @@ dependencies = [
  "mockcore",
  "mp4",
  "nix",
- "ord-bitcoincore-rpc",
  "ordinals",
  "pretty_assertions",
  "redb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ mime = "0.3.16"
 mime_guess = "2.0.4"
 miniscript = "10.0.0"
 mp4 = "0.14.0"
-ord-bitcoincore-rpc = "0.17.2"
+bitcoincore-rpc = "0.17.0"
 ordinals = { version = "0.0.10", path = "crates/ordinals" }
 redb = "2.1.1"
 ref-cast = "1.0.23"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,22 @@ static SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
 static LISTENERS: Mutex<Vec<axum_server::Handle>> = Mutex::new(Vec::new());
 static INDEXER: Mutex<Option<thread::JoinHandle<()>>> = Mutex::new(None);
 
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct Descriptor {
+  pub desc: String,
+  pub timestamp: bitcoincore_rpc::bitcoincore_rpc_json::Timestamp,
+  pub active: bool,
+  pub internal: Option<bool>,
+  pub range: Option<(u64, u64)>,
+  pub next: Option<u64>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct ListDescriptorsResult {
+  pub wallet_name: String,
+  pub descriptors: Vec<Descriptor>,
+}
+
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn fund_raw_transaction(
   client: &Client,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,22 +135,6 @@ static SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
 static LISTENERS: Mutex<Vec<axum_server::Handle>> = Mutex::new(Vec::new());
 static INDEXER: Mutex<Option<thread::JoinHandle<()>>> = Mutex::new(None);
 
-#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-pub struct Descriptor {
-  pub desc: String,
-  pub timestamp: bitcoincore_rpc::bitcoincore_rpc_json::Timestamp,
-  pub active: bool,
-  pub internal: Option<bool>,
-  pub range: Option<(u64, u64)>,
-  pub next: Option<u64>,
-}
-
-#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-pub struct ListDescriptorsResult {
-  pub wallet_name: String,
-  pub descriptors: Vec<Descriptor>,
-}
-
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn fund_raw_transaction(
   client: &Client,

--- a/src/subcommand/wallet.rs
+++ b/src/subcommand/wallet.rs
@@ -1,6 +1,6 @@
 use {
   super::*,
-  crate::wallet::{batch, wallet_constructor::WalletConstructor, Wallet},
+  crate::wallet::{batch, wallet_constructor::WalletConstructor, ListDescriptorsResult, Wallet},
   shared_args::SharedArgs,
 };
 

--- a/src/subcommand/wallet.rs
+++ b/src/subcommand/wallet.rs
@@ -1,7 +1,6 @@
 use {
   super::*,
   crate::wallet::{batch, wallet_constructor::WalletConstructor, Wallet},
-  bitcoincore_rpc::bitcoincore_rpc_json::ListDescriptorsResult,
   shared_args::SharedArgs,
 };
 

--- a/src/subcommand/wallet/dump.rs
+++ b/src/subcommand/wallet/dump.rs
@@ -9,6 +9,8 @@ pub(crate) fn run(wallet: Wallet) -> SubcommandResult {
   );
 
   Ok(Some(Box::new(
-    wallet.bitcoin_client().list_descriptors(Some(true))?,
+    wallet
+      .bitcoin_client()
+      .call::<ListDescriptorsResult>("listdescriptors", &[serde_json::to_value(true)?])?,
   )))
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -47,6 +47,22 @@ impl From<Statistic> for u64 {
   }
 }
 
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct Descriptor {
+  pub desc: String,
+  pub timestamp: bitcoincore_rpc::bitcoincore_rpc_json::Timestamp,
+  pub active: bool,
+  pub internal: Option<bool>,
+  pub range: Option<(u64, u64)>,
+  pub next: Option<u64>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct ListDescriptorsResult {
+  pub wallet_name: String,
+  pub descriptors: Vec<Descriptor>,
+}
+
 #[derive(Debug, PartialEq)]
 pub(crate) enum Maturity {
   BelowMinimumHeight(u64),

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -7,7 +7,7 @@ use {
     bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, Fingerprint},
     psbt::Psbt,
   },
-  bitcoincore_rpc::bitcoincore_rpc_json::{Descriptor, ImportDescriptors, Timestamp},
+  bitcoincore_rpc::bitcoincore_rpc_json::{ImportDescriptors, Timestamp},
   entry::{EtchingEntry, EtchingEntryValue},
   fee_rate::FeeRate,
   index::entry::Entry,
@@ -465,7 +465,7 @@ impl Wallet {
       })
       .collect::<Vec<ImportDescriptors>>();
 
-    client.import_descriptors(descriptors)?;
+    client.call::<serde_json::Value>("importdescriptors", &[serde_json::to_value(descriptors)?])?;
 
     Ok(())
   }
@@ -536,7 +536,7 @@ impl Wallet {
 
     settings
       .bitcoin_rpc_client(Some(name.clone()))?
-      .import_descriptors(vec![ImportDescriptors {
+      .import_descriptors(ImportDescriptors {
         descriptor: descriptor.to_string_with_secret(&key_map),
         timestamp: Timestamp::Now,
         active: Some(true),
@@ -544,7 +544,7 @@ impl Wallet {
         next_index: None,
         internal: Some(change),
         label: None,
-      }])?;
+      })?;
 
     Ok(())
   }

--- a/src/wallet/batch/plan.rs
+++ b/src/wallet/batch/plan.rs
@@ -687,7 +687,7 @@ impl Plan {
 
     let response = wallet
       .bitcoin_client()
-      .import_descriptors(vec![ImportDescriptors {
+      .import_descriptors(ImportDescriptors {
         descriptor: format!("rawtr({})#{}", recovery_private_key.to_wif(), info.checksum),
         timestamp: Timestamp::Now,
         active: Some(false),
@@ -695,7 +695,7 @@ impl Plan {
         next_index: None,
         internal: Some(false),
         label: Some("commit tx recovery key".to_string()),
-      }])?;
+      })?;
 
     for result in response {
       if !result.success {

--- a/src/wallet/wallet_constructor.rs
+++ b/src/wallet/wallet_constructor.rs
@@ -56,7 +56,12 @@ impl WalletConstructor {
       }
 
       if client.get_wallet_info()?.private_keys_enabled {
-        Wallet::check_descriptors(&self.name, client.list_descriptors(None)?.descriptors)?;
+        Wallet::check_descriptors(
+          &self.name,
+          client
+            .call::<ListDescriptorsResult>("listdescriptors", &[serde_json::Value::Null])?
+            .descriptors,
+        )?;
       }
 
       client

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,13 +7,12 @@ use {
     blockdata::constants::COIN_VALUE,
     Network, OutPoint, Sequence, Txid, Witness,
   },
-  bitcoincore_rpc::bitcoincore_rpc_json::ListDescriptorsResult,
   chrono::{DateTime, Utc},
   executable_path::executable_path,
   mockcore::TransactionTemplate,
   ord::{
     api, chain::Chain, decimal::Decimal, outgoing::Outgoing, subcommand::runes::RuneInfo,
-    wallet::batch, InscriptionId, RuneEntry,
+    wallet::batch, InscriptionId, ListDescriptorsResult, RuneEntry,
   },
   ordinals::{
     Artifact, Charm, Edict, Pile, Rarity, Rune, RuneId, Runestone, Sat, SatPoint, SpacedRune,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,7 +12,7 @@ use {
   mockcore::TransactionTemplate,
   ord::{
     api, chain::Chain, decimal::Decimal, outgoing::Outgoing, subcommand::runes::RuneInfo,
-    wallet::batch, InscriptionId, ListDescriptorsResult, RuneEntry,
+    wallet::batch, wallet::ListDescriptorsResult, InscriptionId, RuneEntry,
   },
   ordinals::{
     Artifact, Charm, Edict, Pile, Rarity, Rune, RuneId, Runestone, Sat, SatPoint, SpacedRune,


### PR DESCRIPTION
We need to upgrade `rust-bitcoin`. In order to do that we need to get rid of the dependency on our fork of `bitcoincore_rpc`. This works because most of the reason we forked it was for the now separate `mockcore` crate.