### PR TITLE
Style help text

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -7,11 +7,14 @@ use {
 #[command(
   version,
   styles = Styles::styled()
-    .header(AnsiColor::Green.on_default() | Effects::BOLD)
-    .usage(AnsiColor::Green.on_default() | Effects::BOLD)
-    .literal(AnsiColor::Blue.on_default() | Effects::BOLD)
-    .placeholder(AnsiColor::Cyan.on_default()))
-]
+    .error(AnsiColor::Red.on_default() | Effects::BOLD)
+    .header(AnsiColor::Yellow.on_default() | Effects::BOLD)
+    .invalid(AnsiColor::Red.on_default())
+    .literal(AnsiColor::Blue.on_default())
+    .placeholder(AnsiColor::Cyan.on_default())
+    .usage(AnsiColor::Yellow.on_default() | Effects::BOLD)
+    .valid(AnsiColor::Green.on_default()),
+)]
 pub(crate) struct Arguments {
   #[command(flatten)]
   pub(crate) options: Options,


### PR DESCRIPTION
The main difference is that headings are in yellow, which sets them off a bit.

<details>

![Screenshot 2024-12-02 at 1 23 55 PM](https://github.com/user-attachments/assets/6dfb02cb-1091-4abd-a2ab-0a4410ad0339)

</details>