### PR TITLE
Do not split runestone payload into MAX_SCRIPT_ELEMENT_SIZE pushes

### DIFF
--- a/crates/ordinals/src/lib.rs
+++ b/crates/ordinals/src/lib.rs
@@ -4,7 +4,7 @@
 use {
   bitcoin::{
     consensus::{Decodable, Encodable},
-    constants::{DIFFCHANGE_INTERVAL, MAX_SCRIPT_ELEMENT_SIZE, SUBSIDY_HALVING_INTERVAL},
+    constants::{DIFFCHANGE_INTERVAL, SUBSIDY_HALVING_INTERVAL},
     opcodes,
     script::{self, Instruction},
     Network, OutPoint, ScriptBuf, Transaction,

--- a/crates/ordinals/src/runestone.rs
+++ b/crates/ordinals/src/runestone.rs
@@ -186,7 +186,7 @@ impl Runestone {
       .push_opcode(opcodes::all::OP_RETURN)
       .push_opcode(Runestone::MAGIC_NUMBER);
 
-    for chunk in payload.chunks(MAX_SCRIPT_ELEMENT_SIZE) {
+    for chunk in payload.chunks(u32::MAX.try_into().unwrap()) {
       let push: &script::PushBytes = chunk.try_into().unwrap();
       builder = builder.push_slice(push);
     }
@@ -1794,7 +1794,7 @@ mod tests {
   }
 
   #[test]
-  fn runestone_payload_is_chunked() {
+  fn runestone_payloads_are_not_chunked() {
     let script = Runestone {
       edicts: vec![
         Edict {
@@ -1823,7 +1823,7 @@ mod tests {
     }
     .encipher();
 
-    assert_eq!(script.instructions().count(), 4);
+    assert_eq!(script.instructions().count(), 3);
   }
 
   #[test]


### PR DESCRIPTION
I believe the `MAX_SCRIPT_ELEMENT_SIZE` limit is only checked when outputs are spent. Since runestones begin with an `OP_RETURN`, they can never be spent, so we do not need to chunk the payload.

It's unfortunate that I'm only realizing this now, since if I had known it earlier, we could have required the payload to be a single data push, since without the `MAX_SCRIPT_ELEMENT_SIZE` limit, there's no reason to accept multiple data pushes in the payload.

This is marked as a draft PR, because although I think it's correct, I want to actually test it against Bitcoin Core to confirm before merging.