### PR TITLE
Render borders around thumbnails

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -212,9 +212,14 @@ a.mythic {
 
 .thumbnails > a {
   border-radius: 2%;
+  border: 1px solid #222;
   margin: 1%;
   overflow: hidden;
   width: 23%;
+}
+
+.thumbnails > a:hover {
+  border-color: #444;
 }
 
 .thumbnails iframe {


### PR DESCRIPTION
Render borders around thumbnails. This makes the main page a lot nicer when inscriptions are slow to load. I also made the borders lighten up a little bit on hover, which helps to indicate that they're clickable.

You can't see the mouse, but the second screenshot shows what it looks like on hover.

<details>
<summary>Screenshots</summary>
<img width="866" alt="Screenshot 2025-03-22 at 10 58 09 AM" src="https://github.com/user-attachments/assets/ec1df62b-20d5-4129-b5b5-faa3da7a467d" />
<img width="532" alt="Screenshot 2025-03-22 at 11 00 15 AM" src="https://github.com/user-attachments/assets/ddbb14a4-c366-41ca-aa50-176918a71900" />
</details>