### PR TITLE
Add /r/rawtxinfo/:transaction_id endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ rustls-acme = { version = "0.8.1", features = ["axum"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde-hex = "0.1.0"
 serde_json = { version = "1.0.132", features = ["preserve_order"] }
-serde_with = "3.7.0"
+serde_with = { version = "3.7.0", features = ["hex"] }
 serde_yaml = "0.9.17"
 sha3 = "0.10.8"
 snafu = "0.8.3"

--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -3370,6 +3370,47 @@ curl -s -H "Accept: application/json" \
 ```
 </details>
 
+<details>
+  <summary>
+    <code>GET</code>
+    <code><b>/r/rawtxinfo/&lt;TRANSACTION_ID&gt;</b></code>
+  </summary>
+
+### Description
+
+Raw transaction data for `<TRANSACTION_ID>` with verbose information.
+
+### Example
+
+```bash
+curl -s -H "Accept: application/json" \
+  http://0.0.0.0:80/r/rawtxinfo/60bcf821240064a9c55225c4f01711b0ebbcab39aa3fafeefe4299ab158536fa
+```
+
+```json
+{
+  "blockhash": "00000000000000000000ce2459594de93b8d2f64b809b6c9d7fdd058bf970370",
+  "hex": "0100000000010183572872dcb32bee57003d53c2b8dbb5bc5819ff6478052599",
+  "vin": [
+    {
+      "coinbase": "0000000000000000000000000000000000000000000000000000000000000000",
+      "txid": "bdc7d178771f919925057864ff1958bcb5dbb8c2533d0057ee2bb3dc72285783",
+      "vout": 0
+    }
+  ],
+  "vout": [
+    {
+      "value": 0.0001,
+      "n": 0,
+      "scriptPubKey": {
+        "hex": "5120e41e0cba05c6ac797cf543ff9a6c619a91a53813e59146d1e32ea89747b1"
+      }
+    }
+  ]
+}
+```
+</details>
+
 &nbsp;
 &nbsp;
 

--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -3390,10 +3390,9 @@ curl -s -H "Accept: application/json" \
 ```json
 {
   "blockhash": "00000000000000000000ce2459594de93b8d2f64b809b6c9d7fdd058bf970370",
-  "hex": "0100000000010183572872dcb32bee57003d53c2b8dbb5bc5819ff6478052599",
+  "hex": "0100000000010183572872dcb32bee57003d53c2b8dbb5bc5819ff6478052599...",
   "vin": [
     {
-      "coinbase": "0000000000000000000000000000000000000000000000000000000000000000",
       "txid": "bdc7d178771f919925057864ff1958bcb5dbb8c2533d0057ee2bb3dc72285783",
       "vout": 0
     }
@@ -3403,7 +3402,7 @@ curl -s -H "Accept: application/json" \
       "value": 0.0001,
       "n": 0,
       "scriptPubKey": {
-        "hex": "5120e41e0cba05c6ac797cf543ff9a6c619a91a53813e59146d1e32ea89747b1"
+        "hex": "5120e41e0cba05c6ac797cf543ff9a6c619a91a53813e59146d1e32ea89747b111a6"
       }
     }
   ]

--- a/src/index.rs
+++ b/src/index.rs
@@ -13,14 +13,13 @@ use {
   },
   super::*,
   crate::{
-    api::RawTransactionInfo,
     runes::MintError,
     subcommand::{find::FindRangeOutput, server::query},
     templates::StatusHtml,
   },
   bitcoin::block::Header,
   bitcoincore_rpc::{
-    json::{GetBlockHeaderResult, GetBlockStatsResult},
+    json::{GetBlockHeaderResult, GetBlockStatsResult, GetRawTransactionResult},
     Client,
   },
   chrono::SubsecRound,
@@ -1590,11 +1589,10 @@ impl Index {
     self.client.get_raw_transaction(&txid, None).into_option()
   }
 
-  pub fn get_raw_transaction_info(&self, txid: Txid) -> Result<Option<RawTransactionInfo>> {
+  pub fn raw_transaction_info(&self, txid: Txid) -> Result<Option<GetRawTransactionResult>> {
     self
       .client
       .get_raw_transaction_info(&txid, None)
-      .map(RawTransactionInfo::from)
       .into_option()
   }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,3 +1,4 @@
+pub use self::entry::RuneEntry;
 use {
   self::{
     entry::{
@@ -12,6 +13,7 @@ use {
   },
   super::*,
   crate::{
+    api::RawTransactionInfo,
     runes::MintError,
     subcommand::{find::FindRangeOutput, server::query},
     templates::StatusHtml,
@@ -35,8 +37,6 @@ use {
     sync::Once,
   },
 };
-
-pub use self::entry::RuneEntry;
 
 pub(crate) mod entry;
 pub mod event;
@@ -1588,6 +1588,14 @@ impl Index {
     }
 
     self.client.get_raw_transaction(&txid, None).into_option()
+  }
+
+  pub fn get_raw_transaction_info(&self, txid: Txid) -> Result<Option<RawTransactionInfo>> {
+    self
+      .client
+      .get_raw_transaction_info(&txid, None)
+      .map(RawTransactionInfo::from)
+      .into_option()
   }
 
   pub fn find(&self, sat: Sat) -> Result<Option<SatPoint>> {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -4366,7 +4366,7 @@ mod tests {
     test_server.assert_response(
       format!("/r/rawtxinfo/{txid}"),
       StatusCode::OK,
-      "{\"blockhash\":\"56d05060a0280d0712d113f25321158747310ece87ea9e299bde06cf385b8d85\",\"hex\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"vin\":[],\"vout\":[{\"value\":50.0,\"n\":0,\"scriptPubKey\":{\"hex\":\"5120be7cbbe9ca06a7d7b2a17c6b4ff4b85b362cbcd7ee1970daa66dfaa834df\"}}]}"
+      "{\"blockhash\":\"56d05060a0280d0712d113f25321158747310ece87ea9e299bde06cf385b8d85\",\"hex\":\"\",\"vin\":[],\"vout\":[{\"value\":50.0,\"n\":0,\"scriptPubKey\":{\"hex\":\"5120be7cbbe9ca06a7d7b2a17c6b4ff4b85b362cbcd7ee1970daa66dfaa834df59a0\"}}]}"
     );
   }
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1088,10 +1088,10 @@ impl Server {
   ) -> ServerResult<Json<RawTransactionInfo>> {
     task::block_in_place(|| {
       let raw_transaction_info = index
-        .get_raw_transaction_info(txid)?
+        .raw_transaction_info(txid)?
         .ok_or_not_found(|| format!("transaction {txid}"))?;
 
-      Ok(Json(raw_transaction_info))
+      Ok(Json(api::RawTransactionInfo::from(raw_transaction_info)))
     })
   }
 


### PR DESCRIPTION
This endpoint bypasses the index and acts as a proxy to get raw transaction
data from bitcoin cli

Response from bitcoincore_rpc is converted into a defined structure in this
codebase to help with compatibility