### PR TITLE
Change mint progress to `mints / terms.cap`

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -3177,8 +3177,6 @@ mod tests {
   <dd>no</dd>
   <dt>supply</dt>
   <dd>340282366920938463463374607431768211455\u{A0}%</dd>
-  <dt>mint progress</dt>
-  <dd>100%</dd>
   <dt>premine</dt>
   <dd>340282366920938463463374607431768211455\u{A0}%</dd>
   <dt>premine percentage</dt>

--- a/src/templates/rune.rs
+++ b/src/templates/rune.rs
@@ -8,6 +8,24 @@ pub struct RuneHtml {
   pub parent: Option<InscriptionId>,
 }
 
+impl RuneHtml {
+  fn mint_progress(&self) -> Option<Decimal> {
+    let cap = self.entry.terms?.cap?;
+
+    if cap == 0 {
+      return None;
+    }
+
+    let progress = self.entry.mints as f64 / cap as f64;
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    Some(Decimal {
+      value: (progress * 10000.0) as u128,
+      scale: 2,
+    })
+  }
+}
+
 impl PageContent for RuneHtml {
   fn title(&self) -> String {
     format!("Rune {}", self.entry.spaced_rune)
@@ -40,7 +58,7 @@ mod tests {
             rune: Rune(u128::MAX),
             spacers: 1
           },
-          symbol: Some('%'),
+          symbol: Some('@'),
           timestamp: 0,
           turbo: true,
         },
@@ -72,7 +90,7 @@ mod tests {
       <dt>end</dt>
       <dd><a href=/block/11>11</a></dd>
       <dt>amount</dt>
-      <dd>1.000000001 %</dd>
+      <dd>1.000000001 @</dd>
       <dt>mints</dt>
       <dd>100</dd>
       <dt>cap</dt>
@@ -81,22 +99,22 @@ mod tests {
       <dd>1</dd>
       <dt>mintable</dt>
       <dd>true</dd>
+      <dt>progress</dt>
+      <dd>99%</dd>
     </dl>
   </dd>
   <dt>supply</dt>
-  <dd>100.123456889\u{A0}%</dd>
-  <dt>mint progress</dt>
-  <dd>99.01%</dd>
+  <dd>100.123456889\u{A0}@</dd>
   <dt>premine</dt>
-  <dd>0.123456789\u{A0}%</dd>
+  <dd>0.123456789\u{A0}@</dd>
   <dt>premine percentage</dt>
   <dd>0.12%</dd>
   <dt>burned</dt>
-  <dd>123456789.123456789\u{A0}%</dd>
+  <dd>123456789.123456789\u{A0}@</dd>
   <dt>divisibility</dt>
   <dd>9</dd>
   <dt>symbol</dt>
-  <dd>%</dd>
+  <dd>@</dd>
   <dt>turbo</dt>
   <dd>true</dd>
   <dt>etching</dt>
@@ -229,6 +247,45 @@ mod tests {
   </dd>
 .*</dl>
 "
+    );
+  }
+
+  #[test]
+  fn mint_progress() {
+    assert_regex_match!(
+      RuneHtml {
+        entry: RuneEntry {
+          block: 0,
+          burned: 0,
+          divisibility: 0,
+          etching: Txid::all_zeros(),
+          mints: 5555,
+          terms: Some(Terms {
+            cap: Some(10000),
+            offset: (None, None),
+            height: (None, None),
+            amount: None,
+          }),
+          number: 0,
+          premine: 0,
+          spaced_rune: SpacedRune {
+            rune: Rune(0),
+            spacers: 0
+          },
+          symbol: None,
+          timestamp: 0,
+          turbo: false,
+        },
+        id: RuneId { block: 0, tx: 0 },
+        mintable: false,
+        parent: Some(InscriptionId {
+          txid: Txid::all_zeros(),
+          index: 0,
+        }),
+      },
+      ".*
+      <dt>progress</dt>
+      <dd>55.55%</dd>.*"
     );
   }
 }

--- a/templates/rune.html
+++ b/templates/rune.html
@@ -45,6 +45,10 @@
       <dd>{{ terms.cap.unwrap_or_default() - self.entry.mints }}</dd>
       <dt>mintable</dt>
       <dd>{{ self.mintable }}</dd>
+%% if let Some(mint_progress) = self.mint_progress() {
+      <dt>progress</dt>
+      <dd>{{ mint_progress }}%</dd>
+%% }
     </dl>
   </dd>
 %% } else {
@@ -52,8 +56,6 @@
 %% }
   <dt>supply</dt>
   <dd>{{ self.entry.pile(self.entry.supply()) }}</dd>
-  <dt>mint progress</dt>
-  <dd>{{ Decimal { value: ((self.entry.supply() as f64 / self.entry.max_supply() as f64) * 10000.0) as u128, scale: 2 } }}%</dd>
   <dt>premine</dt>
   <dd>{{ self.entry.pile(self.entry.premine) }}</dd>
   <dt>premine percentage</dt>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,8 +10,8 @@ use {
   executable_path::executable_path,
   mockcore::TransactionTemplate,
   ord::{
-    api, chain::Chain, decimal::Decimal, outgoing::Outgoing, subcommand::runes::RuneInfo,
-    wallet::batch, wallet::ListDescriptorsResult, InscriptionId, RuneEntry,
+    api, chain::Chain, outgoing::Outgoing, subcommand::runes::RuneInfo, wallet::batch,
+    wallet::ListDescriptorsResult, InscriptionId, RuneEntry,
   },
   ordinals::{
     Artifact, Charm, Edict, Pile, Rarity, Rune, RuneId, Runestone, Sat, SatPoint, SpacedRune,
@@ -327,6 +327,11 @@ fn batch(core: &mockcore::Handle, ord: &TestServer, batchfile: batch::File) -> E
     mint_definition.push("<dt>mintable</dt>".into());
     mint_definition.push(format!("<dd>{mintable}</dd>"));
 
+    if terms.cap > 0 {
+      mint_definition.push("<dt>progress</dt>".into());
+      mint_definition.push("<dd>0%</dd>".into());
+    }
+
     mint_definition.push("</dl>".into());
     mint_definition.push("</dd>".into());
   } else {
@@ -334,14 +339,6 @@ fn batch(core: &mockcore::Handle, ord: &TestServer, batchfile: batch::File) -> E
   }
 
   let RuneId { block, tx } = id;
-
-  let supply_int = supply.to_integer(divisibility).unwrap();
-  let premine_int = premine.to_integer(divisibility).unwrap();
-
-  let mint_progress = Decimal {
-    value: ((premine_int as f64 / supply_int as f64) * 10000.0) as u128,
-    scale: 2,
-  };
 
   ord.assert_response_regex(
     format!("/rune/{rune}"),
@@ -356,8 +353,6 @@ fn batch(core: &mockcore::Handle, ord: &TestServer, batchfile: batch::File) -> E
   {}
   <dt>supply</dt>
   <dd>{premine} {symbol}</dd>
-  <dt>mint progress</dt>
-  <dd>{mint_progress}%</dd>
   <dt>premine</dt>
   <dd>{premine} {symbol}</dd>
   <dt>premine percentage</dt>


### PR DESCRIPTION
We've been displaying mint progress as the completely inexplicable `supply / max_supply`. Change it to number of mints / maximum number of mints.