### PR TITLE
Make ParsedEnvelope and Envelope public

### DIFF
--- a/src/inscriptions.rs
+++ b/src/inscriptions.rs
@@ -2,9 +2,12 @@ use super::*;
 
 use tag::Tag;
 
-pub(crate) use self::{envelope::ParsedEnvelope, media::Media};
+pub(crate) use self::media::Media;
 
-pub use self::{envelope::Envelope, inscription::Inscription, inscription_id::InscriptionId};
+pub use self::{
+  envelope::Envelope, envelope::ParsedEnvelope, envelope::RawEnvelope, inscription::Inscription,
+  inscription_id::InscriptionId,
+};
 
 mod envelope;
 mod inscription;

--- a/src/inscriptions/envelope.rs
+++ b/src/inscriptions/envelope.rs
@@ -14,8 +14,8 @@ pub(crate) const PROTOCOL_ID: [u8; 3] = *b"ord";
 pub(crate) const BODY_TAG: [u8; 0] = [];
 
 type Result<T> = std::result::Result<T, script::Error>;
-type RawEnvelope = Envelope<Vec<Vec<u8>>>;
-pub(crate) type ParsedEnvelope = Envelope<Inscription>;
+pub type RawEnvelope = Envelope<Vec<Vec<u8>>>;
+pub type ParsedEnvelope = Envelope<Inscription>;
 
 #[derive(Default, PartialEq, Clone, Serialize, Deserialize, Debug, Eq)]
 pub struct Envelope<T> {
@@ -92,7 +92,7 @@ impl From<RawEnvelope> for ParsedEnvelope {
 }
 
 impl ParsedEnvelope {
-  pub(crate) fn from_transaction(transaction: &Transaction) -> Vec<Self> {
+  pub fn from_transaction(transaction: &Transaction) -> Vec<Self> {
     RawEnvelope::from_transaction(transaction)
       .into_iter()
       .map(|envelope| envelope.into())
@@ -101,7 +101,7 @@ impl ParsedEnvelope {
 }
 
 impl RawEnvelope {
-  pub(crate) fn from_transaction(transaction: &Transaction) -> Vec<Self> {
+  pub fn from_transaction(transaction: &Transaction) -> Vec<Self> {
     let mut envelopes = Vec::new();
 
     for (i, input) in transaction.input.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use {
     inscriptions::{
       inscription_id,
       media::{self, ImageRendering, Media},
-      teleburn, ParsedEnvelope,
+      teleburn,
     },
     into_usize::IntoUsize,
     option_ext::OptionExt,
@@ -96,7 +96,7 @@ pub use self::{
   chain::Chain,
   fee_rate::FeeRate,
   index::{Index, RuneEntry},
-  inscriptions::{Envelope, Inscription, InscriptionId},
+  inscriptions::{Envelope, ParsedEnvelope, RawEnvelope, Inscription, InscriptionId},
   object::Object,
   options::Options,
   wallet::transaction_builder::{Target, TransactionBuilder},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub use self::{
   chain::Chain,
   fee_rate::FeeRate,
   index::{Index, RuneEntry},
-  inscriptions::{Envelope, ParsedEnvelope, RawEnvelope, Inscription, InscriptionId},
+  inscriptions::{Envelope, Inscription, InscriptionId, ParsedEnvelope, RawEnvelope},
   object::Object,
   options::Options,
   wallet::transaction_builder::{Target, TransactionBuilder},


### PR DESCRIPTION
Fix #4246, the PR allows people to access ParsedEnvelope::from_transaction for parsing inscriptions from their Rust code.