### PR TITLE
Use `background-size: cover` for image thumbnails

### DIFF
--- a/deploy/setup
+++ b/deploy/setup
@@ -40,7 +40,7 @@ ufw allow ssh
 case $CHAIN in
   main)
     COOKIE_FILE_DIR=/var/lib/bitcoind
-    CSP_ORIGIN=ordinals.com
+    CSP_ORIGIN=charlie.ordinals.net
     ufw allow 8333
     ;;
   regtest)

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1548,6 +1548,7 @@ impl Server {
               image_rendering,
               inscription_id,
               inscription_number,
+              thumbnail,
             },
           )
             .into_response(),

--- a/src/templates/preview.rs
+++ b/src/templates/preview.rs
@@ -31,6 +31,7 @@ pub(crate) struct PreviewImageHtml {
   pub(crate) image_rendering: ImageRendering,
   pub(crate) inscription_id: InscriptionId,
   pub(crate) inscription_number: i32,
+  pub(crate) thumbnail: bool,
 }
 
 #[derive(Boilerplate)]

--- a/templates/preview-image.html
+++ b/templates/preview-image.html
@@ -14,7 +14,11 @@
         background-image: url(/content/{{self.inscription_id}});
         background-position: center;
         background-repeat: no-repeat;
+%% if self.thumbnail {
+        background-size: cover;
+%% } else {
         background-size: contain;
+%% }
         height: 100%;
         image-rendering: {{ self.image_rendering }};
         margin: 0;


### PR DESCRIPTION
I'm honestly not sure if this is an improvement. Before and after screenshots below. I'm actually leaning towards not doing this. Just in the two random non-square inscriptions that happened to be on the front page, `background-size: cover` crops out details, like the top and bottom borders.

<details>
<summary>screenshots</summary>
<img width="812" alt="Screenshot 2025-03-25 at 2 08 19 AM" src="https://github.com/user-attachments/assets/21e6802a-8974-4ffa-9c22-97d6aaef30b6" />
<img width="801" alt="Screenshot 2025-03-25 at 2 08 10 AM" src="https://github.com/user-attachments/assets/ac399ecd-4ff4-45c7-8396-ed91d40de698" />
</details>