### PR TITLE
Upgrade redb to 2.4.0 to improve reorg performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ mime_guess = "2.0.4"
 miniscript = "12.0.0"
 mp4 = "0.14.0"
 ordinals = { version = "0.0.15", path = "crates/ordinals" }
-redb = "2.3.0"
+redb = "2.4.0"
 ref-cast = "1.0.23"
 regex.workspace = true
 reqwest.workspace = true


### PR DESCRIPTION
Reorg just happened today and I have a version of ord 22.1 running redb 2.3.0 that is still working to recover(and probably will take 1-2 hours) and the one with redb 2.4.0 recovered in 1 second.

https://github.com/cberner/redb/releases/tag/v2.4.0

https://github.com/ordinals/ord/issues/4207 @raphjaph 