### PR TITLE
Show overflow on <ol> in /blocks list

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -104,7 +104,7 @@ dl {
   overflow-wrap: break-word;
 }
 
-ol, ul {
+ul {
   overflow: hidden;
 }
 

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -1,19 +1,20 @@
 <h1>Blocks</h1>
 %% for (i, hash) in self.blocks.iter().enumerate() {
-%% if let Some(inscription_ids) = &self.featured_blocks.get(hash) {
+%%   let height = self.last - u32::try_from(i).unwrap();
+%%   if let Some(inscription_ids) = &self.featured_blocks.get(hash) {
 <div class=block>
-  <h2><a href=/block/{{ self.last - i as u32 }}>Block {{ self.last - i as u32 }}</a></h2>
+  <h2><a href=/block/{{ height }}>Block {{ height }}</a></h2>
   <div class=thumbnails>
-%% for id in *inscription_ids {
+%%     for id in *inscription_ids {
     {{ Iframe::thumbnail(*id) }}
-%% }
+%%     }
   </div>
 </div>
-%% } else {
-%% if i == self.featured_blocks.len() {
-<ol start={{ self.last - self.featured_blocks.len() as u32 }} reversed class=block-list>
-%% }
+%%   } else {
+%%     if i == self.featured_blocks.len() {
+<ol start={{ height }} reversed class=block-list>
+%%     }
   <li><a class=collapse href=/block/{{ hash }}>{{ hash }}</a></li>
-%% }
+%%   }
 %% }
 </ol>


### PR DESCRIPTION
Show overflow on `<ol>` in /blocks list. The only thing that overflows is the block number on each `<li>`. I'm not sure why we hid it in the first place, but it looks pretty bad.

I also simplified the template slightly by calculating the height up front for each block, and indented the rust code to match the indentation level it would have in actual code.