### PR TITLE
Use `as_slice` instead of convert to vec

### DIFF
--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -81,8 +81,7 @@ impl Inscribe {
       mode: batch::Mode::SeparateOutputs,
       no_backup: self.shared.no_backup,
       no_limit: self.shared.no_limit,
-      parent_info: wallet
-        .get_parent_info(&self.parent.map(|parent| vec![parent]).unwrap_or_default())?,
+      parent_info: wallet.get_parent_info(self.parent.as_slice())?,
       postages: vec![self.postage.unwrap_or(TARGET_POSTAGE)],
       reinscribe: self.reinscribe,
       reveal_fee_rate: self.shared.fee_rate,


### PR DESCRIPTION
@raphjaph `Option<T>` actually has an `as_slice` method which returns a zero or one length slice depending on whether the `Option` is `Some`.