### PR TITLE
Add `/r/txhex/<txid>` for tx-hex recursion

### DIFF
--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -247,6 +247,28 @@ curl -s  \
 <details>
   <summary>
     <code>GET</code>
+    <code><b>/r/txhex/&lt;TRANSACTION_ID&gt;</b></code>
+  </summary>
+
+### Description
+
+Raw transaction hex for `<TRANSACTION_ID>`.
+
+### Example
+
+```bash
+curl -s -H "Accept: application/json" \
+  http://0.0.0.0:80/r/txhex/60bcf821240064a9c55225c4f01711b0ebbcab39aa3fafeefe4299ab158536fa
+```
+
+```json
+"0100000000010183572872dcb32bee57003d53c2b8dbb5bc5819ff6478052599911f7778d1c7bd0000000000fdffffff011027000000000000225120e41e0cba05c6ac797cf543ff9a6c619a91a53813e59146d1e32ea89747b111a603407aa50d93d6fc01265fd52d3edc93af4e009ccc1a704ce1b5cb8ede1412a5df31eba587d080b3dc903ceb9002ed9d921aad323fd44d7b4dc2a1ad2ea12d4360424d20c7a3a38df198a4fcde7d5dac5819ed19ff4d25bb893c9511f8e1f51d59326effac0063036f7264010118746578742f706c61696e3b636861727365743d7574662d3800077072696d65730a6821c1c7a3a38df198a4fcde7d5dac5819ed19ff4d25bb893c9511f8e1f51d59326eff00000000"
+```
+</details>
+
+<details>
+  <summary>
+    <code>GET</code>
     <code><b>/r/children/&lt;INSCRIPTION_ID&gt;</b></code>
   </summary>
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1610,6 +1610,10 @@ impl Index {
     self.client.get_raw_transaction(&txid, None).into_option()
   }
 
+  pub fn get_transaction_hex(&self, txid: Txid) -> Result<Option<String>> {
+    self.client.get_raw_transaction_hex(&txid, None).into_option()
+  }
+
   pub fn find(&self, sat: Sat) -> Result<Option<SatPoint>> {
     let sat = sat.0;
     let rtx = self.begin_read()?;

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -263,6 +263,7 @@ impl Server {
           "/r/parents/:inscription_id/:page",
           get(Self::parents_recursive_paginated),
         )
+        .route("/r/txhex/:txid", get(Self::get_raw_transaction_hex))
         .route("/r/sat/:sat_number", get(Self::sat_inscriptions))
         .route(
           "/r/sat/:sat_number/:page",
@@ -1085,6 +1086,19 @@ impl Server {
         .page(server_config)
         .into_response()
       })
+    })
+  }
+
+  async fn get_raw_transaction_hex(
+    Extension(index): Extension<Arc<Index>>,
+    Path(txid): Path<Txid>,
+  ) -> ServerResult<Json<String>> {
+    task::block_in_place(|| {
+      let raw_transaction_hex = index
+        .get_transaction_hex(txid)?
+        .ok_or_not_found(|| format!("transaction {txid}"))?;
+
+      Ok(Json(raw_transaction_hex))
     })
   }
 
@@ -4348,6 +4362,20 @@ mod tests {
   </li>
 </ul>.*"
       ),
+    );
+  }
+
+  #[test]
+  fn raw_transaction_hex() {
+    let test_server = TestServer::new();
+
+    let coinbase_tx = test_server.mine_blocks(1)[0].txdata[0].clone();
+    let txid = coinbase_tx.compute_txid();
+
+    test_server.assert_response(
+      format!("/r/txhex/{txid}"),
+      StatusCode::OK,
+      "\"02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0151ffffffff0100f2052a01000000225120be7cbbe9ca06a7d7b2a17c6b4ff4b85b362cbcd7ee1970daa66dfaa834df59a000000000\""
     );
   }
 


### PR DESCRIPTION
This endpoint bypasses the index and acts as a proxy to get raw transaction hex from bitcoin cli. It returns hex encoded raw transaction data as a JSON string.

PR also includes recursion docs update to reflect the new endpoint and tests for the new endpoint.

