### PR TITLE
Collapse long strings in HTML

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -3689,7 +3689,7 @@ mod tests {
   <dd>.*</dd>
   <dt>git commit</dt>
   <dd>
-    <a href=https://github.com/ordinals/ord/commit/[[:xdigit:]]{40}>
+    <a class=monospace href=https://github.com/ordinals/ord/commit/[[:xdigit:]]{40}>
       [[:xdigit:]]{40}
     </a>
   </dd>
@@ -4057,7 +4057,7 @@ mod tests {
     test_server.assert_response_regex(
       "/blocks",
       StatusCode::OK,
-      ".*<ol start=96 reversed class=block-list>\n(  <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>\n){95}</ol>.*"
+      ".*<ol start=96 reversed class=block-list>\n(  <li><a class=monospace href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>\n){95}</ol>.*"
     );
   }
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -137,7 +137,7 @@ mod tests {
     <link rel=icon href=/static/favicon.svg>
     <link rel=stylesheet href=/static/index.css>
     <link rel=stylesheet href=/static/modern-normalize.css>
-    <script src=/static/index.js defer></script>
+    <script src=/static/index.js></script>
   </head>
   <body>
   <header>

--- a/src/templates/block.rs
+++ b/src/templates/block.rs
@@ -73,8 +73,8 @@ mod tests {
         <div class=thumbnails>
         </div>
         <h2>1 Transaction</h2>
-        <ul class=monospace>
-          <li><a href=/tx/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>
+        <ul>
+          <li><a class=monospace href=/tx/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>
         </ul>
       "
       .unindent()

--- a/src/templates/blocks.rs
+++ b/src/templates/blocks.rs
@@ -79,8 +79,8 @@ mod tests {
         </div>
       </div>
       <ol start=1260001 reversed class=block-list>
-        <li><a href=/block/1{64}>1{64}</a></li>
-        <li><a href=/block/0{64}>0{64}</a></li>
+        <li><a class=monospace href=/block/1{64}>1{64}</a></li>
+        <li><a class=monospace href=/block/0{64}>0{64}</a></li>
       </ol>
       "
       .unindent(),

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -75,7 +75,7 @@ mod tests {
           <dt>offset</dt>
           <dd>0</dd>
           <dt>ethereum teleburn address</dt>
-          <dd>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
+          <dd class=monospace>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
       "
       .unindent()
@@ -104,7 +104,7 @@ mod tests {
         <dl>
           .*
           <dt>address</dt>
-          <dd class=monospace><a href=/address/bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</a></dd>
+          <dd><a class=monospace href=/address/bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</a></dd>
           <dt>value</dt>
           <dd>1</dd>
           .*
@@ -258,7 +258,7 @@ mod tests {
           <dt>offset</dt>
           <dd>0</dd>
           <dt>ethereum teleburn address</dt>
-          <dd>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
+          <dd class=monospace>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
 "
       .unindent()
@@ -321,7 +321,7 @@ mod tests {
           <dt>offset</dt>
           <dd>0</dd>
           <dt>ethereum teleburn address</dt>
-          <dd>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
+          <dd class=monospace>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
       "
       .unindent()
@@ -383,7 +383,7 @@ mod tests {
           <dt>offset</dt>
           <dd>0</dd>
           <dt>ethereum teleburn address</dt>
-          <dd>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
+          <dd class=monospace>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
       "
       .unindent()

--- a/src/templates/output.rs
+++ b/src/templates/output.rs
@@ -41,7 +41,7 @@ mod tests {
         <dl>
           <dt>value</dt><dd>3</dd>
           <dt>script pubkey</dt><dd class=monospace>OP_DUP OP_HASH160 OP_PUSHBYTES_20 0{40} OP_EQUALVERIFY OP_CHECKSIG</dd>
-          <dt>address</dt><dd class=monospace><a href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
+          <dt>address</dt><dd><a class=monospace href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
           <dt>transaction</dt><dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
           <dt>spent</dt><dd>false</dd>
         </dl>
@@ -100,7 +100,7 @@ mod tests {
         <dl>
           <dt>value</dt><dd>3</dd>
           <dt>script pubkey</dt><dd class=monospace>OP_DUP OP_HASH160 OP_PUSHBYTES_20 0{40} OP_EQUALVERIFY OP_CHECKSIG</dd>
-          <dt>address</dt><dd class=monospace><a href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
+          <dt>address</dt><dd><a class=monospace href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
           <dt>transaction</dt><dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
           <dt>spent</dt><dd>true</dd>
         </dl>
@@ -132,7 +132,7 @@ mod tests {
         <dl>
           <dt>value</dt><dd>3</dd>
           <dt>script pubkey</dt><dd class=monospace>OP_DUP OP_HASH160 OP_PUSHBYTES_20 0{40} OP_EQUALVERIFY OP_CHECKSIG</dd>
-          <dt>address</dt><dd class=monospace><a href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
+          <dt>address</dt><dd><a class=monospace href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
           <dt>transaction</dt><dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
           <dt>spent</dt><dd>false</dd>
         </dl>

--- a/src/templates/sat.rs
+++ b/src/templates/sat.rs
@@ -171,7 +171,7 @@ mod tests {
         blocktime: Blocktime::confirmed(0),
         inscriptions: Vec::new(),
       },
-      "<h1>Sat 0</h1>.*<dt>location</dt><dd class=monospace>1{64}:1:0</dd>.*",
+      "<h1>Sat 0</h1>.*<dt>location</dt><dd><a class=monospace href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>.*",
     );
   }
 }

--- a/static/index.css
+++ b/static/index.css
@@ -115,8 +115,6 @@ ol, ul {
 }
 
 .block-list {
-  font-family: monospace, monospace;
-  list-style-position: inside;
   white-space: nowrap;
 }
 
@@ -267,4 +265,8 @@ a.mythic {
 .icon {
   height: 1rem;
   width: 1rem;
+}
+
+[data-original]:not(a) {
+  user-select: all;
 }

--- a/static/index.js
+++ b/static/index.js
@@ -1,34 +1,114 @@
-for (let time of document.body.getElementsByTagName('time')) {
-  time.setAttribute('title', new Date(time.textContent));
-}
-
-let next = document.querySelector('a.next');
-let prev = document.querySelector('a.prev');
-
-window.addEventListener('keydown', e => {
-  if (document.activeElement.tagName == 'INPUT') {
-    return;
+addEventListener("DOMContentLoaded", () => {
+  for (let time of document.body.getElementsByTagName('time')) {
+    time.setAttribute('title', new Date(time.textContent));
   }
 
-  switch (e.key) {
-    case 'ArrowRight':
-      if (next) {
-        window.location = next.href;
-      }
+  let next = document.querySelector('a.next');
+  let prev = document.querySelector('a.prev');
+
+  window.addEventListener('keydown', e => {
+    if (document.activeElement.tagName == 'INPUT') {
       return;
-    case 'ArrowLeft':
-      if (prev) {
-        window.location = prev.href;
-      }
+    }
+
+    switch (e.key) {
+      case 'ArrowRight':
+        if (next) {
+          window.location = next.href;
+        }
+        return;
+      case 'ArrowLeft':
+        if (prev) {
+          window.location = prev.href;
+        }
+        return;
+    }
+  });
+
+  const search = document.querySelector('form[action="/search"]');
+  const query = search.querySelector('input[name="query"]');
+
+  search.addEventListener('submit', (e) => {
+    if (!query.value) {
+      e.preventDefault();
+    }
+  });
+
+  let collapse = [];
+
+  const PATTERNS = [
+    // hash
+    '[a-f0-9]{64}',
+    // outpoint
+    '[a-f0-9]{64}:[0-9]+',
+    // satpoint
+    '[a-f0-9]{64}:[0-9]+:[0-9]+',
+    // ethereum address
+    '0x[A-Fa-f0-9]{40}',
+    // inscription id
+    '[a-f0-9]{64}i[0-9]+',
+    // p2pkh address
+    '1[a-km-zA-HJ-NP-Z1-9]{25,33}',
+    // p2wpkh address
+    '(bc|bcrt|tb)1q[02-9ac-hj-np-z]{38}',
+    // p2wsh address
+    '(bc|bcrt|tb)1q[02-9ac-hj-np-z]{46}',
+    // p2tr address
+    '(bc|bcrt|tb)1p[02-9ac-hj-np-z]{58}',
+    // git hash
+    '[a-f0-9]{40}'
+  ]
+
+  let RE = new RegExp('^(' + PATTERNS.map((p) => '(' + p + ')').join('|') + ')$');
+
+  document.querySelectorAll('.monospace').forEach((node) => {
+    if (node.children.length > 0 || node.parentNode.tagName === 'H1') {
       return;
-  }
-});
+    }
 
-const search = document.querySelector('form[action="/search"]');
-const query = search.querySelector('input[name="query"]');
+    let text = node.textContent.trim();
 
-search.addEventListener('submit', (e) => {
-  if (!query.value) {
-    e.preventDefault();
+    if (!RE.test(text)) {
+      return;
+    }
+
+    node.dataset.original = text;
+    collapse.push(node);
+  });
+
+  let context = document.createElement('canvas').getContext('2d');
+
+  function resize() {
+    for (let node of collapse) {
+      let original = node.dataset.original;
+      let length = original.length;
+      let width = node.clientWidth;
+      if (width == 0) {
+        width = node.parentNode.getBoundingClientRect().width;
+      }
+      context.font = window.getComputedStyle(node).font;
+      let capacity = width / (context.measureText(original).width / length);
+      if (capacity >= length) {
+        node.textContent = original
+      } else {
+        let count = Math.floor((capacity - 1) / 2);
+        let start = original.substring(0, count);
+        let end = original.substring(length - count);
+        node.textContent = `${start}…${end}`;
+      }
+    }
   }
+
+  function copy(e) {
+    if ('original' in e.target.dataset && window.getSelection().toString().includes('…')) {
+      e.clipboardData.setData('text/plain', e.target.dataset.original);
+      e.preventDefault();
+    }
+  }
+
+  addEventListener('resize', resize);
+
+  addEventListener('copy', copy);
+
+  resize();
 });

--- a/templates/block.html
+++ b/templates/block.html
@@ -41,9 +41,9 @@ next
 </div>
 %% }
 <h2>{{"Transaction".tally(self.block.txdata.len())}}</h2>
-<ul class=monospace>
+<ul>
 %% for tx in &self.block.txdata {
 %% let txid = tx.txid();
-  <li><a href=/tx/{{txid}}>{{txid}}</a></li>
+  <li><a class=monospace href=/tx/{{txid}}>{{txid}}</a></li>
 %% }
 </ul>

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -13,7 +13,7 @@
 %% if i == self.featured_blocks.len() {
 <ol start={{ self.last - self.featured_blocks.len() as u32 }} reversed class=block-list>
 %% }
-  <li><a href=/block/{{ hash }}>{{ hash }}</a></li>
+  <li><a class=monospace href=/block/{{ hash }}>{{ hash }}</a></li>
 %% }
 %% }
 </ol>

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -64,7 +64,7 @@
 %% if let Some(output) = &self.output {
 %% if let Ok(address) = self.chain.address_from_script(&output.script_pubkey ) {
   <dt>address</dt>
-  <dd class=monospace><a href=/address/{{address}}>{{ address }}</a></dd>
+  <dd><a class=monospace href=/address/{{address}}>{{ address }}</a></dd>
 %% }
   <dt>value</dt>
   <dd>{{ output.value.to_sat() }}</dd>
@@ -116,5 +116,5 @@
   <dt>offset</dt>
   <dd>{{ self.satpoint.offset }}</dd>
   <dt>ethereum teleburn address</dt>
-  <dd>{{ teleburn::Ethereum::from(self.id) }}</dd>
+  <dd class=monospace>{{ teleburn::Ethereum::from(self.id) }}</dd>
 </dl>

--- a/templates/output.html
+++ b/templates/output.html
@@ -28,7 +28,7 @@
   <dt>value</dt><dd>{{ self.output.value.to_sat() }}</dd>
   <dt>script pubkey</dt><dd class=monospace>{{ self.output.script_pubkey.to_asm_string() }}</dd>
 %% if let Ok(address) = self.chain.address_from_script(&self.output.script_pubkey ) {
-  <dt>address</dt><dd class=monospace><a href=/address/{{address}}>{{ address }}</a></dd>
+  <dt>address</dt><dd><a class=monospace href=/address/{{address}}>{{ address }}</a></dd>
 %% }
   <dt>transaction</dt><dd><a class=monospace href=/tx/{{ self.outpoint.txid }}>{{ self.outpoint.txid }}</a></dd>
   <dt>spent</dt><dd>{{ self.spent }}</dd>

--- a/templates/page.html
+++ b/templates/page.html
@@ -13,7 +13,7 @@
     <link rel=icon href=/static/favicon.svg>
     <link rel=stylesheet href=/static/index.css>
     <link rel=stylesheet href=/static/modern-normalize.css>
-    <script src=/static/index.js defer></script>
+    <script src=/static/index.js></script>
   </head>
   <body>
   <header>

--- a/templates/rune-balances.html
+++ b/templates/rune-balances.html
@@ -11,8 +11,8 @@
       <table>
 %% for (outpoint, balance) in balances {
         <tr>
-          <td class=monospace>
-            <a href=/output/{{ outpoint }}>{{ outpoint }}</a>
+          <td>
+            <a class=monospace href=/output/{{ outpoint }}>{{ outpoint }}</a>
           </td>
           <td class=monospace>
             {{ balance }}

--- a/templates/sat.html
+++ b/templates/sat.html
@@ -31,7 +31,7 @@
   </dd>
 %% }
 %% if let Some(satpoint) = self.satpoint {
-  <dt>location</dt><dd class=monospace>{{ satpoint }}</dd>
+  <dt>location</dt><dd><a class=monospace href=/satpoint/{{ satpoint }}>{{ satpoint }}</a></dd>
 %% }
 </dl>
 <div class=center>

--- a/templates/status.html
+++ b/templates/status.html
@@ -47,7 +47,7 @@
 %% if !env!("GIT_COMMIT").is_empty() {
   <dt>git commit</dt>
   <dd>
-    <a href=https://github.com/ordinals/ord/commit/{{ env!("GIT_COMMIT") }}>
+    <a class=monospace href=https://github.com/ordinals/ord/commit/{{ env!("GIT_COMMIT") }}>
       {{ env!("GIT_COMMIT") }}
     </a>
   </dd>

--- a/templates/transaction.html
+++ b/templates/transaction.html
@@ -31,7 +31,7 @@
       <dt>value</dt><dd>{{ output.value.to_sat() }}</dd>
       <dt>script pubkey</dt><dd class=monospace>{{ output.script_pubkey.to_asm_string() }}</dd>
 %% if let Ok(address) = self.chain.address_from_script(&output.script_pubkey) {
-      <dt>address</dt><dd class=monospace><a href=/address/{{address}}>{{ address }}</a></dd>
+      <dt>address</dt><dd><a class=monospace href=/address/{{address}}>{{ address }}</a></dd>
 %% }
     </dl>
   </li>

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -250,7 +250,7 @@ fn inscription_page() {
   <dt>id</dt>
   <dd class=monospace>{inscription}</dd>
   <dt>address</dt>
-  <dd class=monospace><a href=/address/bc1.*>bc1.*</a></dd>
+  <dd><a class=monospace href=/address/bc1.*>bc1.*</a></dd>
   <dt>value</dt>
   <dd>10000</dd>
   <dt>preview</dt>
@@ -276,7 +276,7 @@ fn inscription_page() {
   <dt>offset</dt>
   <dd>0</dd>
   <dt>ethereum teleburn address</dt>
-  <dd>{ethereum_teleburn_address}</dd>
+  <dd class=monospace>{ethereum_teleburn_address}</dd>
 </dl>.*",
     ),
   );
@@ -380,7 +380,7 @@ fn inscription_page_after_send() {
   ord.assert_response_regex(
     format!("/inscription/{inscription}"),
     format!(
-      r".*<h1>Inscription 0</h1>.*<dt>address</dt>\s*<dd class=monospace><a href=/address/bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv>bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv</a></dd>.*<dt>location</dt>\s*<dd><a class=monospace href=/satpoint/{txid}:0:0>{txid}:0:0</a></dd>.*",
+      r".*<h1>Inscription 0</h1>.*<dt>address</dt>\s*<dd><a class=monospace href=/address/bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv>bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv</a></dd>.*<dt>location</dt>\s*<dd><a class=monospace href=/satpoint/{txid}:0:0>{txid}:0:0</a></dd>.*",
     ),
   )
 }

--- a/tests/wallet/batch_command.rs
+++ b/tests/wallet/batch_command.rs
@@ -682,7 +682,7 @@ inscriptions:
     format!("/inscription/{}", output.inscriptions[0].id),
     ".*
   <dt>address</dt>
-  <dd class=monospace><a href=/address/bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</a></dd>.*",
+  <dd><a class=monospace href=/address/bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</a></dd>.*",
   );
 
   ord.assert_response_regex(
@@ -690,7 +690,7 @@ inscriptions:
     format!(
       ".*
   <dt>address</dt>
-  <dd class=monospace><a href=/address/{0}>{0}</a></dd>.*",
+  <dd><a class=monospace href=/address/{0}>{0}</a></dd>.*",
       core.state().change_addresses[0],
     ),
   );
@@ -699,7 +699,7 @@ inscriptions:
     format!("/inscription/{}", output.inscriptions[2].id),
     ".*
   <dt>address</dt>
-  <dd class=monospace><a href=/address/bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k>bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k</a></dd>.*",
+  <dd><a class=monospace href=/address/bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k>bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k</a></dd>.*",
   );
 }
 

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -153,7 +153,7 @@ fn send_inscription_by_sat() {
   ord.assert_response_regex(
     format!("/inscription/{inscription}"),
     format!(
-      ".*<h1>Inscription 0</h1>.*<dt>address</dt>.*<dd class=monospace><a href=/address/{address}>{address}</a></dd>.*<dt>location</dt>.*<dd><a class=monospace href=/satpoint/{send_txid}:0:0>{send_txid}:0:0</a></dd>.*",
+      ".*<h1>Inscription 0</h1>.*<dt>address</dt>.*<dd><a class=monospace href=/address/{address}>{address}</a></dd>.*<dt>location</dt>.*<dd><a class=monospace href=/satpoint/{send_txid}:0:0>{send_txid}:0:0</a></dd>.*",
     ),
   );
 }


### PR DESCRIPTION
This PR uses JavaScript to collapse hashes, outpoints, satpoints, addresses, and inscription IDs.

Any node which has exactly one child node which is a text mode that matches a regex matching the above is eligible to be collapsed. A `data-original` attribute is added with the original text, and on resize, the size of the element is measured, and if smaller than the size of the text content, the text content is abridged in the middle with `…`.

Since the text content is now changed, we need to fix clipboard copying, so that users can copy the original unabridged text. This is accomplished by intersecting clipboard copy events, and, if they target a collapsible node, replacing the copied text with the original text. One failing of this approach is that if you copy multiple nodes, the target of the copy command will not be a collapsible node, but it may contain collapsible nodes, so the copied text will may contain abridged text. We could fix that by traversing the nodes which are copied and replacing any copied text with original text, but I think this PR is still an improvement, and we should merge it and fix that issue in a future PR.

Another thing which we should fix, I think also in a future PR, is not using heuristics to find collapsible nodes, and instead relying on the presence of a CSS class to determine if a node is collapsible. Since all collapsible items already have the CSS monospace class, we can simply replace `monospace` on collapsible classes with `collapsible`. (Or maybe `collapse`, since it's shorter and I can never spell "collapsible" on the first try.)

One thing which I'm not sure we can fully fix, but we should try, is visible resizing of the page after elements are collapsed. Text is collapsed after the page first renders, so element movement after collapsing is visible.

Edit: Okay, I actually fixed visible resizing. I changed our JS from running as a `defer` script to running after the DOMContentLoaded event. This runs our JS after the DOM is loaded, but earlier than defer scripts, which wait for images, other scripts, stylesheets, etc. Apparently DOMContentLoaded runs before first render, so our JS can modify the HTML without the original HTML being visible.


<details>
  <summary>before and after</summary>

![before](https://github.com/user-attachments/assets/1b6dea91-3f43-4353-a0ff-0f7ddf38a63c)
![after](https://github.com/user-attachments/assets/f57920ea-0bc9-40f2-bb77-6243e77dbbfc)

</details>