### PR TITLE
Fix off-by-one-error in sat range template

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -3936,7 +3936,7 @@ mod tests {
 </dl>
 <h2>1 Sat Range</h2>
 <ul class=monospace>
-  <li><a href=/sat/0 class=mythic>0</a>-<a href=/sat/5000000000 class=uncommon>5000000000</a> \\(5000000000 sats\\)</li>
+  <li><a href=/sat/0 class=mythic>0</a>-<a href=/sat/4999999999 class=common>4999999999</a> \\(5000000000 sats\\)</li>
 </ul>.*"
         ),
       );
@@ -3981,7 +3981,7 @@ mod tests {
 </dl>
 <h2>1 Sat Range</h2>
 <ul class=monospace>
-  <li><a href=/sat/5000000000 class=uncommon>5000000000</a>-<a href=/sat/10000000000 class=uncommon>10000000000</a> \\(5000000000 sats\\)</li>
+  <li><a href=/sat/5000000000 class=uncommon>5000000000</a>-<a href=/sat/9999999999 class=common>9999999999</a> \\(5000000000 sats\\)</li>
 </ul>.*"
       ),
     );

--- a/src/templates/output.rs
+++ b/src/templates/output.rs
@@ -48,7 +48,7 @@ mod tests {
         <h2>2 Sat Ranges</h2>
         <ul class=monospace>
           <li><a href=/sat/0 class=mythic>0</a></li>
-          <li><a href=/sat/1 class=common>1</a>-<a href=/sat/3 class=common>3</a> \\(2 sats\\)</li>
+          <li><a href=/sat/1 class=common>1</a>-<a href=/sat/2 class=common>2</a> \\(2 sats\\)</li>
         </ul>
       "
       .unindent()
@@ -107,7 +107,7 @@ mod tests {
         <h2>2 Sat Ranges</h2>
         <ul class=monospace>
           <li><a href=/sat/0 class=mythic>0</a></li>
-          <li><a href=/sat/1 class=common>1</a>-<a href=/sat/3 class=common>3</a> \\(2 sats\\)</li>
+          <li><a href=/sat/1 class=common>1</a>-<a href=/sat/2 class=common>2</a> \\(2 sats\\)</li>
         </ul>
       "
       .unindent()

--- a/templates/output.html
+++ b/templates/output.html
@@ -38,10 +38,11 @@
 <ul class=monospace>
 %% for (start, end) in sat_ranges {
 %% let value = end - start;
+%% let last = end - 1;
 %% if value == 1 {
   <li><a href=/sat/{{start}} class={{Sat(*start).rarity()}}>{{start}}</a></li>
 %% } else {
-  <li><a href=/sat/{{start}} class={{Sat(*start).rarity()}}>{{start}}</a>-<a href=/sat/{{end}} class={{Sat(*end).rarity()}}>{{end}}</a> ({{value}} sats)</li>
+  <li><a href=/sat/{{start}} class={{Sat(*start).rarity()}}>{{start}}</a>-<a href=/sat/{{last}} class=common>{{last}}</a> ({{value}} sats)</li>
 %% }
 %% }
 </ul>


### PR DESCRIPTION
Sat ranges are no longer intervals, and instead link to the first and last sat in the range. However, the last sat is off by one. Fix that.