### PR TITLE
Don't unnecessarily bump pointer by postage for SameSat mode

### DIFF
--- a/src/wallet/batch/file.rs
+++ b/src/wallet/batch/file.rs
@@ -161,7 +161,9 @@ impl File {
         self.postage.map(Amount::from_sat).unwrap_or(TARGET_POSTAGE)
       };
 
-      pointer += postage.to_sat();
+      if self.mode != Mode::SameSat {
+        pointer += postage.to_sat();
+      }
 
       if self.mode == Mode::SameSat && i > 0 {
         continue;


### PR DESCRIPTION
Noticed that the pointer gets bumped by the postage amount for every inscription even when in `SameSat` mode. Added a small fix to only bump the pointer when in other modes.

This doesn't change which sat inscriptions are attached to because they all overflow back to a pointer of 0 anyway. You do save some space on unnecessary pointers though.