### PR TITLE
Remove double commit for redb bug

### DIFF
--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -862,10 +862,6 @@ impl Updater<'_> {
     Index::increment_statistic(&wtx, Statistic::Commits, 1)?;
     wtx.commit()?;
 
-    // Commit twice since due to a bug redb will only reuse pages freed in the
-    // transaction before last.
-    self.index.begin_write()?.commit()?;
-
     Reorg::update_savepoints(self.index, self.height)?;
 
     Ok(())


### PR DESCRIPTION
@casey can we get rid of this now?