### PR TITLE
`ord env` less aggressive exit

### DIFF
--- a/src/subcommand/env.rs
+++ b/src/subcommand/env.rs
@@ -241,10 +241,14 @@ bitcoin-cli -datadir={datadir} getblockchaininfo
 
     loop {
       if SHUTTING_DOWN.load(atomic::Ordering::Relaxed) {
-        break Ok(None);
+        break;
       }
 
       thread::sleep(Duration::from_millis(100));
     }
+
+    thread::sleep(Duration::from_secs(5));
+
+    Ok(None)
   }
 }


### PR DESCRIPTION


We were very aggressive with killing the process. Not allowing Bitcoinn Core time to process the `kill` command, which lead it to bork it's database. This now waits 5 seconds, giving it enough time to exit.