### PR TITLE
Wait for wallet to load

### DIFF
--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -555,36 +555,29 @@ impl Wallet {
       });
     }
 
-    loop {
-      match settings
-        .bitcoin_rpc_client(Some(name.clone()))?
-        .call::<serde_json::Value>(
-          "importdescriptors",
-          &[serde_json::to_value(descriptors.clone())?],
-        ) {
-        Ok(_) => {
-          break;
-        }
-        Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
-          if err.code == -4 && err.message == "Wallet already loading." =>
-        {
-          // wallet loading
-          thread::sleep(Duration::from_secs(3));
-          continue;
-        }
-        Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
-          if err.code == -35 =>
-        {
-          // wallet already loaded
-          break;
-        }
-        Err(err) => {
-          bail!("Failed to import descriptors for wallet {}: {err}", name);
-        }
+    match settings
+      .bitcoin_rpc_client(Some(name.clone()))?
+      .call::<serde_json::Value>(
+        "importdescriptors",
+        &[serde_json::to_value(descriptors.clone())?],
+      ) {
+      Ok(_) => Ok(()),
+      Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
+        if err.code == -4 && err.message == "Wallet already loading." =>
+      {
+        // wallet loading
+        Ok(())
+      }
+      Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
+        if err.code == -35 =>
+      {
+        // wallet already loaded
+        Ok(())
+      }
+      Err(err) => {
+        bail!("Failed to import descriptors for wallet {}: {err}", name)
       }
     }
-
-    Ok(())
   }
 
   pub(crate) fn check_version(client: Client) -> Result<Client> {

--- a/src/wallet/wallet_constructor.rs
+++ b/src/wallet/wallet_constructor.rs
@@ -61,6 +61,7 @@ impl WalletConstructor {
               if err.code == -4 && err.message == "Wallet already loading." =>
             {
               // wallet loading
+              eprint!(".");
               thread::sleep(Duration::from_secs(3));
               continue;
             }

--- a/src/wallet/wallet_constructor.rs
+++ b/src/wallet/wallet_constructor.rs
@@ -58,7 +58,7 @@ impl WalletConstructor {
               break;
             }
             Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
-              if err.code == -4 =>
+              if err.code == -4 && err.message == "Wallet already loading." =>
             {
               // wallet loading
               thread::sleep(Duration::from_secs(3));

--- a/src/wallet/wallet_constructor.rs
+++ b/src/wallet/wallet_constructor.rs
@@ -52,7 +52,29 @@ impl WalletConstructor {
         Wallet::check_version(self.settings.bitcoin_rpc_client(Some(self.name.clone()))?)?;
 
       if !client.list_wallets()?.contains(&self.name) {
-        client.load_wallet(&self.name)?;
+        loop {
+          match client.load_wallet(&self.name) {
+            Ok(_) => {
+              break;
+            }
+            Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
+              if err.code == -4 =>
+            {
+              // wallet loading
+              thread::sleep(Duration::from_secs(3));
+              continue;
+            }
+            Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
+              if err.code == -35 =>
+            {
+              // wallet already loaded
+              break;
+            }
+            Err(err) => {
+              bail!("Failed to load wallet {}: {err}", self.name);
+            }
+          }
+        }
       }
 
       if client.get_wallet_info()?.private_keys_enabled {


### PR DESCRIPTION
Addresses #4091 and #4111.

@gmart7t2 This catches a couple of errors that usually occur when the wallet takes a long time to load. It should now wait until a wallet or descriptor is finished loading before proceeding. 

Do you know by chance what the Bitcoin Core error code or message is if a descriptor for a wallet is still loading?