### PR TITLE
Enable redb's new quick-repair mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2904,8 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.2.0"
-source = "git+https://github.com/cberner/redb?rev=c66447a6530d62615c5b377b3dca05799ab03efd#c66447a6530d62615c5b377b3dca05799ab03efd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c2a94325f9c5826b17c42af11067230f503747f870117a28180e85696e21ba"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,8 +2905,7 @@ dependencies = [
 [[package]]
 name = "redb"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b1de48a7cf7ba193e81e078d17ee2b786236eed1d3f7c60f8a09545efc4925"
+source = "git+https://github.com/cberner/redb?rev=c66447a6530d62615c5b377b3dca05799ab03efd#c66447a6530d62615c5b377b3dca05799ab03efd"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ mime_guess = "2.0.4"
 miniscript = "12.0.0"
 mp4 = "0.14.0"
 ordinals = { version = "0.0.13", path = "crates/ordinals" }
-redb = { git = "https://github.com/cberner/redb", rev = "c66447a6530d62615c5b377b3dca05799ab03efd" }
+redb = "2.3.0"
 ref-cast = "1.0.23"
 regex = "1.6.0"
 reqwest = { version = "0.11.27", features = ["blocking", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ mime_guess = "2.0.4"
 miniscript = "12.0.0"
 mp4 = "0.14.0"
 ordinals = { version = "0.0.12", path = "crates/ordinals" }
-redb = "2.2.0"
+redb = { git = "https://github.com/cberner/redb", rev = "c66447a6530d62615c5b377b3dca05799ab03efd" }
 ref-cast = "1.0.23"
 regex = "1.6.0"
 reqwest = { version = "0.11.27", features = ["blocking", "json"] }

--- a/src/index.rs
+++ b/src/index.rs
@@ -303,6 +303,7 @@ impl Index {
         let mut tx = database.begin_write()?;
 
         tx.set_durability(durability);
+        tx.set_quick_repair(true);
 
         tx.open_multimap_table(SAT_TO_SEQUENCE_NUMBER)?;
         tx.open_multimap_table(SCRIPT_PUBKEY_TO_OUTPOINT)?;
@@ -773,6 +774,7 @@ impl Index {
   fn begin_write(&self) -> Result<WriteTransaction> {
     let mut tx = self.database.begin_write()?;
     tx.set_durability(self.durability);
+    tx.set_quick_repair(true);
     Ok(tx)
   }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -664,7 +664,8 @@ impl Wallet {
       {
         let database = Database::builder().create(&path)?;
 
-        let tx = database.begin_write()?;
+        let mut tx = database.begin_write()?;
+        tx.set_quick_repair(true);
 
         tx.open_table(RUNE_TO_ETCHING)?;
 
@@ -688,7 +689,8 @@ impl Wallet {
     reveal: &Transaction,
     output: batch::Output,
   ) -> Result {
-    let wtx = self.database.begin_write()?;
+    let mut wtx = self.database.begin_write()?;
+    wtx.set_quick_repair(true);
 
     wtx.open_table(RUNE_TO_ETCHING)?.insert(
       rune.0,
@@ -717,7 +719,8 @@ impl Wallet {
   }
 
   pub(crate) fn clear_etching(&self, rune: Rune) -> Result {
-    let wtx = self.database.begin_write()?;
+    let mut wtx = self.database.begin_write()?;
+    wtx.set_quick_repair(true);
 
     wtx.open_table(RUNE_TO_ETCHING)?.remove(rune.0)?;
     wtx.commit()?;


### PR DESCRIPTION
This enables redb's new quick-repair mode so you can try it out.  It's using redb master, since this version hasn't been released yet.

Recovery after a crash always means rolling back to the last complete commit; if that commit was made with quick-repair enabled, then recovery will be instant.  So to get the new behavior, you'll need to let it make one successful commit with the new code before you start making it crash.  After that, no matter what you do, you should never have to wait for repair again.  You can tell it's working because it won't print the "Index file needs recovery" message, even after a crash; it'll just look like a normal clean startup.

Quick-repair mode needs to save the database allocator state with each commit, which costs about 200 ms per commit for a 190 GB database (it scales linearly with file size).  My guess is that's totally fine, so for now quick-repair is unconditionally enabled for all writes to the database.

If you try this out, let me know how it goes!