### PR TITLE
Include blockhash in /r/utxo response

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -164,6 +164,7 @@ pub struct UtxoRecursive {
   pub runes: Option<BTreeMap<SpacedRune, Pile>>,
   pub sat_ranges: Option<Vec<(u64, u64)>>,
   pub value: u64,
+  pub blockhash: Option<BlockHash>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]

--- a/src/index.rs
+++ b/src/index.rs
@@ -2393,11 +2393,20 @@ impl Index {
       return Ok(None);
     };
 
+    let Some(tx_info) = self
+      .client
+      .get_raw_transaction_info(&outpoint.txid, None)
+      .into_option()?
+    else {
+      panic!("can't get transaction info: {}", &outpoint.txid);
+    };
+
     Ok(Some(api::UtxoRecursive {
       inscriptions: self.get_inscriptions_for_output(outpoint)?,
       runes: self.get_rune_balances_for_output(outpoint)?,
       sat_ranges: self.list(outpoint)?,
       value: utxo_entry.value().parse(self).total_value(),
+      blockhash: tx_info.blockhash,
     }))
   }
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -6072,7 +6072,7 @@ next
       ..default()
     });
 
-    server.mine_blocks(1);
+    let block = &server.mine_blocks(1)[0];
 
     let inscription_id = InscriptionId { txid, index: 0 };
     let second_inscription_id = InscriptionId { txid, index: 1 };
@@ -6102,6 +6102,7 @@ next
           (50 * COIN_VALUE, 2 * 50 * COIN_VALUE)
         ]),
         value: 150 * COIN_VALUE,
+        blockhash: Some(block.header.block_hash()),
       }
     );
   }
@@ -6117,7 +6118,7 @@ next
       ..default()
     });
 
-    server.mine_blocks(1);
+    let block = &server.mine_blocks(1)[0];
 
     let inscription_id = InscriptionId { txid, index: 0 };
     let outpoint: OutPoint = OutPoint { txid, vout: 0 };
@@ -6131,6 +6132,7 @@ next
         runes: None,
         sat_ranges: None,
         value: 50 * COIN_VALUE,
+        blockhash: Some(block.header.block_hash()),
       }
     );
   }


### PR DESCRIPTION
This enables recursive retrieval of a UTXO blockhash, allowing to determine how long an inscription has been held or when it was burned.