### PR TITLE
Use `application/x-bittorrent` media type for `.torrent` files

### DIFF
--- a/src/inscriptions/media.rs
+++ b/src/inscriptions/media.rs
@@ -75,6 +75,7 @@ impl Media {
     ("application/pdf",             GENERIC, Pdf,              &["pdf"]),
     ("application/pgp-signature",   TEXT,    Text,             &["asc"]),
     ("application/protobuf",        GENERIC, Unknown,          &["binpb"]),
+    ("application/x-bittorrent",    GENERIC, Unknown,          &["torrent"]),
     ("application/x-javascript",    TEXT,    Code(JavaScript), &[]),
     ("application/yaml",            TEXT,    Code(Yaml),       &["yaml", "yml"]),
     ("audio/flac",                  GENERIC, Audio,            &["flac"]),


### PR DESCRIPTION
Allows inscribing torrent files with `ord`. Doesn't add any preview functionality, although that could be added later.