### PR TITLE
Pin `bitcoin` to 0.32.3 in `ordinals` crate

### DIFF
--- a/crates/ordinals/Cargo.toml
+++ b/crates/ordinals/Cargo.toml
@@ -9,7 +9,7 @@ license = "CC0-1.0"
 rust-version = "1.74.0"
 
 [dependencies]
-bitcoin = { version = "0.32.3", features = ["rand"] }
+bitcoin = { version = "=0.32.3", features = ["rand"] }
 derive_more = { version = "1.0.0", features = ["display", "from_str"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_with = "3.7.0"


### PR DESCRIPTION
I needed to pin `bitcoin` to 0.32.3 in `ordinals` crate to publish it.