### PR TITLE
Recognize inscriptions with content type `audio/ogg` as audio

### DIFF
--- a/src/inscriptions/media.rs
+++ b/src/inscriptions/media.rs
@@ -80,6 +80,7 @@ impl Media {
     ("application/yaml",            TEXT,    Code(Yaml),       &["yaml", "yml"]),
     ("audio/flac",                  GENERIC, Audio,            &["flac"]),
     ("audio/mpeg",                  GENERIC, Audio,            &["mp3"]),
+    ("audio/ogg",                   GENERIC, Audio,            &[]),
     ("audio/ogg;codecs=opus",       GENERIC, Audio,            &["opus"]),
     ("audio/wav",                   GENERIC, Audio,            &["wav"]),
     ("font/otf",                    GENERIC, Font,             &["otf"]),


### PR DESCRIPTION
When making inscriptions, we prefer to use the most specific content type possible, including media type parameters. However, when deciding to use which preview to use, we should accept media types without parameters.

Fixes #4285. 