### PR TITLE
Add assert_html function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,10 +76,10 @@ urlencoding = "2.1.3"
 [dev-dependencies]
 criterion = "0.5.1"
 executable-path = "1.0.0"
+mockcore = { path = "crates/mockcore" }
 nix = { version = "0.29.0", features = ["signal"] }
 pretty_assertions = "1.2.1"
 reqwest = { version = "0.11.27", features = ["blocking", "brotli", "json"] }
-mockcore = { path = "crates/mockcore" }
 unindent = "0.2.1"
 
 [[bin]]

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -2494,7 +2494,7 @@ mod tests {
         Arc::new(ServerConfig {
           chain: Chain::Regtest,
           domain: Some(System::host_name().unwrap()),
-          ..ServerConfig::default()
+          ..Default::default()
         }),
       )
       .to_string();

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -427,8 +427,6 @@ impl Server {
   fn acme_domains(&self) -> Result<Vec<String>> {
     if !self.acme_domain.is_empty() {
       Ok(self.acme_domain.clone())
-    } else if cfg!(test) {
-      Ok(vec!["ordinals.com".into()])
     } else {
       Ok(vec![
         System::host_name().ok_or(anyhow!("no hostname found"))?
@@ -2495,6 +2493,7 @@ mod tests {
         content,
         Arc::new(ServerConfig {
           chain: Chain::Regtest,
+          domain: Some(System::host_name().unwrap()),
           ..ServerConfig::default()
         }),
       )

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -427,6 +427,8 @@ impl Server {
   fn acme_domains(&self) -> Result<Vec<String>> {
     if !self.acme_domain.is_empty() {
       Ok(self.acme_domain.clone())
+    } else if cfg!(test) {
+      Ok(vec!["ordinals.com".into()])
     } else {
       Ok(vec![
         System::host_name().ok_or(anyhow!("no hostname found"))?
@@ -2478,6 +2480,29 @@ mod tests {
       assert_regex_match!(response.text().unwrap(), regex.as_ref());
     }
 
+    #[track_caller]
+    fn assert_html(&self, path: impl AsRef<str>, content: impl PageContent) {
+      let response = self.get(path);
+
+      assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "{}",
+        response.text().unwrap()
+      );
+
+      let expected_response = PageHtml::new(
+        content,
+        Arc::new(ServerConfig {
+          chain: Chain::Regtest,
+          ..ServerConfig::default()
+        }),
+      )
+      .to_string();
+
+      pretty_assert_eq!(response.text().unwrap(), expected_response);
+    }
+
     fn assert_response_csp(
       &self,
       path: impl AsRef<str>,
@@ -3084,10 +3109,14 @@ mod tests {
 
     server.mine_blocks(1);
 
-    server.assert_response_regex(
+    server.assert_html(
       "/runes",
-      StatusCode::OK,
-      ".*<title>Runes</title>.*<h1>Runes</h1>\n<ul>\n</ul>\n<div class=center>\n    prev\n      next\n  </div>.*",
+      RunesHtml {
+        entries: Vec::new(),
+        more: false,
+        prev: None,
+        next: None,
+      },
     );
 
     let (txid, id) = server.etch(
@@ -3133,14 +3162,23 @@ mod tests {
       [(OutPoint { txid, vout: 0 }, vec![(id, u128::MAX)])]
     );
 
-    server.assert_response_regex(
+    server.assert_html(
       "/runes",
-      StatusCode::OK,
-      ".*<title>Runes</title>.*
-<h1>Runes</h1>
-<ul>
-  <li><a href=/rune/AAAAAAAAAAAAA>AAAAAAAAAAAAA</a></li>
-</ul>.*",
+      RunesHtml {
+        entries: vec![(
+          RuneId::default(),
+          RuneEntry {
+            spaced_rune: SpacedRune {
+              rune: Rune(RUNE),
+              spacers: 0,
+            },
+            ..default()
+          },
+        )],
+        more: false,
+        prev: None,
+        next: None,
+      },
     );
   }
 
@@ -3185,73 +3223,38 @@ mod tests {
       ),
     );
 
-    assert_eq!(
-      server.index.runes().unwrap(),
-      [(
-        id,
-        RuneEntry {
-          block: id.block,
-          etching: txid,
-          spaced_rune: SpacedRune { rune, spacers: 0 },
-          premine: u128::MAX,
-          symbol: Some('%'),
-          timestamp: id.block,
-          turbo: true,
-          ..default()
-        }
-      )]
-    );
+    let entry = RuneEntry {
+      block: id.block,
+      etching: txid,
+      spaced_rune: SpacedRune { rune, spacers: 0 },
+      premine: u128::MAX,
+      symbol: Some('%'),
+      timestamp: id.block,
+      turbo: true,
+      ..default()
+    };
+
+    assert_eq!(server.index.runes().unwrap(), [(id, entry)]);
 
     assert_eq!(
       server.index.get_rune_balances().unwrap(),
       [(OutPoint { txid, vout: 0 }, vec![(id, u128::MAX)])]
     );
 
-    server.assert_response_regex(
+    let parent = InscriptionId { txid, index: 0 };
+
+    server.assert_html(
       format!("/rune/{rune}"),
-      StatusCode::OK,
-      format!(
-        ".*<title>Rune AAAAAAAAAAAAA</title>.*
-<h1>AAAAAAAAAAAAA</h1>
-.*<a.*<iframe .* src=/preview/{txid}i0></iframe></a>.*
-<dl>
-  <dt>number</dt>
-  <dd>0</dd>
-  <dt>timestamp</dt>
-  <dd><time>1970-01-01 00:00:08 UTC</time></dd>
-  <dt>id</dt>
-  <dd>8:1</dd>
-  <dt>etching block</dt>
-  <dd><a href=/block/8>8</a></dd>
-  <dt>etching transaction</dt>
-  <dd>1</dd>
-  <dt>mint</dt>
-  <dd>no</dd>
-  <dt>supply</dt>
-  <dd>340282366920938463463374607431768211455\u{A0}%</dd>
-  <dt>premine</dt>
-  <dd>340282366920938463463374607431768211455\u{A0}%</dd>
-  <dt>premine percentage</dt>
-  <dd>100%</dd>
-  <dt>burned</dt>
-  <dd>0\u{A0}%</dd>
-  <dt>divisibility</dt>
-  <dd>0</dd>
-  <dt>symbol</dt>
-  <dd>%</dd>
-  <dt>turbo</dt>
-  <dd>true</dd>
-  <dt>etching</dt>
-  <dd><a class=collapse href=/tx/{txid}>{txid}</a></dd>
-  <dt>parent</dt>
-  <dd><a class=collapse href=/inscription/{txid}i0>{txid}i0</a></dd>
-</dl>
-.*"
-      ),
+      RuneHtml {
+        id,
+        entry,
+        mintable: false,
+        parent: Some(parent),
+      },
     );
 
     server.assert_response_regex(
-      format!("/inscription/{txid}i0"),
+      format!("/inscription/{parent}"),
       StatusCode::OK,
       ".*
 <dl>


### PR DESCRIPTION
This PR adds an `assert_html` test method which takes a path and a value implementing `PageContent`, and asserts that the page returned from the server is the same as that from rendering the value as an HTML template.

I think this is a dramatic improvement over our HTML / regex-based tests, which have terrible diffs and are super verbose, and basically force the test to recreate all the formatting of templates.

I only converted three instances of the old test type to use `assert_html`. I think going forward, we should change to `assert_html` whenever a test breaks.