### PR TITLE
update minimum required bitcoin core version to v25

### DIFF
--- a/docs/src/guides/wallet.md
+++ b/docs/src/guides/wallet.md
@@ -43,7 +43,7 @@ Installing Bitcoin Core
 Bitcoin Core is available from [bitcoincore.org](https://bitcoincore.org/) on
 the [download page](https://bitcoincore.org/en/download/).
 
-Making inscriptions requires Bitcoin Core 24 or newer.
+Making inscriptions requires Bitcoin Core 25 or newer.
 
 This guide does not cover installing Bitcoin Core in detail. Once Bitcoin Core
 is installed, you should be able to run `bitcoind -version` successfully from


### PR DESCRIPTION
#4106 updated the required version of Bitcoin Core to 25 - this updates the documentation.

thanks to @so7ow for pointing this out