### PR TITLE
Runes 2.0 proposal

### DIFF
--- a/crates/ordinals/src/etching.rs
+++ b/crates/ordinals/src/etching.rs
@@ -9,6 +9,7 @@ pub struct Etching {
   pub symbol: Option<char>,
   pub terms: Option<Terms>,
   pub turbo: bool,
+  pub minter: Option<u32>,
 }
 
 impl Etching {

--- a/crates/ordinals/src/runestone/tag.rs
+++ b/crates/ordinals/src/runestone/tag.rs
@@ -20,6 +20,7 @@ pub(super) enum Tag {
   Divisibility = 1,
   Spacers = 3,
   Symbol = 5,
+  Minter = 7,
   #[allow(unused)]
   Nop = 127,
 }


### PR DESCRIPTION
# Runes 2.0 proposal

Currently Runes have a specific Mint mechanism where anyone can mint a certain amount of runes for some specified period.

As Runes has gained huge popularity as the native token standard for BTC, there is a suggestion to improve the existing standard by allowing the specification of Minter Bitcoin address in Etching inscription.


```rs
struct Etching {
  divisibility: Option<u8>,
  premine: Option<u128>,
  rune: Option<Rune>,
  spacers: Option<u32>,
  symbol: Option<char>,
  terms: Option<Terms>,
  minter: Option<u32>,
  // ...other minting parameters, discussable...
}
```

To preserve the original compact structure of Runestone we can use `Runestone.Edict` for additional mintings. `Etching.minter` can make `Edict { id, Amount: minAmount, Output: outputIndex }` and place a transaction output at outputIndex with the output script set to the target address, to which minting should happen. To only allow this minting for `Etching.minter` we must add a condition to accept a transaction: at least one of the inputs in the transaction must use the previous output that belongs to `Etching.minter`. 

## Potential solution to allow Minter address change:

We can set `Runestone.Mint` and make `Edict { id, Amount: 0, Output: outputIndex, }` with 0 amount where `outputIndex` will correspond to output with a script set to the corresponding script of the new Minter address.

## Global adjustments

There can be other suggestions on how to efficiently add this targeted minting mechanism by Minter and how to perform minting transaction validation.

Small adjustments can be easily reflected at the official Ord indexer, libraries and wallets that support Runes.

## Main use case  

The main use case to support such minting is to enable Runes stablecoins where the total supply of coins cannot be known in advance.  
