### PR TITLE
Improve `ord wallet send` help message

### DIFF
--- a/src/subcommand/wallet/burn.rs
+++ b/src/subcommand/wallet/burn.rs
@@ -99,7 +99,7 @@ impl Burn {
     Ok(Some(Box::new(send::Output {
       txid,
       psbt,
-      outgoing: Outgoing::InscriptionId(self.inscription),
+      asset: Outgoing::InscriptionId(self.inscription),
       fee,
     })))
   }

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -12,15 +12,22 @@ pub(crate) struct Send {
     value_name = "AMOUNT"
   )]
   pub(crate) postage: Option<Amount>,
+  #[arg(help = "Recipient address")]
   address: Address<NetworkUnchecked>,
-  outgoing: Outgoing,
+  #[arg(
+    help = "Outgoing asset formatted as a bitcoin amount, rune amount, sat name, satpoint, or \
+    inscription ID. Bitcoin amounts are `DECIMAL UNIT` where `UNIT` is one of \
+    `bit btc cbtc mbtc msat nbtc pbtc sat satoshi ubtc`. Rune amounts are `DECIMAL:RUNE` and \
+    respect divisibility"
+  )]
+  asset: Outgoing,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Output {
   pub txid: Txid,
   pub psbt: String,
-  pub outgoing: Outgoing,
+  pub asset: Outgoing,
   pub fee: u64,
 }
 
@@ -31,7 +38,7 @@ impl Send {
       .clone()
       .require_network(wallet.chain().network())?;
 
-    let unsigned_transaction = match self.outgoing {
+    let unsigned_transaction = match self.asset {
       Outgoing::Amount(amount) => {
         Self::create_unsigned_send_amount_transaction(&wallet, address, amount, self.fee_rate)?
       }
@@ -79,7 +86,7 @@ impl Send {
     Ok(Some(Box::new(Output {
       txid,
       psbt,
-      outgoing: self.outgoing,
+      asset: self.asset,
       fee,
     })))
   }

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -671,7 +671,7 @@ fn send_dry_run() {
     .to_sat(),
     output.fee
   );
-  assert_eq!(output.outgoing, Outgoing::InscriptionId(inscription));
+  assert_eq!(output.asset, Outgoing::InscriptionId(inscription));
 }
 
 #[test]


### PR DESCRIPTION
The help text is definitely an improvement. I also think that changing the argument name from `outgoing` to `asset` is also an improvement. I'm not sure about changing `outgoing` to `asset` in the output. I think it's better, but it breaks any commands relying on it.