### PR TITLE
Extend properties CDDL with attributes

### DIFF
--- a/docs/src/inscriptions/properties.md
+++ b/docs/src/inscriptions/properties.md
@@ -20,13 +20,40 @@ of the properties value is as follows:
 ```cddl
 Properties = {
   ? 0: [*GalleryItem],
+  ? 1: Attributes,
   * any => any,
 }
 
 GalleryItem = {
-  ? 0: bstr .size (32..36),
+  ? 0: bytes .size (32..36), ; inscription ID
+  ? 1: Attributes,
   * any => any,
 }
+
+Attributes = {
+  ? 0: text,   ; title
+  ? 1: text,   ; description
+  ? 2: text,   ; alt text
+  ? 3: text,   ; author
+  ? 4: Traits, ; traits
+}
+
+Traits = {
+  * text => Value
+}
+
+Value =
+  Proportion /
+  bool /
+  bytes /
+  float /
+  integer /
+  tdate /
+  text /
+  time /
+  uri
+
+Proportion = #6.6582895(float)
 ```
 
 The above CDDL schema is provided as a convenience. As always, the ordinals

--- a/docs/src/inscriptions/properties.md
+++ b/docs/src/inscriptions/properties.md
@@ -54,6 +54,8 @@ Value =
   uri ; <a> tag
 
 Proportion = #6.6582895(float) ; value may be between 0 and 1 inclusive
+InscriptionId = #6.6582896(bytes .size (32..36)) ; links to `/inscription/<id>`
+RuneId = #6.6582897([integer, integer]) ; links to `/rune/<id>`
 ```
 
 The above CDDL schema is provided as a convenience. As always, the ordinals

--- a/docs/src/inscriptions/properties.md
+++ b/docs/src/inscriptions/properties.md
@@ -33,10 +33,9 @@ GalleryItem = {
 Attributes = {
   ? 0: text, ; title
   ? 1: text, ; description
-  ? 2: text, ; alt text
-  ? 3: text, ; author
-  ? 4: [+ uri], ; links
-  ? 5: Traits, ; traits
+  ? 2: text, ; author
+  ? 3: [+ uri], ; links
+  ? 4: Traits, ; traits
 }
 
 Traits = {

--- a/docs/src/inscriptions/properties.md
+++ b/docs/src/inscriptions/properties.md
@@ -31,11 +31,12 @@ GalleryItem = {
 }
 
 Attributes = {
-  ? 0: text,   ; title
-  ? 1: text,   ; description
-  ? 2: text,   ; alt text
-  ? 3: text,   ; author
-  ? 4: Traits, ; traits
+  ? 0: text, ; title
+  ? 1: text, ; description
+  ? 2: text, ; alt text
+  ? 3: text, ; author
+  ? 4: [+ uri], ; links
+  ? 5: Traits, ; traits
 }
 
 Traits = {
@@ -43,17 +44,17 @@ Traits = {
 }
 
 Value =
-  Proportion /
-  bool /
-  bytes /
-  float /
-  integer /
-  tdate /
-  text /
-  time /
-  uri
+  Proportion / ; progress bar
+  bool / ; "yes" or "no"
+  bytes / ; hex
+  float / ; decimal
+  integer / ; integer
+  tdate / ; date-time string
+  text / ; text
+  time / ; date-time string from epoch timestamp
+  uri ; <a> tag
 
-Proportion = #6.6582895(float)
+Proportion = #6.6582895(float) ; value may be between 0 and 1 inclusive
 ```
 
 The above CDDL schema is provided as a convenience. As always, the ordinals

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -164,4 +164,13 @@ mod tests {
 
     assert_eq!(Properties::from_cbor(&buffer), Properties::default());
   }
+
+  #[test]
+  fn ord_tag() {
+    let mut value = 0;
+    for (i, c) in "ord".chars().enumerate() {
+      value += u32::from(c) << (i * 8);
+    }
+    assert_eq!(value, 6582895);
+  }
 }


### PR DESCRIPTION
Fixes #4222. As a first stab, just extend the CDDL.

To do:
- write tests for all different value types
- make sure trait order is preserved
- how should gallery item metadata be displayed?
- hidden metadata
- look at existing collection attributes
- add a value for "none", since this seems to be common