### PR TITLE
Add replicate and swap recipes

### DIFF
--- a/bin/replicate
+++ b/bin/replicate
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+systemctl stop ord
+
+for host in alpha bravo; do
+  rsync \
+    --archive \
+    --progress \
+    /var/lib/ord/index.redb \
+    root@$host.ordinals.net:/var/lib/ord/index.redb.new
+done
+
+systemctl restart ord

--- a/bin/swap
+++ b/bin/swap
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+die() {
+  echo "$1"
+  exit 1
+}
+
+new=/var/lib/ord/index.redb.new
+current=/var/lib/ord/index.redb
+old=/var/lib/ord/index.redb.old
+
+[[ -f $new ]] || die "new index missing: $new"
+[[ -f $current ]] || die "old index missing: $current"
+[[ ! -f $old ]] || die "backup index already exists: $old"
+
+systemctl stop ord
+
+chown ord:ord $new
+
+mv $current $old
+mv $new $current
+
+systemctl restart ord

--- a/justfile
+++ b/justfile
@@ -217,3 +217,11 @@ benchmark-server:
 
 update-contributors:
   cargo run --release --package update-contributors
+
+replicate:
+  rsync --archive bin/replicate root@charlie.ordinals.net:replicate
+  ssh root@charlie.ordinals.net ./replicate
+
+swap host:
+  rsync --archive bin/swap root@{{ host }}.ordinals.net:swap
+  ssh root@{{ host }}.ordinals.net ./swap


### PR DESCRIPTION
`just replicate` copies indices from `charlie` to `alpha` and `bravo`

`just swap HOST` swaps in the new index on the given host.