### PR TITLE
Charms info recursive `/r/charms`

### DIFF
--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -228,6 +228,40 @@ curl -s  \
 <details>
   <summary>
     <code>GET</code>
+    <code><b>/r/charms</b></code>
+  </summary>
+
+### Description
+Latest charms.
+
+### Example
+```bash
+curl -s  \
+  http://0.0.0.0:80/r/charms
+```
+```json
+{
+  "coin": "🪙",
+  "uncommon": "🌱",
+  "rare": "🧿",
+  "epic": "🪻",
+  "legendary": "🌝",
+  "mythic": "🎃",
+  "nineball": "9️⃣",
+  "reinscription": "♻️",
+  "cursed": "👹",
+  "unbound": "🔓",
+  "lost": "🤔",
+  "vindicated": "❤️‍🔥",
+  "burned": "🔥"
+}
+```
+</details>
+
+
+<details>
+  <summary>
+    <code>GET</code>
     <code><b>/r/children/&lt;INSCRIPTION_ID&gt;</b></code>
   </summary>
 
@@ -3332,6 +3366,7 @@ plain-text responses.
 - `/blockhash`: latest block hash.
 - `/blockhash/<HEIGHT>`: block hash at given block height.
 - `/blocktime`: UNIX time stamp of latest block.
+
 
 See
 [examples](examples.md#recursion) for on-chain examples of inscriptions that feature this functionality.

--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -1,7 +1,8 @@
-# Recursion
+Recursion
+=========
 
 An important exception to [sandboxing](../inscriptions.md#sandboxing) is
-recursion. Recursive endpoints are whitelisted endpoints that allow access to1
+recursion. Recursive endpoints are whitelisted endpoints that allow access to
 on-chain data, including the content of other inscriptions.
 
 Since changes to recursive endpoints might break inscriptions that rely on

--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -1,8 +1,7 @@
-Recursion
-=========
+# Recursion
 
 An important exception to [sandboxing](../inscriptions.md#sandboxing) is
-recursion. Recursive endpoints are whitelisted endpoints that allow access to
+recursion. Recursive endpoints are whitelisted endpoints that allow access to1
 on-chain data, including the content of other inscriptions.
 
 Since changes to recursive endpoints might break inscriptions that rely on
@@ -3332,7 +3331,6 @@ plain-text responses.
 - `/blockhash`: latest block hash.
 - `/blockhash/<HEIGHT>`: block hash at given block height.
 - `/blocktime`: UNIX time stamp of latest block.
-
 
 See
 [examples](examples.md#recursion) for on-chain examples of inscriptions that feature this functionality.

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -6254,7 +6254,7 @@ next
     let charms_response = server.get_json::<HashMap<String, String>>("/r/charms");
 
     assert!(!charms_response.is_empty());
-    
+
     for charm in Charm::ALL {
       let icon = charm.icon();
       let name = charm.to_string();
@@ -6267,7 +6267,6 @@ next
       assert!(Charm::ALL.iter().any(|c| c.to_string() == *value));
     }
   }
-
 
   #[test]
   fn children_recursive_endpoint() {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1746,7 +1746,7 @@ impl Server {
   async fn charms() -> ServerResult {
     let charms_map: HashMap<String, String> = Charm::ALL
       .iter()
-      .map(|charm| (charm.icon().to_string(), charm.to_string()))
+      .map(|charm| (charm.to_string(), charm.icon().to_string()))
       .collect();
 
     Ok(Json(charms_map).into_response())
@@ -6256,15 +6256,15 @@ next
     assert!(!charms_response.is_empty());
 
     for charm in Charm::ALL {
-      let icon = charm.icon();
+      let icon = charm.icon().to_string();
       let name = charm.to_string();
-      assert_eq!(charms_response.get(icon), Some(&name));
+      assert_eq!(charms_response.get(&name), Some(&icon));
     }
 
     assert_eq!(charms_response.len(), Charm::ALL.len());
 
     for value in charms_response.values() {
-      assert!(Charm::ALL.iter().any(|c| c.to_string() == *value));
+      assert!(Charm::ALL.iter().any(|c| c.icon() == value));
     }
   }
 


### PR DESCRIPTION
Returns the currently supported charms and their associated names. 
Allows inscriptions to have forwards compatibility with any new charms added. 
