### PR TITLE
Hide image preview and thumbnail scrollbars

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -3947,7 +3947,7 @@ mod tests {
 <dl>
   <dt>inscriptions</dt>
   <dd class=thumbnails>
-    <a href=/inscription/.*><iframe sandbox=allow-scripts loading=lazy src=/preview/.*></iframe></a>
+    <a href=/inscription/.*><iframe sandbox=allow-scripts scrolling=no loading=lazy src=/preview/.*></iframe></a>
   </dd>.*",
     );
   }

--- a/src/templates/iframe.rs
+++ b/src/templates/iframe.rs
@@ -24,20 +24,21 @@ impl Iframe {
 impl Display for Iframe {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
     if self.thumbnail {
-      write!(f, "<a href=/inscription/{}>", self.inscription_id)?;
+      write!(
+        f,
+        "<a href=/inscription/{}>\
+          <iframe sandbox=allow-scripts scrolling=no loading=lazy src=/preview/{}>\
+          </iframe>\
+        </a>",
+        self.inscription_id, self.inscription_id,
+      )
+    } else {
+      write!(
+        f,
+        "<iframe sandbox=allow-scripts loading=lazy src=/preview/{}></iframe>",
+        self.inscription_id,
+      )
     }
-
-    write!(
-      f,
-      "<iframe sandbox=allow-scripts loading=lazy src=/preview/{}></iframe>",
-      self.inscription_id
-    )?;
-
-    if self.thumbnail {
-      write!(f, "</a>",)?
-    }
-
-    Ok(())
   }
 }
 
@@ -50,7 +51,7 @@ mod tests {
     assert_regex_match!(
       Iframe::thumbnail(inscription_id(1))
       .0.to_string(),
-      "<a href=/inscription/1{64}i1><iframe sandbox=allow-scripts loading=lazy src=/preview/1{64}i1></iframe></a>",
+      "<a href=/inscription/1{64}i1><iframe sandbox=allow-scripts scrolling=no loading=lazy src=/preview/1{64}i1></iframe></a>",
     );
   }
 

--- a/templates/preview-image.html
+++ b/templates/preview-image.html
@@ -20,6 +20,7 @@
       }
 
       img {
+        float: left;
         height: 100%;
         opacity: 0;
         width: 100%;


### PR DESCRIPTION
In #3947, we allowed scrolling in iframes. I recently visited ordinals.com on windows, and there were hideous scrollbars on nearly every inscription.

This isn't a windows-specific issue, i.e., the scrollbars are there on macOS, they just look worse on Windows, which is why we didn't notice.

This PR does a couple things:

- Add `float: left` to images in the image preview. This, for some reason, makes the images the correct size, so they don't overflow, due to some mysterious CSS behavior that I don't fully understand.
- Add back `scrolling=no` to inscription thumbnails. This prevents scrollbars for appearing everywhere except the actual /inscription page, which I think is better. There's no reason to allow scrolling a thumbnail, especially if the user can just click it to scroll.

I'm still not sure that we shouldn't just re-add `scrolling=no` to inscriptions. Users can click the content link if they want to scroll, and the bars on windows are absolutely disgusting looking. If you made an HTML inscription, previewed it on an old version of ord, and then inscribed it on mainnet, you're now getting scrollbars where before you didn't see any.

However, this PR is a pareto improvement, unlikely removing scrollbars entirely, so I think we should merge this and if the remaining scroll bars are an issue, deal with them later.