### PR TITLE
Add blockhashes endpoint at /blockhashes/{start}/{interval}/{page}

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -42,6 +42,30 @@ impl Block {
   }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct BlockHashesParams {
+  pub start: u64,
+  pub interval: Option<u64>,
+  pub page: Option<u64>,
+}
+
+impl BlockHashesParams {
+  pub fn new(start: u64, interval: Option<u64>, page: Option<u64>) -> Self {
+    Self {
+      start,
+      interval,
+      page,
+    }
+  }
+}
+
+#[derive(Serialize)]
+pub struct BlockHashesJson {
+  pub block_hashes: Vec<String>,
+  pub prev_page: Option<u64>,
+  pub next_page: Option<u64>,
+}
+
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct BlockInfo {
   pub average_fee: u64,

--- a/src/index/rtx.rs
+++ b/src/index/rtx.rs
@@ -1,5 +1,5 @@
 use super::*;
-const PAGE_SIZE: u32 = 100; // Example page size
+const PAGE_SIZE: u32 = 100;
 pub struct Rtx(pub redb::ReadTransaction);
 
 impl Rtx {
@@ -52,7 +52,6 @@ impl Rtx {
     let height_to_block_header = self.0.open_table(HEIGHT_TO_BLOCK_HEADER)?;
     let mut block_hashes = Vec::new();
 
-    // Current height starts at `start + (page * PAGE_SIZE * interval)`, saturating to avoid overflow.
     let mut current_height =
       start.saturating_add(page.saturating_mul(PAGE_SIZE).saturating_mul(interval));
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -5,6 +5,7 @@ use {
     error::{OptionExt, ServerError, ServerResult},
   },
   super::*,
+  crate::api::{BlockHashesJson, BlockHashesParams},
   crate::templates::{
     AddressHtml, BlockHtml, BlocksHtml, ChildrenHtml, ClockSvg, CollectionsHtml, HomeHtml,
     InputHtml, InscriptionHtml, InscriptionsBlockHtml, InscriptionsHtml, OutputHtml, PageContent,
@@ -183,6 +184,15 @@ impl Server {
         .route("/blockcount", get(Self::block_count))
         .route("/blockhash", get(Self::block_hash))
         .route("/blockhash/{height}", get(Self::block_hash_from_height))
+        .route("/blockhashes/{start}", get(Self::block_hashes_start_only))
+        .route(
+          "/blockhashes/{start}/{interval}",
+          get(Self::block_hashes_start_interval),
+        )
+        .route(
+          "/blockhashes/{start}/{interval}/{page}",
+          get(Self::block_hashes_paginated),
+        )
         .route("/blockheight", get(Self::block_height))
         .route("/blocks", get(Self::blocks))
         .route("/blocktime", get(Self::block_time))
@@ -2354,6 +2364,63 @@ impl Server {
 
     Redirect::to(&destination)
   }
+  async fn block_hashes_paginated(
+    Extension(index): Extension<Arc<Index>>,
+    Path(params): Path<BlockHashesParams>,
+  ) -> impl IntoResponse {
+    // e.g. your BlockHashesParams had `start: u64, interval: Option<u64>, page: Option<u64>`
+    let interval = params.interval.unwrap_or(1);
+    let page = params.page.unwrap_or(0);
+
+    match tokio::task::block_in_place(|| {
+      // Convert from u64 to u32
+      let start_u32 = u32::try_from(params.start).unwrap_or(u32::MAX);
+      let interval_u32 = u32::try_from(interval).unwrap_or(u32::MAX);
+      let page_u32 = u32::try_from(page).unwrap_or(u32::MAX);
+
+      // Now call index with u32
+      index.block_hashes_in_interval_paginated(start_u32, interval_u32, page_u32)
+    }) {
+      Ok((block_hashes, more_blocks)) => {
+        // we got (Vec<BlockHash>, bool)
+        let prev_page = if page > 0 { Some(page - 1) } else { None };
+        let next_page = if more_blocks { Some(page + 1) } else { None };
+
+        Json(BlockHashesJson {
+          block_hashes: block_hashes
+            .into_iter()
+            .map(|hash| hash.to_string())
+            .collect(),
+          prev_page,
+          next_page,
+        })
+        .into_response()
+      }
+      Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+  }
+
+  async fn block_hashes_start_only(
+    Extension(index): Extension<Arc<Index>>,
+    Path(start): Path<u64>,
+  ) -> impl IntoResponse {
+    Self::block_hashes_paginated(
+      Extension(index),
+      Path(BlockHashesParams::new(start, Some(1), Some(0))),
+    )
+    .await
+  }
+
+  async fn block_hashes_start_interval(
+    Extension(index): Extension<Arc<Index>>,
+    Path((start, interval)): Path<(u64, u64)>,
+  ) -> impl IntoResponse {
+    Self::block_hashes_paginated(
+      Extension(index),
+      Path(BlockHashesParams::new(start, Some(interval), Some(0))),
+    )
+    .await
+  }
 }
 
 #[cfg(test)]
@@ -4015,6 +4082,77 @@ mod tests {
       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
     );
   }
+
+  #[test]
+  fn blockhashes_from_height_endpoint() {
+    let test_server = TestServer::new();
+
+    let response = test_server.get("/blockhashes/0");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.text().unwrap();
+
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Invalid JSON");
+
+    let hashes = json
+      .get("block_hashes")
+      .expect("Missing block_hashes key")
+      .as_array()
+      .expect("block_hashes is not an array");
+
+    let first_hash = hashes.first().unwrap().as_str().unwrap();
+
+    assert_eq!(
+      first_hash,
+      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+    );
+  }
+
+  //   #[test]
+  // fn test_blockhashes_correct_content() {
+  //     let test_server = TestServer::new();
+  //     // Here we assume your TestServer loads a known test database or index.
+  //     // For example, assume the test index is pre-populated with block headers for blocks 0..119,
+  //     // where block 0 is genesis and subsequent blocks have known hash values.
+  //     //
+  //     // You can adjust the expected values below according to your test fixture.
+  //     let response = test_server.get("/blockhashes/0/1/0");
+  //     assert_eq!(response.status(), StatusCode::OK);
+
+  //     // Check that the Content-Type is correct.
+  //     let headers = response.headers();
+  //     assert_eq!(headers.get("content-type").unwrap(), "application/json");
+
+  //     // Parse the JSON.
+  //     let body = response.text().unwrap();
+  //     let json: Value = serde_json::from_str(&body).expect("Response is not valid JSON");
+
+  //     // Check for keys.
+  //     let block_hashes = json.get("block_hashes").expect("Missing block_hashes key");
+  //     let prev_page = json.get("prev_page").expect("Missing prev_page key");
+  //     let next_page = json.get("next_page").expect("Missing next_page key");
+
+  //     // For page 0 we expect prev_page to be null.
+  //     assert!(prev_page.is_null());
+
+  //     // Assume that, in your test data, page 0 returns exactly 100 block hashes.
+  //     let hashes = block_hashes.as_array().expect("block_hashes is not an array");
+  //     assert_eq!(hashes.len(), 100);
+
+  //     // Optionally, if your test data is known, verify that the first and last hash values are what you expect.
+  //     // (Replace these expected strings with the actual values from your test fixture.)
+  //     let first_hash = hashes.first().unwrap().as_str().unwrap();
+  //     let last_hash = hashes.last().unwrap().as_str().unwrap();
+  //     assert_eq!(first_hash, "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+  //     // For example, if block 99’s hash is expected to be "expected_hash_value", then:
+  //     // assert_eq!(last_hash, "expected_hash_value");
+
+  //     // If your test data does not have additional blocks beyond page 0, next_page should be null.
+  //     // Otherwise, if there are more blocks, next_page might be a number.
+  //     // Here we simply assert that the key exists and is either null or a number.
+  //     assert!(next_page.is_null() || next_page.is_number());
+  // }
 
   #[test]
   fn block_time_endpoint() {


### PR DESCRIPTION
This endpoint is intended to fix #3879 by providing an array of 100 blockhashes starting at block `/{start}`.  If this endpoint is called with `/{start}/{interval}`, the array will contain 100 blockhashes starting at block `/{start}` and then skip `/{interval}` before the 2nd blockhash, and so on.  Finally, if the endpoint is called with `/{start}/{interval}/{page}`, the array will contain 100 blockhashes starting at block `/{start}` and then skip `/{interval}` before returning the `/{page}` of results for `/{start}/{interval}`.  If there are not 100 blockhashes for the provided parameters, a smaller dataset will be returned.  If there are no blockhashes for the provided parameters, an empty set will be produced.

For example, calling `curl -s -H "Accept: application/json"   http://localhost/blockhashes/0 | jq` will return blockhashes for blocks 0-99.  Calling `curl -s -H "Accept: application/json"   http://localhost/blockhashes/0/2 | jq` will return every other blockhash, starting with block 0 so that the set contains blockhashes for block 0, 2, 4, 6, etc-198.  Finally, the pagination works by calling `curl -s -H "Accept: application/json"   http://localhost/blockhashes/0/1/1 | jq` to get the second page of blockhashes starting with block 0 without an interval, so the array would contain blockhashes 100-199.  `curl -s -H "Accept: application/json"   http://localhost/blockhashes/0/100/0 | jq ` would give you block 0, 100, 200, 300, etc.

***Reviewer note**: this is definitely my most involved PR to date, and while I have tested this code and confirmed the results and that all tests pass, I'd be surprised if everything here is done 100% correctly.  I am also really new to tests, so I'm hoping the coverage included makes sense but am also open to adding more tests if needed.  Please provide feedback as to what needs improvement and I'll work to make it happen.  Additionally, I will add documentation once this has passed review, either in this or a new PR.  Thanks!