### PR TITLE
Set `maxburnamount` when burning

### DIFF
--- a/crates/mockcore/src/api.rs
+++ b/crates/mockcore/src/api.rs
@@ -87,7 +87,12 @@ pub trait Api {
   ) -> Result<Value, jsonrpc_core::Error>;
 
   #[rpc(name = "sendrawtransaction")]
-  fn send_raw_transaction(&self, tx: String) -> Result<String, jsonrpc_core::Error>;
+  fn send_raw_transaction(
+    &self,
+    tx: String,
+    maxfeerate: Option<()>,
+    maxburnamount: Option<f64>,
+  ) -> Result<String, jsonrpc_core::Error>;
 
   #[rpc(name = "sendtoaddress")]
   fn send_to_address(

--- a/crates/mockcore/src/lib.rs
+++ b/crates/mockcore/src/lib.rs
@@ -74,7 +74,7 @@ pub fn builder() -> Builder {
   Builder {
     fail_lock_unspent: false,
     network: Network::Bitcoin,
-    version: 240000,
+    version: 250000,
   }
 }
 

--- a/src/subcommand/wallet/burn.rs
+++ b/src/subcommand/wallet/burn.rs
@@ -111,8 +111,6 @@ impl Burn {
       65,
     );
 
-    eprintln!("tx len: {}", unsigned_transaction.base_size());
-
     let (txid, psbt, fee) =
       wallet.sign_and_broadcast_transaction(unsigned_transaction, self.dry_run, Some(value))?;
 

--- a/src/subcommand/wallet/burn.rs
+++ b/src/subcommand/wallet/burn.rs
@@ -104,11 +104,10 @@ impl Burn {
       script_pubkey,
     )?;
 
+    let base_size = unsigned_transaction.base_size();
     assert!(
-      unsigned_transaction.base_size() >= 65,
-      "transaction base size less than minimum standard tx nonwitness size: {} < {}",
-      unsigned_transaction.base_size(),
-      65,
+      base_size >= 65,
+      "transaction base size less than minimum standard tx nonwitness size: {base_size} < 65",
     );
 
     let (txid, psbt, fee) =

--- a/src/subcommand/wallet/burn.rs
+++ b/src/subcommand/wallet/burn.rs
@@ -94,7 +94,7 @@ impl Burn {
     )?;
 
     let (txid, psbt, fee) =
-      wallet.sign_and_broadcast_transaction(unsigned_transaction, self.dry_run)?;
+      wallet.sign_and_broadcast_transaction(unsigned_transaction, self.dry_run, Some(value))?;
 
     Ok(Some(Box::new(send::Output {
       txid,

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -74,7 +74,7 @@ impl Send {
     };
 
     let (txid, psbt, fee) =
-      wallet.sign_and_broadcast_transaction(unsigned_transaction, self.dry_run)?;
+      wallet.sign_and_broadcast_transaction(unsigned_transaction, self.dry_run, None)?;
 
     Ok(Some(Box::new(Output {
       txid,

--- a/src/subcommand/wallet/split.rs
+++ b/src/subcommand/wallet/split.rs
@@ -145,7 +145,7 @@ impl Split {
     let unsigned_transaction = consensus::encode::deserialize(&unsigned_transaction)?;
 
     let (txid, psbt, fee) =
-      wallet.sign_and_broadcast_transaction(unsigned_transaction, self.dry_run)?;
+      wallet.sign_and_broadcast_transaction(unsigned_transaction, self.dry_run, None)?;
 
     Ok(Some(Box::new(Output { txid, psbt, fee })))
   }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -563,7 +563,7 @@ impl Wallet {
   }
 
   pub(crate) fn check_version(client: Client) -> Result<Client> {
-    const MIN_VERSION: usize = 240000;
+    const MIN_VERSION: usize = 250000;
 
     let bitcoin_version = client.version()?;
     if bitcoin_version < MIN_VERSION {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -743,6 +743,7 @@ impl Wallet {
     &self,
     unsigned_transaction: Transaction,
     dry_run: bool,
+    burn_amount: Option<Amount>,
   ) -> Result<(Txid, String, u64)> {
     let unspent_outputs = self.utxos();
 
@@ -777,10 +778,7 @@ impl Wallet {
         .hex
         .ok_or_else(|| anyhow!("unable to sign transaction"))?;
 
-      (
-        self.bitcoin_client().send_raw_transaction(&signed_tx)?,
-        psbt,
-      )
+      (self.send_raw_transaction(&signed_tx, burn_amount)?, psbt)
     };
 
     let mut fee = 0;
@@ -796,5 +794,24 @@ impl Wallet {
     }
 
     Ok((txid, psbt, fee))
+  }
+
+  fn send_raw_transaction<R: bitcoincore_rpc::RawTx>(
+    &self,
+    tx: R,
+    burn_amount: Option<Amount>,
+  ) -> Result<Txid> {
+    let mut arguments = vec![tx.raw_hex().into()];
+
+    if let Some(burn_amount) = burn_amount {
+      arguments.push(serde_json::Value::Null);
+      arguments.push(burn_amount.to_btc().into());
+    }
+
+    Ok(
+      self
+        .bitcoin_client()
+        .call("sendrawtransaction", &arguments)?,
+    )
   }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -778,6 +778,14 @@ impl Wallet {
         .hex
         .ok_or_else(|| anyhow!("unable to sign transaction"))?;
 
+      {
+        let tx =
+          Transaction::consensus_decode(&mut io::BufReader::new(Cursor::new(signed_tx.clone())))
+            .unwrap();
+
+        eprintln!("tx length: {}", tx.base_size());
+      }
+
       (self.send_raw_transaction(&signed_tx, burn_amount)?, psbt)
     };
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -778,14 +778,6 @@ impl Wallet {
         .hex
         .ok_or_else(|| anyhow!("unable to sign transaction"))?;
 
-      {
-        let tx =
-          Transaction::consensus_decode(&mut io::BufReader::new(Cursor::new(signed_tx.clone())))
-            .unwrap();
-
-        eprintln!("tx length: {}", tx.base_size());
-      }
-
       (self.send_raw_transaction(&signed_tx, burn_amount)?, psbt)
     };
 

--- a/tests/wallet/burn.rs
+++ b/tests/wallet/burn.rs
@@ -33,7 +33,7 @@ fn inscriptions_can_be_burned() {
     <span title=burned>🔥</span>
   </dd>
   <dt>value</dt>
-  <dd>9922</dd>
+  <dd>9918</dd>
   .*
   <dt>content length</dt>
   <dd>3 bytes</dd>

--- a/tests/wallet/inscribe.rs
+++ b/tests/wallet/inscribe.rs
@@ -74,13 +74,13 @@ fn metaprotocol_appears_on_inscription_page() {
 
 #[test]
 fn inscribe_fails_if_bitcoin_core_is_too_old() {
-  let core = mockcore::builder().version(230000).build();
+  let core = mockcore::builder().version(240000).build();
   let ord = TestServer::spawn(&core);
 
   CommandBuilder::new("wallet inscribe --file hello.txt --fee-rate 1")
     .write("hello.txt", "HELLOWORLD")
     .expected_exit_code(1)
-    .expected_stderr("error: Bitcoin Core 24.0.0 or newer required, current version is 23.0.0\n")
+    .expected_stderr("error: Bitcoin Core 25.0.0 or newer required, current version is 24.0.0\n")
     .core(&core)
     .ord(&ord)
     .run_and_extract_stdout();


### PR DESCRIPTION
Tested locally on regtest. Also bumps minimum bitcoin core version to 25, so we can pad to 65 bytes, instead of 82 bytes.

See this PR:

https://bitcoincore.reviews/26265