### PR TITLE
Add "In reserve" Rune Field

### DIFF
--- a/src/templates/rune.rs
+++ b/src/templates/rune.rs
@@ -6,6 +6,12 @@ pub struct RuneHtml {
   pub id: RuneId,
   pub mintable: bool,
   pub parent: Option<InscriptionId>,
+  /// The amount of runes held at the same address as the parent inscription (reserved supply)
+  /// 
+  /// This is calculated by finding all balances of this rune at the same address that
+  /// holds the parent inscription. These runes can be considered "reserved" or "in reserve"
+  /// and are often used by creators to distribute later.
+  pub reserved: Option<u128>,
 }
 
 impl RuneHtml {
@@ -39,6 +45,7 @@ impl PageContent for RuneHtml {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use regex::Regex;
 
   #[test]
   fn display() {
@@ -72,6 +79,7 @@ mod tests {
           txid: Txid::all_zeros(),
           index: 0,
         }),
+        reserved: Some(100),
       },
       "<h1>B•CGDENLQRQWDSLRUGSNLBTMFIJAV</h1>
 .*<a href=/inscription/.*<iframe .* src=/preview/0{64}i0></iframe></a>.*
@@ -108,7 +116,9 @@ mod tests {
     </dl>
   </dd>
   <dt>supply</dt>
-  <dd>100.123456889\u{A0}@</dd>
+  <dd>100.123456789\u{A0}@</dd>
+  <dt>reserved</dt>
+  <dd>0.0000001\u{A0}@</dd>
   <dt>premine</dt>
   <dd>0.123456789\u{A0}@</dd>
   <dt>premine percentage</dt>
@@ -154,6 +164,7 @@ mod tests {
         id: RuneId { block: 10, tx: 9 },
         mintable: false,
         parent: None,
+        reserved: None,
       },
       "<h1>B•CGDENLQRQWDSLRUGSNLBTMFIJAV</h1>
 <dl>.*
@@ -188,6 +199,7 @@ mod tests {
         id: RuneId { block: 10, tx: 9 },
         mintable: false,
         parent: None,
+        reserved: None,
       },
       "<h1>B•CGDENLQRQWDSLRUGSNLBTMFIJAV</h1>
 <dl>.*
@@ -227,6 +239,7 @@ mod tests {
         id: RuneId { block: 10, tx: 9 },
         mintable: false,
         parent: None,
+        reserved: None,
       },
       "<h1>B•CGDENLQRQWDSLRUGSNLBTMFIJAV</h1>
 <dl>.*
@@ -286,6 +299,7 @@ mod tests {
           txid: Txid::all_zeros(),
           index: 0,
         }),
+        reserved: Some(100),
       },
       ".*
       <dt>mintable</dt>
@@ -323,6 +337,7 @@ mod tests {
           txid: Txid::all_zeros(),
           index: 0,
         }),
+        reserved: Some(200),
       },
       ".*
       <dt>mintable</dt>

--- a/templates/rune.html
+++ b/templates/rune.html
@@ -54,8 +54,15 @@
 %% } else {
   <dd>no</dd>
 %% }
+%% if let Some(reserved) = self.reserved {
   <dt>supply</dt>
-  <dd>{{ self.entry.pile(self.entry.supply()) }}</dd>
+  <dd>{{ self.entry.pile(self.entry.supply() - reserved) }}</dd>
+  <dt>reserved</dt>
+  <dd>{{ self.entry.pile(reserved) }}</dd>
+%% } else {
+    <dt>supply</dt>
+    <dd>{{ self.entry.pile(self.entry.supply()) }}</dd>
+%% }
   <dt>premine</dt>
   <dd>{{ self.entry.pile(self.entry.premine) }}</dd>
   <dt>premine percentage</dt>

--- a/tests/json_api.rs
+++ b/tests/json_api.rs
@@ -632,6 +632,7 @@ fn get_runes() {
         txid: a.output.reveal,
         index: 0,
       }),
+      reserved: Some(1000),
     }
   );
 


### PR DESCRIPTION
This PR implements a new "in reserve" field, referenced in this issue https://github.com/ordinals/ord/issues/3895. This field represents the amount of runes held at the same address as the parent inscription. This feature helps users distinguish between the total supply and the portion that's still controlled by the original creator/issuer.  

## Key Changes:
- Added a new `reserved` field to the Rune structs in API responses
- Implemented `calculate_rune_reserved` helper function to determine the reserved amount
- Updated HTML templates to display `reserved `supply separately from circulating `supply`

## Implementation Details  

The "in reserve" calculation works by:
- Finding the parent inscription of a rune
- Determining which address holds that parent inscription
- Iterating through **all UTXOs (outputs)** owned by that address to find balances of the specific rune
- Summing up all found balances to calculate the total reserved amount

No changes to the index structure were made. Currently, scans all address outpoints rather than using a direct lookup mechanism.

## Test Coverage
Implemented several server tests:
- `rune_without_parent_shows_no_reserved_supply` –– runes without parent inscriptions
- `rune_shows_reserved_supply` –– runes with parent inscriptions
- `rune_reserved_supply_changes_when_transferred` –– the **reserved** calculations logic is correct

Open to comments and suggestions :)