### PR TITLE
Better preview titles

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1459,15 +1459,15 @@ impl Server {
       if settings.is_hidden(inscription_id) {
         return Ok(PreviewUnknownHtml.into_response());
       }
-      let inscription_number = index
-        .get_inscription_entry(inscription_id)
-        .unwrap()
-        .unwrap()
-        .inscription_number;
 
       let mut inscription = index
         .get_inscription_by_id(inscription_id)?
         .ok_or_not_found(|| format!("inscription {inscription_id}"))?;
+
+      let inscription_number = index
+        .get_inscription_entry(inscription_id)?
+        .ok_or_not_found(|| format!("inscription {inscription_id}"))?
+        .inscription_number;
 
       if let Some(delegate) = inscription.delegate() {
         inscription = index

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -4682,6 +4682,9 @@ mod tests {
       let text = response.text().unwrap();
       let re = Regex::new(expected).unwrap();
 
+      dbg!(&text);
+      dbg!(&re);
+
       if !re.is_match(&text) {
         panic!(
           "/{endpoint} response for {}: {sec_fetch_dest} did not match regex {expected}:\n{text}",
@@ -4701,9 +4704,8 @@ mod tests {
 
     server.mine_blocks(1);
 
-    let pattern = format!(
-      r".*<title>Inscription 0 Preview</title>.*<iframe sandbox=allow-scripts loading=lazy src=/content/{id}></iframe>.*"
-    );
+    let pattern =
+      format!(r".*<iframe sandbox=allow-scripts loading=lazy src=/content/{id}></iframe>.*");
 
     case(&server, id, "preview", "iframe", "foo");
     case(&server, id, "preview", "document", &pattern);

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1475,6 +1475,10 @@ impl Server {
       if settings.is_hidden(inscription_id) {
         return Ok(PreviewUnknownHtml.into_response());
       }
+      let entry = index
+        .get_inscription_entry(inscription_id)
+        .unwrap()
+        .unwrap();
 
       let mut inscription = index
         .get_inscription_by_id(inscription_id)?
@@ -1505,22 +1509,37 @@ impl Server {
       let content_security_policy = server_config.preview_content_security_policy(media)?;
 
       match media {
-        Media::Audio => {
-          Ok((content_security_policy, PreviewAudioHtml { inscription_id }).into_response())
-        }
+        Media::Audio => Ok(
+          (
+            content_security_policy,
+            PreviewAudioHtml {
+              inscription_id,
+              inscription_number: entry.inscription_number,
+            },
+          )
+            .into_response(),
+        ),
         Media::Code(language) => Ok(
           (
             content_security_policy,
             PreviewCodeHtml {
               inscription_id,
               language,
+              inscription_number: entry.inscription_number,
             },
           )
             .into_response(),
         ),
-        Media::Font => {
-          Ok((content_security_policy, PreviewFontHtml { inscription_id }).into_response())
-        }
+        Media::Font => Ok(
+          (
+            content_security_policy,
+            PreviewFontHtml {
+              inscription_id,
+              inscription_number: entry.inscription_number,
+            },
+          )
+            .into_response(),
+        ),
         Media::Iframe => unreachable!(),
         Media::Image(image_rendering) => Ok(
           (
@@ -1528,6 +1547,7 @@ impl Server {
             PreviewImageHtml {
               image_rendering,
               inscription_id,
+              inscription_number: entry.inscription_number,
             },
           )
             .into_response(),
@@ -1535,23 +1555,54 @@ impl Server {
         Media::Markdown => Ok(
           (
             content_security_policy,
-            PreviewMarkdownHtml { inscription_id },
+            PreviewMarkdownHtml {
+              inscription_id,
+              inscription_number: entry.inscription_number,
+            },
           )
             .into_response(),
         ),
-        Media::Model => {
-          Ok((content_security_policy, PreviewModelHtml { inscription_id }).into_response())
-        }
-        Media::Pdf => {
-          Ok((content_security_policy, PreviewPdfHtml { inscription_id }).into_response())
-        }
-        Media::Text => {
-          Ok((content_security_policy, PreviewTextHtml { inscription_id }).into_response())
-        }
+        Media::Model => Ok(
+          (
+            content_security_policy,
+            PreviewModelHtml {
+              inscription_id,
+              inscription_number: entry.inscription_number,
+            },
+          )
+            .into_response(),
+        ),
+        Media::Pdf => Ok(
+          (
+            content_security_policy,
+            PreviewPdfHtml {
+              inscription_id,
+              inscription_number: entry.inscription_number,
+            },
+          )
+            .into_response(),
+        ),
+        Media::Text => Ok(
+          (
+            content_security_policy,
+            PreviewTextHtml {
+              inscription_id,
+              inscription_number: entry.inscription_number,
+            },
+          )
+            .into_response(),
+        ),
         Media::Unknown => Ok((content_security_policy, PreviewUnknownHtml).into_response()),
-        Media::Video => {
-          Ok((content_security_policy, PreviewVideoHtml { inscription_id }).into_response())
-        }
+        Media::Video => Ok(
+          (
+            content_security_policy,
+            PreviewVideoHtml {
+              inscription_id,
+              inscription_number: entry.inscription_number,
+            },
+          )
+            .into_response(),
+        ),
       }
     })
   }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -4422,7 +4422,10 @@ mod tests {
         format!("/preview/{}", inscription_id),
         StatusCode::OK,
         "default-src 'self'",
-        format!(".*<html lang=en data-inscription={}>.*", inscription_id),
+        format!(
+          ".*<html lang=en data-inscription={}>.*<title>Inscription 0 Preview</title>.*",
+          inscription_id
+        ),
       );
     }
 
@@ -4698,8 +4701,9 @@ mod tests {
 
     server.mine_blocks(1);
 
-    let pattern =
-      format!(r".*<iframe sandbox=allow-scripts loading=lazy src=/content/{id}></iframe>.*");
+    let pattern = format!(
+      r".*<title>Inscription 0 Preview</title>.*<iframe sandbox=allow-scripts loading=lazy src=/content/{id}></iframe>.*"
+    );
 
     case(&server, id, "preview", "iframe", "foo");
     case(&server, id, "preview", "document", &pattern);

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1475,10 +1475,11 @@ impl Server {
       if settings.is_hidden(inscription_id) {
         return Ok(PreviewUnknownHtml.into_response());
       }
-      let entry = index
+      let inscription_number = index
         .get_inscription_entry(inscription_id)
         .unwrap()
-        .unwrap();
+        .unwrap()
+        .inscription_number;
 
       let mut inscription = index
         .get_inscription_by_id(inscription_id)?
@@ -1497,6 +1498,7 @@ impl Server {
           r::content_response(
             &server_config,
             inscription_id,
+            inscription_number,
             accept_encoding,
             sec_fetch_dest,
             inscription,
@@ -1514,7 +1516,7 @@ impl Server {
             content_security_policy,
             PreviewAudioHtml {
               inscription_id,
-              inscription_number: entry.inscription_number,
+              inscription_number,
             },
           )
             .into_response(),
@@ -1525,7 +1527,7 @@ impl Server {
             PreviewCodeHtml {
               inscription_id,
               language,
-              inscription_number: entry.inscription_number,
+              inscription_number,
             },
           )
             .into_response(),
@@ -1535,7 +1537,7 @@ impl Server {
             content_security_policy,
             PreviewFontHtml {
               inscription_id,
-              inscription_number: entry.inscription_number,
+              inscription_number,
             },
           )
             .into_response(),
@@ -1547,7 +1549,7 @@ impl Server {
             PreviewImageHtml {
               image_rendering,
               inscription_id,
-              inscription_number: entry.inscription_number,
+              inscription_number,
             },
           )
             .into_response(),
@@ -1557,7 +1559,7 @@ impl Server {
             content_security_policy,
             PreviewMarkdownHtml {
               inscription_id,
-              inscription_number: entry.inscription_number,
+              inscription_number,
             },
           )
             .into_response(),
@@ -1567,7 +1569,7 @@ impl Server {
             content_security_policy,
             PreviewModelHtml {
               inscription_id,
-              inscription_number: entry.inscription_number,
+              inscription_number,
             },
           )
             .into_response(),
@@ -1577,7 +1579,7 @@ impl Server {
             content_security_policy,
             PreviewPdfHtml {
               inscription_id,
-              inscription_number: entry.inscription_number,
+              inscription_number,
             },
           )
             .into_response(),
@@ -1587,7 +1589,7 @@ impl Server {
             content_security_policy,
             PreviewTextHtml {
               inscription_id,
-              inscription_number: entry.inscription_number,
+              inscription_number,
             },
           )
             .into_response(),
@@ -1598,7 +1600,7 @@ impl Server {
             content_security_policy,
             PreviewVideoHtml {
               inscription_id,
-              inscription_number: entry.inscription_number,
+              inscription_number,
             },
           )
             .into_response(),
@@ -4336,6 +4338,7 @@ mod tests {
     assert!(r::content_response(
       &ServerConfig::default(),
       inscription_id(0),
+      0,
       AcceptEncoding::default(),
       SecFetchDest::Other,
       Inscription {
@@ -4353,6 +4356,7 @@ mod tests {
     let response = r::content_response(
       &ServerConfig::default(),
       inscription_id(0),
+      0,
       AcceptEncoding::default(),
       SecFetchDest::Other,
       Inscription {
@@ -4373,6 +4377,7 @@ mod tests {
     let response = r::content_response(
       &ServerConfig::default(),
       inscription_id(0),
+      0,
       AcceptEncoding::default(),
       SecFetchDest::Other,
       Inscription {
@@ -4398,6 +4403,7 @@ mod tests {
         ..default()
       },
       inscription_id(0),
+      0,
       AcceptEncoding::default(),
       SecFetchDest::Other,
       Inscription {
@@ -4492,6 +4498,7 @@ mod tests {
     let content_response = r::content_response(
       &ServerConfig::default(),
       inscription_id(0),
+      0,
       AcceptEncoding::default(),
       SecFetchDest::Other,
       Inscription {
@@ -4512,6 +4519,7 @@ mod tests {
     let content_response = r::content_response(
       &ServerConfig::default(),
       inscription_id(0),
+      0,
       AcceptEncoding::default(),
       SecFetchDest::Other,
       Inscription {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -4682,9 +4682,6 @@ mod tests {
       let text = response.text().unwrap();
       let re = Regex::new(expected).unwrap();
 
-      dbg!(&text);
-      dbg!(&re);
-
       if !re.is_match(&text) {
         panic!(
           "/{endpoint} response for {}: {sec_fetch_dest} did not match regex {expected}:\n{text}",

--- a/src/subcommand/server/r.rs
+++ b/src/subcommand/server/r.rs
@@ -299,8 +299,14 @@ pub(crate) fn content_response(
   inscription: Inscription,
 ) -> ServerResult<Option<ContentResponse>> {
   if sec_fetch_dest == SecFetchDest::Document {
+    let inscription_number = 0;
     return Ok(Some(ContentResponse {
-      body: PreviewIframeHtml { inscription_id }.to_string().into(),
+      body: PreviewIframeHtml {
+        inscription_id,
+        inscription_number,
+      }
+      .to_string()
+      .into(),
       cache_control: None,
       content_encoding: None,
       content_security_policy: HeaderValue::from_static("default-src 'self'"),

--- a/src/subcommand/server/r.rs
+++ b/src/subcommand/server/r.rs
@@ -235,10 +235,16 @@ pub(super) async fn content(
         .ok_or_not_found(|| format!("delegate {inscription_id}"))?
     }
 
+    let inscription_number = index
+      .get_inscription_entry(inscription_id)
+      .unwrap()
+      .unwrap()
+      .inscription_number;
     Ok(
       content_response(
         &server_config,
         inscription_id,
+        inscription_number,
         accept_encoding,
         sec_fetch_dest,
         inscription,
@@ -294,12 +300,12 @@ impl IntoResponse for ContentResponse {
 pub(crate) fn content_response(
   server_config: &ServerConfig,
   inscription_id: InscriptionId,
+  inscription_number: i32,
   accept_encoding: AcceptEncoding,
   sec_fetch_dest: SecFetchDest,
   inscription: Inscription,
 ) -> ServerResult<Option<ContentResponse>> {
   if sec_fetch_dest == SecFetchDest::Document {
-    let inscription_number = 0;
     return Ok(Some(ContentResponse {
       body: PreviewIframeHtml {
         inscription_id,
@@ -651,10 +657,17 @@ pub(super) async fn undelegated_content(
       .get_inscription_by_id(inscription_id)?
       .ok_or_not_found(|| format!("inscription {inscription_id}"))?;
 
+    let inscription_number = index
+      .get_inscription_entry(inscription_id)
+      .unwrap()
+      .unwrap()
+      .inscription_number;
+
     Ok(
       r::content_response(
         &server_config,
         inscription_id,
+        inscription_number,
         accept_encoding,
         sec_fetch_dest,
         inscription,

--- a/src/subcommand/server/r.rs
+++ b/src/subcommand/server/r.rs
@@ -229,17 +229,17 @@ pub(super) async fn content(
       )));
     };
 
+    let inscription_number = index
+      .get_inscription_entry(inscription_id)?
+      .ok_or_not_found(|| format!("inscription {inscription_id}"))?
+      .inscription_number;
+
     if let Some(delegate) = inscription.delegate() {
       inscription = index
         .get_inscription_by_id(delegate)?
         .ok_or_not_found(|| format!("delegate {inscription_id}"))?
     }
 
-    let inscription_number = index
-      .get_inscription_entry(inscription_id)
-      .unwrap()
-      .unwrap()
-      .inscription_number;
     Ok(
       content_response(
         &server_config,
@@ -658,9 +658,8 @@ pub(super) async fn undelegated_content(
       .ok_or_not_found(|| format!("inscription {inscription_id}"))?;
 
     let inscription_number = index
-      .get_inscription_entry(inscription_id)
-      .unwrap()
-      .unwrap()
+      .get_inscription_entry(inscription_id)?
+      .ok_or_not_found(|| format!("inscription {inscription_id}"))?
       .inscription_number;
 
     Ok(

--- a/src/templates/preview.rs
+++ b/src/templates/preview.rs
@@ -3,48 +3,57 @@ use super::*;
 #[derive(Boilerplate)]
 pub(crate) struct PreviewAudioHtml {
   pub(crate) inscription_id: InscriptionId,
+  pub(crate) inscription_number: i32,
 }
 
 #[derive(Boilerplate)]
 pub(crate) struct PreviewCodeHtml {
   pub(crate) inscription_id: InscriptionId,
   pub(crate) language: media::Language,
+  pub(crate) inscription_number: i32,
 }
 
 #[derive(Boilerplate)]
 pub(crate) struct PreviewFontHtml {
   pub(crate) inscription_id: InscriptionId,
+  pub(crate) inscription_number: i32,
 }
 
 #[derive(Boilerplate)]
 pub struct PreviewIframeHtml {
   pub inscription_id: InscriptionId,
+  pub inscription_number: i32,
 }
 
 #[derive(Boilerplate)]
 pub(crate) struct PreviewImageHtml {
   pub(crate) image_rendering: ImageRendering,
   pub(crate) inscription_id: InscriptionId,
+  pub(crate) inscription_number: i32,
 }
 
 #[derive(Boilerplate)]
 pub(crate) struct PreviewMarkdownHtml {
   pub(crate) inscription_id: InscriptionId,
+  pub(crate) inscription_number: i32,
 }
 
 #[derive(Boilerplate)]
 pub(crate) struct PreviewModelHtml {
   pub(crate) inscription_id: InscriptionId,
+  pub(crate) inscription_number: i32,
 }
 
 #[derive(Boilerplate)]
 pub(crate) struct PreviewPdfHtml {
   pub(crate) inscription_id: InscriptionId,
+  pub(crate) inscription_number: i32,
 }
 
 #[derive(Boilerplate)]
 pub(crate) struct PreviewTextHtml {
   pub(crate) inscription_id: InscriptionId,
+  pub(crate) inscription_number: i32,
 }
 
 #[derive(Boilerplate)]
@@ -53,4 +62,5 @@ pub(crate) struct PreviewUnknownHtml;
 #[derive(Boilerplate)]
 pub(crate) struct PreviewVideoHtml {
   pub(crate) inscription_id: InscriptionId,
+  pub(crate) inscription_number: i32,
 }

--- a/templates/preview-audio.html
+++ b/templates/preview-audio.html
@@ -2,6 +2,7 @@
 <html lang=en>
   <head>
     <meta charset=utf-8>
+    <title>Inscription {{self.inscription_number}} Preview</title>
     <link rel=stylesheet href=/static/preview-audio.css>
   </head>
   <body>

--- a/templates/preview-code.html
+++ b/templates/preview-code.html
@@ -2,6 +2,7 @@
 <html lang=en data-inscription={{self.inscription_id}} data-language={{self.language}}>
   <head>
     <meta charset=utf-8>
+    <title>Inscription {{self.inscription_number}} Preview</title>
     <link rel=stylesheet href=/static/preview-code.css>
     <script src=/static/preview-code.js defer type=module></script>
   </head>

--- a/templates/preview-font.html
+++ b/templates/preview-font.html
@@ -2,6 +2,7 @@
 <html lang=en >
   <head>
     <meta charset=utf-8>
+    <title>Inscription {{self.inscription_number}} Preview</title>
     <style>
       @font-face {
         font-family: 'Inscription';

--- a/templates/preview-iframe.html
+++ b/templates/preview-iframe.html
@@ -2,6 +2,7 @@
 <html lang=en>
   <head>
     <meta charset=utf-8>
+    <title>Inscription {{self.inscription_number}} Preview</title>
     <link rel=stylesheet href=/static/preview-iframe.css>
   </head>
   <body>

--- a/templates/preview-image.html
+++ b/templates/preview-image.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset=utf-8>
     <meta name=format-detection content='telephone=no'>
+    <title>Inscription {{self.inscription_number}} Preview</title>
     <style>
       html {
         background-color: #131516;

--- a/templates/preview-markdown.html
+++ b/templates/preview-markdown.html
@@ -2,6 +2,7 @@
 <html lang=en data-inscription={{self.inscription_id}}>
   <head>
     <meta charset=utf-8>
+    <title>Inscription {{self.inscription_number}} Preview</title>
     <link rel=stylesheet href=/static/preview-markdown.css></link>
     <script src=/static/preview-markdown.js type=module defer></script>
   </head>

--- a/templates/preview-model.html
+++ b/templates/preview-model.html
@@ -2,6 +2,7 @@
 <html lang=en>
   <head>
     <meta charset=utf-8>
+    <title>Inscription {{self.inscription_number}} Preview</title>
     <script type=module src=https://ajax.googleapis.com/ajax/libs/model-viewer/3.1.1/model-viewer.min.js></script>
     <style>
       model-viewer {

--- a/templates/preview-pdf.html
+++ b/templates/preview-pdf.html
@@ -2,6 +2,7 @@
 <html lang=en>
   <head>
     <meta charset=utf-8>
+    <title>Inscription {{self.inscription_number}} Preview</title>
     <link rel=stylesheet href=/static/preview-pdf.css>
     <script src=/static/preview-pdf.js defer type=module></script>
   </head>

--- a/templates/preview-text.html
+++ b/templates/preview-text.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset=utf-8>
     <meta name=format-detection content='telephone=no'>
+    <title>Inscription {{self.inscription_number}} Preview</title>
     <link href=/static/preview-text.css rel=stylesheet>
     <script src=/static/preview-text.js type=module defer></script>
   </head>

--- a/templates/preview-video.html
+++ b/templates/preview-video.html
@@ -2,6 +2,7 @@
 <html lang=en>
   <head>
     <meta charset=utf-8>
+    <title>Inscription {{self.inscription_number}} Preview</title>
     <link rel=stylesheet href=/static/preview-video.css>
     <script src=/static/preview-video.js type=module defer></script>
   </head>


### PR DESCRIPTION
Add better titles to preview pages (per https://github.com/ordinals/ord/issues/4264)

In this solution, `inscription_number` is fetched from the index entry where necessary, and passed to the preview structs and templates, to be used as part of the HTML title tags, respectively. Note also `inscription_number` is added to the `r::content_response` function signature, to be able to be passed to `PreviewIframeHtml`, and explicitly set to 0 in tests.