### PR TITLE
Identify collapsible nodes with class=collapse

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -3242,9 +3242,9 @@ mod tests {
   <dt>turbo</dt>
   <dd>true</dd>
   <dt>etching</dt>
-  <dd><a class=monospace href=/tx/{txid}>{txid}</a></dd>
+  <dd><a class=collapse href=/tx/{txid}>{txid}</a></dd>
   <dt>parent</dt>
-  <dd><a class=monospace href=/inscription/{txid}i0>{txid}i0</a></dd>
+  <dd><a class=collapse href=/inscription/{txid}i0>{txid}i0</a></dd>
 </dl>
 .*"
       ),
@@ -3689,7 +3689,7 @@ mod tests {
   <dd>.*</dd>
   <dt>git commit</dt>
   <dd>
-    <a class=monospace href=https://github.com/ordinals/ord/commit/[[:xdigit:]]{40}>
+    <a class=collapse href=https://github.com/ordinals/ord/commit/[[:xdigit:]]{40}>
       [[:xdigit:]]{40}
     </a>
   </dd>
@@ -3842,7 +3842,7 @@ mod tests {
 <dl>
   <dt>value</dt><dd>5000000000</dd>
   <dt>script pubkey</dt><dd class=monospace>OP_PUSHBYTES_65 [[:xdigit:]]{{130}} OP_CHECKSIG</dd>
-  <dt>transaction</dt><dd><a class=monospace href=/tx/{txid}>{txid}</a></dd>
+  <dt>transaction</dt><dd><a class=collapse href=/tx/{txid}>{txid}</a></dd>
   <dt>spent</dt><dd>false</dd>
 </dl>
 <h2>1 Sat Range</h2>
@@ -3864,7 +3864,7 @@ mod tests {
 <dl>
   <dt>value</dt><dd>5000000000</dd>
   <dt>script pubkey</dt><dd class=monospace>OP_PUSHBYTES_65 [[:xdigit:]]{{130}} OP_CHECKSIG</dd>
-  <dt>transaction</dt><dd><a class=monospace href=/tx/{txid}>{txid}</a></dd>
+  <dt>transaction</dt><dd><a class=collapse href=/tx/{txid}>{txid}</a></dd>
   <dt>spent</dt><dd>false</dd>
 </dl>.*"
       ),
@@ -3887,7 +3887,7 @@ mod tests {
 <dl>
   <dt>value</dt><dd>5000000000</dd>
   <dt>script pubkey</dt><dd class=monospace></dd>
-  <dt>transaction</dt><dd><a class=monospace href=/tx/{txid}>{txid}</a></dd>
+  <dt>transaction</dt><dd><a class=collapse href=/tx/{txid}>{txid}</a></dd>
   <dt>spent</dt><dd>false</dd>
 </dl>
 <h2>1 Sat Range</h2>
@@ -3935,8 +3935,8 @@ mod tests {
       format!(
         ".*<dl>
   <dt>id</dt>
-  <dd class=monospace>{inscription_id}</dd>.*<dt>output</dt>
-  <dd><a class=monospace href=/output/0000000000000000000000000000000000000000000000000000000000000000:0>0000000000000000000000000000000000000000000000000000000000000000:0</a></dd>.*"
+  <dd class=collapse>{inscription_id}</dd>.*<dt>output</dt>
+  <dd><a class=collapse href=/output/0000000000000000000000000000000000000000000000000000000000000000:0>0000000000000000000000000000000000000000000000000000000000000000:0</a></dd>.*"
       ),
     );
 
@@ -4057,7 +4057,7 @@ mod tests {
     test_server.assert_response_regex(
       "/blocks",
       StatusCode::OK,
-      ".*<ol start=96 reversed class=block-list>\n(  <li><a class=monospace href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>\n){95}</ol>.*"
+      ".*<ol start=96 reversed class=block-list>\n(  <li><a class=collapse href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>\n){95}</ol>.*"
     );
   }
 
@@ -4155,12 +4155,12 @@ mod tests {
 </dl>
 <h2>1 Input</h2>
 <ul>
-  <li><a class=monospace href=/output/0000000000000000000000000000000000000000000000000000000000000000:4294967295>0000000000000000000000000000000000000000000000000000000000000000:4294967295</a></li>
+  <li><a class=collapse href=/output/0000000000000000000000000000000000000000000000000000000000000000:4294967295>0000000000000000000000000000000000000000000000000000000000000000:4294967295</a></li>
 </ul>
 <h2>1 Output</h2>
 <ul class=monospace>
   <li>
-    <a href=/output/{txid}:0 class=monospace>
+    <a href=/output/{txid}:0 class=collapse>
       {txid}:0
     </a>
     <dl>
@@ -5492,7 +5492,7 @@ next
       format!(
         ".*<title>Inscription 1</title>.*
 .*<dt>id</dt>
-.*<dd class=monospace>{child0}</dd>.*"
+.*<dd class=collapse>{child0}</dd>.*"
       ),
     );
 
@@ -5507,7 +5507,7 @@ next
       format!(
         ".*<title>Inscription -1</title>.*
 .*<dt>id</dt>
-.*<dd class=monospace>{child1}</dd>.*"
+.*<dd class=collapse>{child1}</dd>.*"
       ),
     );
   }
@@ -5668,7 +5668,7 @@ next
         ".*<h1>Inscription 0</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{inscription_id}</dd>.*"
+  <dd class=collapse>{inscription_id}</dd>.*"
       ),
     );
     server.assert_response_regex(
@@ -5678,7 +5678,7 @@ next
         ".*<h1>Inscription 0</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{inscription_id}</dd>.*"
+  <dd class=collapse>{inscription_id}</dd>.*"
       ),
     );
 
@@ -5689,7 +5689,7 @@ next
         ".*<h1>Inscription -1</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{cursed_inscription_id}</dd>.*"
+  <dd class=collapse>{cursed_inscription_id}</dd>.*"
       ),
     )
   }
@@ -5720,7 +5720,7 @@ next
         ".*<h1>Inscription -1</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   <dt>charms</dt>
   <dd>
     <span title=cursed>👹</span>
@@ -5759,7 +5759,7 @@ next
         ".*<h1>Inscription 0</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   .*
   <dt>value</dt>
   .*
@@ -5795,7 +5795,7 @@ next
         ".*<h1>Inscription 0</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   <dt>charms</dt>
   <dd>.*<span title=coin>🪙</span>.*</dd>
   .*
@@ -5831,7 +5831,7 @@ next
         ".*<h1>Inscription 0</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   <dt>charms</dt>
   <dd>.*<span title=uncommon>🌱</span>.*</dd>
   .*
@@ -5867,7 +5867,7 @@ next
         ".*<h1>Inscription 0</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   <dt>charms</dt>
   <dd>.*<span title=nineball>9️⃣</span>.*</dd>
   .*
@@ -5907,7 +5907,7 @@ next
         ".*<h1>Inscription -1</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   <dt>charms</dt>
   <dd>
     <span title=reinscription>♻️</span>
@@ -5971,7 +5971,7 @@ next
         ".*<h1>Inscription 0</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   .*
   <dt>value</dt>
   .*
@@ -6032,7 +6032,7 @@ next
         ".*<h1>Inscription 0</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   .*
   <dt>value</dt>
   .*
@@ -6082,7 +6082,7 @@ next
         ".*<h1>Inscription -1</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   <dt>charms</dt>
   <dd>
     <span title=cursed>👹</span>
@@ -6118,7 +6118,7 @@ next
         ".*<h1>Inscription 0</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   .*
   <dt>value</dt>
   <dd>5000000000</dd>
@@ -6144,7 +6144,7 @@ next
         ".*<h1>Inscription 0</h1>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{id}</dd>
+  <dd class=collapse>{id}</dd>
   <dt>charms</dt>
   <dd>
     <span title=lost>🤔</span>
@@ -6603,7 +6603,7 @@ next
         ".*<h1>Inscription 1</h1>.*
         <dl>
           <dt>id</dt>
-          <dd class=monospace>{id}</dd>
+          <dd class=collapse>{id}</dd>
           .*
           <dt>delegate</dt>
           <dd><a href=/inscription/{delegate}>{delegate}</a></dd>

--- a/src/templates/address.rs
+++ b/src/templates/address.rs
@@ -87,7 +87,7 @@ mod tests {
   #[test]
   fn test_outputs_rendering() {
     let address_html = setup();
-    let expected_pattern = r#".*<dt>outputs</dt>\n\s*<dd>\n\s*<ul>\n\s*<li><a class=monospace href=/output/1{64}:1>1{64}:1</a></li>\n\s*<li><a class=monospace href=/output/2{64}:2>2{64}:2</a></li>\n\s*</ul>\n\s*</dd>.*"#;
+    let expected_pattern = r#".*<dt>outputs</dt>\n\s*<dd>\n\s*<ul>\n\s*<li><a class=collapse href=/output/1{64}:1>1{64}:1</a></li>\n\s*<li><a class=collapse href=/output/2{64}:2>2{64}:2</a></li>\n\s*</ul>\n\s*</dd>.*"#;
     assert_regex_match!(address_html, expected_pattern);
   }
 }

--- a/src/templates/block.rs
+++ b/src/templates/block.rs
@@ -58,8 +58,8 @@ mod tests {
       "
         <h1>Block 0</h1>
         <dl>
-          <dt>hash</dt><dd class=monospace>[[:xdigit:]]{64}</dd>
-          <dt>target</dt><dd class=monospace>[[:xdigit:]]{64}</dd>
+          <dt>hash</dt><dd class=collapse>[[:xdigit:]]{64}</dd>
+          <dt>target</dt><dd class=collapse>[[:xdigit:]]{64}</dd>
           <dt>timestamp</dt><dd><time>2009-01-03 18:15:05 UTC</time></dd>
           <dt>size</dt><dd>285</dd>
           <dt>weight</dt><dd>1140</dd>
@@ -74,7 +74,7 @@ mod tests {
         </div>
         <h2>1 Transaction</h2>
         <ul>
-          <li><a class=monospace href=/tx/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>
+          <li><a class=collapse href=/tx/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>
         </ul>
       "
       .unindent()

--- a/src/templates/blocks.rs
+++ b/src/templates/blocks.rs
@@ -79,8 +79,8 @@ mod tests {
         </div>
       </div>
       <ol start=1260001 reversed class=block-list>
-        <li><a class=monospace href=/block/1{64}>1{64}</a></li>
-        <li><a class=monospace href=/block/0{64}>0{64}</a></li>
+        <li><a class=collapse href=/block/1{64}>1{64}</a></li>
+        <li><a class=collapse href=/block/0{64}>0{64}</a></li>
       </ol>
       "
       .unindent(),

--- a/src/templates/input.rs
+++ b/src/templates/input.rs
@@ -39,7 +39,7 @@ mod tests {
       "
       <h1>Input /1/2/3</h1>
       <dl>
-        <dt>previous output</dt><dd class=monospace>0000000000000000000000000000000000000000000000000000000000000000:0</dd>
+        <dt>previous output</dt><dd class=collapse>0000000000000000000000000000000000000000000000000000000000000000:0</dd>
         <dt>witness</dt><dd class=monospace>010101</dd>
         <dt>script sig</dt><dd class=monospace>OP_PUSHBYTES_3 666f6f</dd>
         <dt>text</dt><dd>\x03foo</dd>

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -51,7 +51,7 @@ mod tests {
         </div>
         <dl>
           <dt>id</dt>
-          <dd class=monospace>1{64}i1</dd>
+          <dd class=collapse>1{64}i1</dd>
           <dt>preview</dt>
           <dd><a href=/preview/1{64}i1>link</a></dd>
           <dt>content</dt>
@@ -67,15 +67,15 @@ mod tests {
           <dt>fee</dt>
           <dd>1</dd>
           <dt>reveal transaction</dt>
-          <dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
+          <dd><a class=collapse href=/tx/1{64}>1{64}</a></dd>
           <dt>location</dt>
-          <dd><a class=monospace href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>
+          <dd><a class=collapse href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>
           <dt>output</dt>
-          <dd><a class=monospace href=/output/1{64}:1>1{64}:1</a></dd>
+          <dd><a class=collapse href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
           <dt>ethereum teleburn address</dt>
-          <dd class=monospace>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
+          <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
       "
       .unindent()
@@ -104,7 +104,7 @@ mod tests {
         <dl>
           .*
           <dt>address</dt>
-          <dd><a class=monospace href=/address/bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</a></dd>
+          <dd><a class=collapse href=/address/bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</a></dd>
           <dt>value</dt>
           <dd>1</dd>
           .*
@@ -194,9 +194,9 @@ mod tests {
         <dl>
           .*
           <dt>location</dt>
-          <dd><a class=monospace href=/satpoint/0{64}:0:0>0{64}:0:0</a></dd>
+          <dd><a class=collapse href=/satpoint/0{64}:0:0>0{64}:0:0</a></dd>
           <dt>output</dt>
-          <dd><a class=monospace href=/output/0{64}:0>0{64}:0</a></dd>
+          <dd><a class=collapse href=/output/0{64}:0>0{64}:0</a></dd>
           .*
         </dl>
       "
@@ -234,7 +234,7 @@ mod tests {
             </div>
           </dd>
           <dt>id</dt>
-          <dd class=monospace>1{64}i1</dd>
+          <dd class=collapse>1{64}i1</dd>
           <dt>preview</dt>
           <dd><a href=/preview/1{64}i1>link</a></dd>
           <dt>content</dt>
@@ -250,15 +250,15 @@ mod tests {
           <dt>fee</dt>
           <dd>1</dd>
           <dt>reveal transaction</dt>
-          <dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
+          <dd><a class=collapse href=/tx/1{64}>1{64}</a></dd>
           <dt>location</dt>
-          <dd><a class=monospace href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>
+          <dd><a class=collapse href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>
           <dt>output</dt>
-          <dd><a class=monospace href=/output/1{64}:1>1{64}:1</a></dd>
+          <dd><a class=collapse href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
           <dt>ethereum teleburn address</dt>
-          <dd class=monospace>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
+          <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
 "
       .unindent()
@@ -297,7 +297,7 @@ mod tests {
             </div>
           </dd>
           <dt>id</dt>
-          <dd class=monospace>1{64}i1</dd>
+          <dd class=collapse>1{64}i1</dd>
           <dt>preview</dt>
           <dd><a href=/preview/1{64}i1>link</a></dd>
           <dt>content</dt>
@@ -313,15 +313,15 @@ mod tests {
           <dt>fee</dt>
           <dd>1</dd>
           <dt>reveal transaction</dt>
-          <dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
+          <dd><a class=collapse href=/tx/1{64}>1{64}</a></dd>
           <dt>location</dt>
-          <dd><a class=monospace href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>
+          <dd><a class=collapse href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>
           <dt>output</dt>
-          <dd><a class=monospace href=/output/1{64}:1>1{64}:1</a></dd>
+          <dd><a class=collapse href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
           <dt>ethereum teleburn address</dt>
-          <dd class=monospace>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
+          <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
       "
       .unindent()
@@ -359,7 +359,7 @@ mod tests {
             </div>
           </dd>
           <dt>id</dt>
-          <dd class=monospace>1{64}i1</dd>
+          <dd class=collapse>1{64}i1</dd>
           <dt>preview</dt>
           <dd><a href=/preview/1{64}i1>link</a></dd>
           <dt>content</dt>
@@ -375,15 +375,15 @@ mod tests {
           <dt>fee</dt>
           <dd>1</dd>
           <dt>reveal transaction</dt>
-          <dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
+          <dd><a class=collapse href=/tx/1{64}>1{64}</a></dd>
           <dt>location</dt>
-          <dd><a class=monospace href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>
+          <dd><a class=collapse href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>
           <dt>output</dt>
-          <dd><a class=monospace href=/output/1{64}:1>1{64}:1</a></dd>
+          <dd><a class=collapse href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
           <dt>ethereum teleburn address</dt>
-          <dd class=monospace>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
+          <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
       "
       .unindent()

--- a/src/templates/output.rs
+++ b/src/templates/output.rs
@@ -41,8 +41,8 @@ mod tests {
         <dl>
           <dt>value</dt><dd>3</dd>
           <dt>script pubkey</dt><dd class=monospace>OP_DUP OP_HASH160 OP_PUSHBYTES_20 0{40} OP_EQUALVERIFY OP_CHECKSIG</dd>
-          <dt>address</dt><dd><a class=monospace href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
-          <dt>transaction</dt><dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
+          <dt>address</dt><dd><a class=collapse href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
+          <dt>transaction</dt><dd><a class=collapse href=/tx/1{64}>1{64}</a></dd>
           <dt>spent</dt><dd>false</dd>
         </dl>
         <h2>2 Sat Ranges</h2>
@@ -75,7 +75,7 @@ mod tests {
         <dl>
           <dt>value</dt><dd>1</dd>
           <dt>script pubkey</dt><dd class=monospace>OP_0</dd>
-          <dt>transaction</dt><dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
+          <dt>transaction</dt><dd><a class=collapse href=/tx/1{64}>1{64}</a></dd>
           <dt>spent</dt><dd>true</dd>
         </dl>
       "
@@ -100,8 +100,8 @@ mod tests {
         <dl>
           <dt>value</dt><dd>3</dd>
           <dt>script pubkey</dt><dd class=monospace>OP_DUP OP_HASH160 OP_PUSHBYTES_20 0{40} OP_EQUALVERIFY OP_CHECKSIG</dd>
-          <dt>address</dt><dd><a class=monospace href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
-          <dt>transaction</dt><dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
+          <dt>address</dt><dd><a class=collapse href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
+          <dt>transaction</dt><dd><a class=collapse href=/tx/1{64}>1{64}</a></dd>
           <dt>spent</dt><dd>true</dd>
         </dl>
         <h2>2 Sat Ranges</h2>
@@ -132,8 +132,8 @@ mod tests {
         <dl>
           <dt>value</dt><dd>3</dd>
           <dt>script pubkey</dt><dd class=monospace>OP_DUP OP_HASH160 OP_PUSHBYTES_20 0{40} OP_EQUALVERIFY OP_CHECKSIG</dd>
-          <dt>address</dt><dd><a class=monospace href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
-          <dt>transaction</dt><dd><a class=monospace href=/tx/1{64}>1{64}</a></dd>
+          <dt>address</dt><dd><a class=collapse href=/address/1111111111111111111114oLvT2>1111111111111111111114oLvT2</a></dd>
+          <dt>transaction</dt><dd><a class=collapse href=/tx/1{64}>1{64}</a></dd>
           <dt>spent</dt><dd>false</dd>
         </dl>
       "

--- a/src/templates/rune.rs
+++ b/src/templates/rune.rs
@@ -122,9 +122,9 @@ mod tests {
   <dt>turbo</dt>
   <dd>true</dd>
   <dt>etching</dt>
-  <dd><a class=monospace href=/tx/0{64}>0{64}</a></dd>
+  <dd><a class=collapse href=/tx/0{64}>0{64}</a></dd>
   <dt>parent</dt>
-  <dd><a class=monospace href=/inscription/0{64}i0>0{64}i0</a></dd>
+  <dd><a class=collapse href=/inscription/0{64}i0>0{64}i0</a></dd>
 </dl>
 "
     );

--- a/src/templates/sat.rs
+++ b/src/templates/sat.rs
@@ -171,7 +171,7 @@ mod tests {
         blocktime: Blocktime::confirmed(0),
         inscriptions: Vec::new(),
       },
-      "<h1>Sat 0</h1>.*<dt>location</dt><dd><a class=monospace href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>.*",
+      "<h1>Sat 0</h1>.*<dt>location</dt><dd><a class=collapse href=/satpoint/1{64}:1:0>1{64}:1:0</a></dd>.*",
     );
   }
 }

--- a/src/templates/transaction.rs
+++ b/src/templates/transaction.rs
@@ -59,12 +59,12 @@ mod tests {
         </dl>
         <h2>1 Input</h2>
         <ul>
-          <li><a class=monospace href=/output/0000000000000000000000000000000000000000000000000000000000000000:4294967295>0000000000000000000000000000000000000000000000000000000000000000:4294967295</a></li>
+          <li><a class=collapse href=/output/0000000000000000000000000000000000000000000000000000000000000000:4294967295>0000000000000000000000000000000000000000000000000000000000000000:4294967295</a></li>
         </ul>
         <h2>2 Outputs</h2>
         <ul class=monospace>
           <li>
-            <a href=/output/{txid}:0 class=monospace>
+            <a href=/output/{txid}:0 class=collapse>
               {txid}:0
             </a>
             <dl>
@@ -73,7 +73,7 @@ mod tests {
             </dl>
           </li>
           <li>
-            <a href=/output/{txid}:1 class=monospace>
+            <a href=/output/{txid}:1 class=collapse>
               {txid}:1
             </a>
             <dl>

--- a/static/index.css
+++ b/static/index.css
@@ -139,6 +139,10 @@ ol, ul {
   text-align: center;
 }
 
+.collapse {
+  font-family: monospace, monospace;
+}
+
 .monospace {
   font-family: monospace, monospace;
 }

--- a/static/index.css
+++ b/static/index.css
@@ -141,6 +141,7 @@ ol, ul {
 
 .collapse {
   font-family: monospace, monospace;
+  user-select: all;
 }
 
 .monospace {
@@ -269,8 +270,4 @@ a.mythic {
 .icon {
   height: 1rem;
   width: 1rem;
-}
-
-[data-original]:not(a) {
-  user-select: all;
 }

--- a/static/index.css
+++ b/static/index.css
@@ -141,6 +141,9 @@ ol, ul {
 
 .collapse {
   font-family: monospace, monospace;
+}
+
+.collapse:not(a) {
   user-select: all;
 }
 

--- a/static/index.js
+++ b/static/index.js
@@ -36,14 +36,13 @@ addEventListener("DOMContentLoaded", () => {
 
   let collapse = document.getElementsByClassName('collapse');
 
-  for (let node of collapse) {
-    node.dataset.original = node.textContent.trim();
-  }
-
   let context = document.createElement('canvas').getContext('2d');
 
   function resize() {
     for (let node of collapse) {
+      if (!('original' in node.dataset)) {
+        node.dataset.original = node.textContent.trim();
+      }
       let original = node.dataset.original;
       let length = original.length;
       let width = node.clientWidth;

--- a/static/index.js
+++ b/static/index.js
@@ -34,47 +34,11 @@ addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  let collapse = [];
+  let collapse = document.getElementsByClassName('collapse');
 
-  const PATTERNS = [
-    // hash
-    '[a-f0-9]{64}',
-    // outpoint
-    '[a-f0-9]{64}:[0-9]+',
-    // satpoint
-    '[a-f0-9]{64}:[0-9]+:[0-9]+',
-    // ethereum address
-    '0x[A-Fa-f0-9]{40}',
-    // inscription id
-    '[a-f0-9]{64}i[0-9]+',
-    // p2pkh address
-    '1[a-km-zA-HJ-NP-Z1-9]{25,33}',
-    // p2wpkh address
-    '(bc|bcrt|tb)1q[02-9ac-hj-np-z]{38}',
-    // p2wsh address
-    '(bc|bcrt|tb)1q[02-9ac-hj-np-z]{46}',
-    // p2tr address
-    '(bc|bcrt|tb)1p[02-9ac-hj-np-z]{58}',
-    // git hash
-    '[a-f0-9]{40}'
-  ]
-
-  let RE = new RegExp('^(' + PATTERNS.map((p) => '(' + p + ')').join('|') + ')$');
-
-  document.querySelectorAll('.monospace').forEach((node) => {
-    if (node.children.length > 0 || node.parentNode.tagName === 'H1') {
-      return;
-    }
-
-    let text = node.textContent.trim();
-
-    if (!RE.test(text)) {
-      return;
-    }
-
-    node.dataset.original = text;
-    collapse.push(node);
-  });
+  for (let node of collapse) {
+    node.dataset.original = node.textContent.trim();
+  }
 
   let context = document.createElement('canvas').getContext('2d');
 

--- a/templates/address.html
+++ b/templates/address.html
@@ -22,7 +22,7 @@
   <dd>
     <ul>
 %% for output in self.outputs.iter() {
-      <li><a class=monospace href=/output/{{ output }}>{{ output }}</a></li>
+      <li><a class=collapse href=/output/{{ output }}>{{ output }}</a></li>
 %% }
     </ul>
   </dd>

--- a/templates/block.html
+++ b/templates/block.html
@@ -1,12 +1,12 @@
 <h1>Block {{ self.height }}</h1>
 <dl>
-  <dt>hash</dt><dd class=monospace>{{self.hash}}</dd>
-  <dt>target</dt><dd class=monospace>{{self.target}}</dd>
+  <dt>hash</dt><dd class=collapse>{{self.hash}}</dd>
+  <dt>target</dt><dd class=collapse>{{self.target}}</dd>
   <dt>timestamp</dt><dd><time>{{timestamp(self.block.header.time.into())}}</time></dd>
   <dt>size</dt><dd>{{self.block.total_size()}}</dd>
   <dt>weight</dt><dd>{{self.block.weight()}}</dd>
 %% if self.height.0 > 0 {
-  <dt>previous blockhash</dt><dd><a href=/block/{{self.block.header.prev_blockhash}} class=monospace>{{self.block.header.prev_blockhash}}</a></dd>
+  <dt>previous blockhash</dt><dd><a href=/block/{{self.block.header.prev_blockhash}} class=collapse>{{self.block.header.prev_blockhash}}</a></dd>
 %% }
 </dl>
 <div class=center>
@@ -44,6 +44,6 @@ next
 <ul>
 %% for tx in &self.block.txdata {
 %% let txid = tx.txid();
-  <li><a class=monospace href=/tx/{{txid}}>{{txid}}</a></li>
+  <li><a class=collapse href=/tx/{{txid}}>{{txid}}</a></li>
 %% }
 </ul>

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -13,7 +13,7 @@
 %% if i == self.featured_blocks.len() {
 <ol start={{ self.last - self.featured_blocks.len() as u32 }} reversed class=block-list>
 %% }
-  <li><a class=monospace href=/block/{{ hash }}>{{ hash }}</a></li>
+  <li><a class=collapse href=/block/{{ hash }}>{{ hash }}</a></li>
 %% }
 %% }
 </ol>

--- a/templates/input.html
+++ b/templates/input.html
@@ -1,7 +1,7 @@
 <h1>Input /{{self.path.0}}/{{self.path.1}}/{{self.path.2}}</h1>
 <dl>
 %% if !self.input.previous_output.is_null() {
-  <dt>previous output</dt><dd class=monospace>{{self.input.previous_output}}</dd>
+  <dt>previous output</dt><dd class=collapse>{{self.input.previous_output}}</dd>
 %% }
 %% if self.input.sequence != Sequence::MAX {
   <dt>sequence</dt><dd>{{self.input.sequence}}</dd>

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -44,7 +44,7 @@
   <dd><a href=/rune/{{ rune }}>{{ rune }}</a></dd>
 %% }
   <dt>id</dt>
-  <dd class=monospace>{{ self.id }}</dd>
+  <dd class=collapse>{{ self.id }}</dd>
 %% if self.charms != 0 {
   <dt>charms</dt>
   <dd>
@@ -64,7 +64,7 @@
 %% if let Some(output) = &self.output {
 %% if let Ok(address) = self.chain.address_from_script(&output.script_pubkey ) {
   <dt>address</dt>
-  <dd><a class=monospace href=/address/{{address}}>{{ address }}</a></dd>
+  <dd><a class=collapse href=/address/{{address}}>{{ address }}</a></dd>
 %% }
   <dt>value</dt>
   <dd>{{ output.value.to_sat() }}</dd>
@@ -108,13 +108,13 @@
   <dt>fee</dt>
   <dd>{{ self.fee }}</dd>
   <dt>reveal transaction</dt>
-  <dd><a class=monospace href=/tx/{{ self.id.txid }}>{{ self.id.txid }}</a></dd>
+  <dd><a class=collapse href=/tx/{{ self.id.txid }}>{{ self.id.txid }}</a></dd>
   <dt>location</dt>
-  <dd><a class=monospace href=/satpoint/{{ self.satpoint }}>{{ self.satpoint }}</a></dd>
+  <dd><a class=collapse href=/satpoint/{{ self.satpoint }}>{{ self.satpoint }}</a></dd>
   <dt>output</dt>
-  <dd><a class=monospace href=/output/{{ self.satpoint.outpoint }}>{{ self.satpoint.outpoint }}</a></dd>
+  <dd><a class=collapse href=/output/{{ self.satpoint.outpoint }}>{{ self.satpoint.outpoint }}</a></dd>
   <dt>offset</dt>
   <dd>{{ self.satpoint.offset }}</dd>
   <dt>ethereum teleburn address</dt>
-  <dd class=monospace>{{ teleburn::Ethereum::from(self.id) }}</dd>
+  <dd class=collapse>{{ teleburn::Ethereum::from(self.id) }}</dd>
 </dl>

--- a/templates/output.html
+++ b/templates/output.html
@@ -28,9 +28,9 @@
   <dt>value</dt><dd>{{ self.output.value.to_sat() }}</dd>
   <dt>script pubkey</dt><dd class=monospace>{{ self.output.script_pubkey.to_asm_string() }}</dd>
 %% if let Ok(address) = self.chain.address_from_script(&self.output.script_pubkey ) {
-  <dt>address</dt><dd><a class=monospace href=/address/{{address}}>{{ address }}</a></dd>
+  <dt>address</dt><dd><a class=collapse href=/address/{{address}}>{{ address }}</a></dd>
 %% }
-  <dt>transaction</dt><dd><a class=monospace href=/tx/{{ self.outpoint.txid }}>{{ self.outpoint.txid }}</a></dd>
+  <dt>transaction</dt><dd><a class=collapse href=/tx/{{ self.outpoint.txid }}>{{ self.outpoint.txid }}</a></dd>
   <dt>spent</dt><dd>{{ self.spent }}</dd>
 </dl>
 %% if let Some(sat_ranges) = &self.sat_ranges {

--- a/templates/rune-balances.html
+++ b/templates/rune-balances.html
@@ -12,9 +12,9 @@
 %% for (outpoint, balance) in balances {
         <tr>
           <td>
-            <a class=monospace href=/output/{{ outpoint }}>{{ outpoint }}</a>
+            <a class=collapse href=/output/{{ outpoint }}>{{ outpoint }}</a>
           </td>
-          <td class=monospace>
+          <td class=collapse>
             {{ balance }}
           </td>
         </tr>

--- a/templates/rune.html
+++ b/templates/rune.html
@@ -71,9 +71,9 @@
   <dt>turbo</dt>
   <dd>{{ self.entry.turbo }}</dd>
   <dt>etching</dt>
-  <dd><a class=monospace href=/tx/{{ self.entry.etching }}>{{ self.entry.etching }}</a></dd>
+  <dd><a class=collapse href=/tx/{{ self.entry.etching }}>{{ self.entry.etching }}</a></dd>
 %% if let Some(parent) = self.parent {
   <dt>parent</dt>
-  <dd><a class=monospace href=/inscription/{{ parent }}>{{ parent }}</a></dd>
+  <dd><a class=collapse href=/inscription/{{ parent }}>{{ parent }}</a></dd>
 %% }
 </dl>

--- a/templates/sat.html
+++ b/templates/sat.html
@@ -31,7 +31,7 @@
   </dd>
 %% }
 %% if let Some(satpoint) = self.satpoint {
-  <dt>location</dt><dd><a class=monospace href=/satpoint/{{ satpoint }}>{{ satpoint }}</a></dd>
+  <dt>location</dt><dd><a class=collapse href=/satpoint/{{ satpoint }}>{{ satpoint }}</a></dd>
 %% }
 </dl>
 <div class=center>

--- a/templates/status.html
+++ b/templates/status.html
@@ -47,7 +47,7 @@
 %% if !env!("GIT_COMMIT").is_empty() {
   <dt>git commit</dt>
   <dd>
-    <a class=monospace href=https://github.com/ordinals/ord/commit/{{ env!("GIT_COMMIT") }}>
+    <a class=collapse href=https://github.com/ordinals/ord/commit/{{ env!("GIT_COMMIT") }}>
       {{ env!("GIT_COMMIT") }}
     </a>
   </dd>

--- a/templates/transaction.html
+++ b/templates/transaction.html
@@ -16,7 +16,7 @@
 <h2>{{"Input".tally(self.transaction.input.len())}}</h2>
 <ul>
 %% for input in &self.transaction.input {
-  <li><a class=monospace href=/output/{{input.previous_output}}>{{input.previous_output}}</a></li>
+  <li><a class=collapse href=/output/{{input.previous_output}}>{{input.previous_output}}</a></li>
 %% }
 </ul>
 <h2>{{"Output".tally(self.transaction.output.len())}}</h2>
@@ -24,14 +24,14 @@
 %% for (vout, output) in self.transaction.output.iter().enumerate() {
 %% let outpoint = OutPoint::new(self.txid, vout as u32);
   <li>
-    <a href=/output/{{outpoint}} class=monospace>
+    <a href=/output/{{outpoint}} class=collapse>
       {{ outpoint }}
     </a>
     <dl>
       <dt>value</dt><dd>{{ output.value.to_sat() }}</dd>
       <dt>script pubkey</dt><dd class=monospace>{{ output.script_pubkey.to_asm_string() }}</dd>
 %% if let Ok(address) = self.chain.address_from_script(&output.script_pubkey) {
-      <dt>address</dt><dd><a class=monospace href=/address/{{address}}>{{ address }}</a></dd>
+      <dt>address</dt><dd><a class=collapse href=/address/{{address}}>{{ address }}</a></dd>
 %% }
     </dl>
   </li>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -368,9 +368,9 @@ fn batch(core: &mockcore::Handle, ord: &TestServer, batchfile: batch::File) -> E
   <dt>turbo</dt>
   <dd>{turbo}</dd>
   <dt>etching</dt>
-  <dd><a class=monospace href=/tx/{reveal}>{reveal}</a></dd>
+  <dd><a class=collapse href=/tx/{reveal}>{reveal}</a></dd>
   <dt>parent</dt>
-  <dd><a class=monospace href=/inscription/{parent}>{parent}</a></dd>
+  <dd><a class=collapse href=/inscription/{parent}>{parent}</a></dd>
 .*",
       mint_definition.join("\\s+"),
     ),

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -54,7 +54,7 @@ fn address_page_shows_outputs_and_sat_balance() {
   ord.assert_response_regex(
     format!("/address/{address}"),
     format!(
-      ".*<h1>Address {address}</h1>.*<dd>200000000</dd>.*<a class=monospace href=/output/{}.*",
+      ".*<h1>Address {address}</h1>.*<dd>200000000</dd>.*<a class=collapse href=/output/{}.*",
       OutPoint {
         txid: send.txid,
         vout: 0
@@ -248,9 +248,9 @@ fn inscription_page() {
 .*<iframe .* src=/preview/{inscription}></iframe>.*
 <dl>
   <dt>id</dt>
-  <dd class=monospace>{inscription}</dd>
+  <dd class=collapse>{inscription}</dd>
   <dt>address</dt>
-  <dd><a class=monospace href=/address/bc1.*>bc1.*</a></dd>
+  <dd><a class=collapse href=/address/bc1.*>bc1.*</a></dd>
   <dt>value</dt>
   <dd>10000</dd>
   <dt>preview</dt>
@@ -268,15 +268,15 @@ fn inscription_page() {
   <dt>fee</dt>
   <dd>138</dd>
   <dt>reveal transaction</dt>
-  <dd><a class=monospace href=/tx/{reveal}>{reveal}</a></dd>
+  <dd><a class=collapse href=/tx/{reveal}>{reveal}</a></dd>
   <dt>location</dt>
-  <dd><a class=monospace href=/satpoint/{reveal}:0:0>{reveal}:0:0</a></dd>
+  <dd><a class=collapse href=/satpoint/{reveal}:0:0>{reveal}:0:0</a></dd>
   <dt>output</dt>
-  <dd><a class=monospace href=/output/{reveal}:0>{reveal}:0</a></dd>
+  <dd><a class=collapse href=/output/{reveal}:0>{reveal}:0</a></dd>
   <dt>offset</dt>
   <dd>0</dd>
   <dt>ethereum teleburn address</dt>
-  <dd class=monospace>{ethereum_teleburn_address}</dd>
+  <dd class=collapse>{ethereum_teleburn_address}</dd>
 </dl>.*",
     ),
   );
@@ -362,7 +362,7 @@ fn inscription_page_after_send() {
   ord.assert_response_regex(
     format!("/inscription/{inscription}"),
     format!(
-      r".*<h1>Inscription 0</h1>.*<dt>location</dt>\s*<dd><a class=monospace href=/satpoint/{reveal}:0:0>{reveal}:0:0</a></dd>.*",
+      r".*<h1>Inscription 0</h1>.*<dt>location</dt>\s*<dd><a class=collapse href=/satpoint/{reveal}:0:0>{reveal}:0:0</a></dd>.*",
     ),
   );
 
@@ -380,7 +380,7 @@ fn inscription_page_after_send() {
   ord.assert_response_regex(
     format!("/inscription/{inscription}"),
     format!(
-      r".*<h1>Inscription 0</h1>.*<dt>address</dt>\s*<dd><a class=monospace href=/address/bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv>bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv</a></dd>.*<dt>location</dt>\s*<dd><a class=monospace href=/satpoint/{txid}:0:0>{txid}:0:0</a></dd>.*",
+      r".*<h1>Inscription 0</h1>.*<dt>address</dt>\s*<dd><a class=collapse href=/address/bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv>bc1qcqgs2pps4u4yedfyl5pysdjjncs8et5utseepv</a></dd>.*<dt>location</dt>\s*<dd><a class=collapse href=/satpoint/{txid}:0:0>{txid}:0:0</a></dd>.*",
     ),
   )
 }

--- a/tests/wallet/batch_command.rs
+++ b/tests/wallet/batch_command.rs
@@ -682,7 +682,7 @@ inscriptions:
     format!("/inscription/{}", output.inscriptions[0].id),
     ".*
   <dt>address</dt>
-  <dd><a class=monospace href=/address/bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</a></dd>.*",
+  <dd><a class=collapse href=/address/bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4>bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4</a></dd>.*",
   );
 
   ord.assert_response_regex(
@@ -690,7 +690,7 @@ inscriptions:
     format!(
       ".*
   <dt>address</dt>
-  <dd><a class=monospace href=/address/{0}>{0}</a></dd>.*",
+  <dd><a class=collapse href=/address/{0}>{0}</a></dd>.*",
       core.state().change_addresses[0],
     ),
   );
@@ -699,7 +699,7 @@ inscriptions:
     format!("/inscription/{}", output.inscriptions[2].id),
     ".*
   <dt>address</dt>
-  <dd><a class=monospace href=/address/bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k>bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k</a></dd>.*",
+  <dd><a class=collapse href=/address/bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k>bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k</a></dd>.*",
   );
 }
 
@@ -1529,7 +1529,7 @@ fn batch_can_etch_rune() {
   ord.assert_response_regex(
     "/rune/AAAAAAAAAAAAA",
     format!(
-      r".*\s*<dt>turbo</dt>\s*<dd>false</dd>.*<dt>parent</dt>\s*<dd><a class=monospace href=/inscription/{parent}>{parent}</a></dd>.*"
+      r".*\s*<dt>turbo</dt>\s*<dd>false</dd>.*<dt>parent</dt>\s*<dd><a class=collapse href=/inscription/{parent}>{parent}</a></dd>.*"
     ),
   );
 
@@ -1630,7 +1630,7 @@ fn batch_can_etch_turbo_rune() {
   ord.assert_response_regex(
     "/rune/AAAAAAAAAAAAA",
     format!(
-      r".*\s*<dt>turbo</dt>\s*<dd>true</dd>.*<dt>parent</dt>\s*<dd><a class=monospace href=/inscription/{parent}>{parent}</a></dd>.*"
+      r".*\s*<dt>turbo</dt>\s*<dd>true</dd>.*<dt>parent</dt>\s*<dd><a class=collapse href=/inscription/{parent}>{parent}</a></dd>.*"
     ),
   );
 }
@@ -1692,7 +1692,7 @@ fn batch_can_etch_rune_without_premine() {
   ord.assert_response_regex(
     "/rune/AAAAAAAAAAAAA",
     format!(
-      r".*<dt>parent</dt>\s*<dd><a class=monospace href=/inscription/{parent}>{parent}</a></dd>.*"
+      r".*<dt>parent</dt>\s*<dd><a class=collapse href=/inscription/{parent}>{parent}</a></dd>.*"
     ),
   );
 
@@ -1778,7 +1778,7 @@ fn batch_inscribe_can_etch_rune_with_offset() {
   ord.assert_response_regex(
     "/rune/AAAAAAAAAAAAA",
     format!(
-      r".*<dt>parent</dt>\s*<dd><a class=monospace href=/inscription/{parent}>{parent}</a></dd>.*"
+      r".*<dt>parent</dt>\s*<dd><a class=collapse href=/inscription/{parent}>{parent}</a></dd>.*"
     ),
   );
 
@@ -1852,7 +1852,7 @@ fn batch_inscribe_can_etch_rune_with_height() {
   ord.assert_response_regex(
     "/rune/AAAAAAAAAAAAA",
     format!(
-      r".*<dt>parent</dt>\s*<dd><a class=monospace href=/inscription/{parent}>{parent}</a></dd>.*"
+      r".*<dt>parent</dt>\s*<dd><a class=collapse href=/inscription/{parent}>{parent}</a></dd>.*"
     ),
   );
 

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -39,7 +39,7 @@ fn inscriptions_can_be_sent() {
   <dd>text/plain;charset=utf-8</dd>
   .*
   <dt>location</dt>
-  <dd><a class=monospace href=/satpoint/{send_txid}:0:0>{send_txid}:0:0</a></dd>
+  <dd><a class=collapse href=/satpoint/{send_txid}:0:0>{send_txid}:0:0</a></dd>
   .*
 </dl>
 .*",
@@ -153,7 +153,7 @@ fn send_inscription_by_sat() {
   ord.assert_response_regex(
     format!("/inscription/{inscription}"),
     format!(
-      ".*<h1>Inscription 0</h1>.*<dt>address</dt>.*<dd><a class=monospace href=/address/{address}>{address}</a></dd>.*<dt>location</dt>.*<dd><a class=monospace href=/satpoint/{send_txid}:0:0>{send_txid}:0:0</a></dd>.*",
+      ".*<h1>Inscription 0</h1>.*<dt>address</dt>.*<dd><a class=collapse href=/address/{address}>{address}</a></dd>.*<dt>location</dt>.*<dd><a class=collapse href=/satpoint/{send_txid}:0:0>{send_txid}:0:0</a></dd>.*",
     ),
   );
 }


### PR DESCRIPTION
Instead of identifying collapsible with `class=collapse`, instead of with a regular expression.

This is faster, simpler, and less error prone. Going forward, any elements which should be collapsable should get this class. Things like addresses, any kind of hash, outpoints, and satpoints, should be collapsable.