### PR TITLE
Add function to calculate rune unlock height

### DIFF
--- a/crates/ordinals/src/rune.rs
+++ b/crates/ordinals/src/rune.rs
@@ -527,9 +527,6 @@ mod tests {
 
     case("ZZZZZZZZZ", START + Rune::UNLOCK_INTERVAL * 3);
 
-    case("A", 1_049_999);
-    case("B", 1_049_326);
-
     case("ZZZ", 997_500);
 
     case("AAA", 1_014_999);

--- a/crates/ordinals/src/rune.rs
+++ b/crates/ordinals/src/rune.rs
@@ -110,18 +110,18 @@ impl Rune {
     let min_block_height = height + blocks_since_rune_start as u32;
 
     // Calculate the remainder using the correct step boundaries
-    let number_at_step_start = Self::STEPS[step_index];
-    let number_at_step_end = if step_index > 0 {
+    let start = Self::STEPS[step_index];
+    let end = if step_index > 0 {
       Self::STEPS[step_index - 1]
     } else {
       0
     };
 
-    let numbers_between_steps = number_at_step_start - number_at_step_end;
-    let numbers_since_step_start = number_at_step_start - self.0;
+    let interval = start - end;
+    let progress = start - self.0;
 
     // Calculate progress as a ratio first, then multiply by interval
-    let ratio = (numbers_since_step_start as f64) / (numbers_between_steps as f64);
+    let ratio = (progress as f64) / (interval as f64);
     let progress_as_blocks = ((ratio * Self::UNLOCK_INTERVAL as f64) - 1.0).ceil() as u32;
 
     let height = min_block_height + progress_as_blocks;

--- a/crates/ordinals/src/rune.rs
+++ b/crates/ordinals/src/rune.rs
@@ -8,6 +8,10 @@ pub struct Rune(pub u128);
 impl Rune {
   const RESERVED: u128 = 6402364363415443603228541259936211926;
 
+  const UNLOCKED: usize = 12;
+
+  const UNLOCK_INTERVAL: u32 = SUBSIDY_HALVING_INTERVAL / 12;
+
   const STEPS: &'static [u128] = &[
     0,
     26,
@@ -38,10 +42,6 @@ impl Rune {
     6402364363415443603228541259936211926,
     166461473448801533683942072758341510102,
   ];
-
-  const UNLOCK_INTERVAL: u32 = SUBSIDY_HALVING_INTERVAL / 12;
-
-  const UNLOCKED: usize = 12;
 
   pub fn n(self) -> u128 {
     self.0

--- a/crates/ordinals/src/rune.rs
+++ b/crates/ordinals/src/rune.rs
@@ -545,14 +545,13 @@ mod tests {
     case("B", 1_049_326);
     case("A", 1_049_999);
 
-    // Break glass in case of emergency:
-    // for i in 0..5 {
-    //   for n in Rune::STEPS[i]..Rune::STEPS[i + 1] {
-    //     let rune = Rune(n);
-    //     let unlock_height = rune.unlock_height(Network::Bitcoin).unwrap();
-    //     assert!(rune >= Rune::minimum_at_height(Network::Bitcoin, unlock_height));
-    //     assert!(rune < Rune::minimum_at_height(Network::Bitcoin, Height(unlock_height.0 - 1)));
-    //   }
-    // }
+    for i in 0..4 {
+      for n in Rune::STEPS[i]..Rune::STEPS[i + 1] {
+        let rune = Rune(n);
+        let unlock_height = rune.unlock_height(Network::Bitcoin).unwrap();
+        assert!(rune >= Rune::minimum_at_height(Network::Bitcoin, unlock_height));
+        assert!(rune < Rune::minimum_at_height(Network::Bitcoin, Height(unlock_height.0 - 1)));
+      }
+    }
   }
 }


### PR DESCRIPTION
See `Rune::unlock_height`. This works but makes me nervous. I noticed that my height calculation was one too high whenever we were 0/4, 1/4, 2/4, or 3/4ths of the way through an interval of runes with a given length. So I just fudged it and subtracted one in those cases.

I've exhaustively tested lengths 1 through 7, and they're all correct. (Checked by cross checking with asserts that the result of `Rune::unlock_height` matches `Rune::minimum_at_height`.) However, I'm worried that this pattern is actually the result of some deep number theory harmonic integer sequence or something, and is somehow wrong for larger intervals.