### PR TITLE
Show video controls on click

### DIFF
--- a/static/preview-video.js
+++ b/static/preview-video.js
@@ -1,4 +1,3 @@
-let video = document.getElementsByTagName('video')[0];
-video.addEventListener('click', () => {
-  video.controls = true;
+document.getElementsByTagName('video')[0].addEventListener('click', (event) => {
+  event.target.controls = true;
 });

--- a/static/preview-video.js
+++ b/static/preview-video.js
@@ -1,0 +1,4 @@
+let video = document.getElementsByTagName('video')[0];
+video.addEventListener('click', () => {
+  video.controls = true;
+});

--- a/templates/preview-video.html
+++ b/templates/preview-video.html
@@ -3,9 +3,15 @@
   <head>
     <meta charset=utf-8>
     <link rel=stylesheet href=/static/preview-video.css>
+    <script type=module>
+      let video = document.getElementsByTagName('video')[0];
+      video.addEventListener('click', () => {
+        video.controls = true;
+      });
+    </script>
   </head>
   <body>
-    <video controls loop muted autoplay>
+    <video loop muted autoplay>
       <source src=/content/{{self.inscription_id}}>
     </video>
   </body>

--- a/templates/preview-video.html
+++ b/templates/preview-video.html
@@ -3,12 +3,7 @@
   <head>
     <meta charset=utf-8>
     <link rel=stylesheet href=/static/preview-video.css>
-    <script type=module>
-      let video = document.getElementsByTagName('video')[0];
-      video.addEventListener('click', () => {
-        video.controls = true;
-      });
-    </script>
+    <script src=/static/preview-video.js type=module defer></script>
   </head>
   <body>
     <video loop muted autoplay>


### PR DESCRIPTION
This PR modifies inscription video previews so controls (play, pause, etc) are only visible after clicking the preview.

Since thumbnail iframes are wrapped with an `<a>` tag, the `<a>` tag will intecept any clicks, so it entirely disables video controls on thumbnails, which I think is correct.

On `/inscription` the preview iframe isn't wrapped with an `<a>`, so you can enable controls by clicking on it.

I think this is nice, since otherwise video inscriptions load with visible controls, which is not very nice looking.