### PR TITLE
Weird error when upgrading bitcoin dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.3"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0032b0e8ead7074cda7fc4f034409607e3f03a6f71d66ade8a307f79b4d99e73"
+checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
 dependencies = [
  "base58ck",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ axum-server = "0.5.0"
 base64 = "0.22.0"
 bip322 = "0.0.8"
 bip39 = "2.0.0"
-bitcoin = { version = "0.32.3", features = ["rand"] }
+bitcoin = { version = "0.32.4", features = ["rand"] }
 bitcoincore-rpc = "0.19.0"
 boilerplate = { version = "1.0.0", features = ["axum"] }
 brotli = "7.0.0"

--- a/crates/mockcore/Cargo.toml
+++ b/crates/mockcore/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ordinals/ord"
 
 [dependencies]
 base64 = "0.22.0"
-bitcoin = { version = "0.32.3", features = ["serde", "rand"] }
+bitcoin = { version = "0.32.4", features = ["serde", "rand"] }
 hex = "0.4.3"
 jsonrpc-core = "18.0.0"
 jsonrpc-derive = "18.0.0"

--- a/crates/ordinals/Cargo.toml
+++ b/crates/ordinals/Cargo.toml
@@ -9,7 +9,7 @@ license = "CC0-1.0"
 rust-version = "1.74.0"
 
 [dependencies]
-bitcoin = { version = "0.32.3", features = ["rand"] }
+bitcoin = { version = "0.32.4", features = ["rand"] }
 derive_more = { version = "1.0.0", features = ["display", "from_str"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_with = "3.7.0"

--- a/crates/ordinals/src/sat_point.rs
+++ b/crates/ordinals/src/sat_point.rs
@@ -44,7 +44,7 @@ impl Encodable for SatPoint {
 }
 
 impl Decodable for SatPoint {
-  fn consensus_decode<D: bitcoin::io::Read + ?Sized + bitcoin::io::BufRead>(
+  fn consensus_decode<D: bitcoin::io::Read + ?Sized>(
     d: &mut D,
   ) -> Result<Self, bitcoin::consensus::encode::Error> {
     Ok(SatPoint {


### PR DESCRIPTION
For some reason this test fails when upgrading from `bitcoin = "0.32.3"` to `bitcoin = "0.32.4"`

```
---- inscriptions::envelope::tests::ignore_key_path_spends_with_annex stdout ----
thread 'inscriptions::envelope::tests::ignore_key_path_spends_with_annex' panicked at src/inscriptions/envelope.rs:300:5:
assertion `left == right` failed
  left: [Envelope { input: 0, offset: 0, payload: Inscription { body: None, content_encoding: None, content_type: None, delegate: None, duplicate_field: false, incomplete_field: false, metadata: None, metaprotocol: None, parents: [], pointer: None, rune: None, unrecognized_even_field: false }, pushnum: false, stutter: false }]
 right: []
```