### PR TITLE
Fill iframe when displaying images under /thumbnail

### DIFF
--- a/static/preview-image.js
+++ b/static/preview-image.js
@@ -1,15 +1,29 @@
+function isThumbnailRoute() {
+  return window.location.pathname.includes('/thumbnail');
+}
+
 function resize() {
   if (
     body.clientWidth * window.devicePixelRatio < img.naturalWidth
     || body.clientHeight * window.devicePixelRatio < img.naturalHeight
   ) {
     body.style.imageRendering = 'auto';
+    
+    // If we're in the thumbnail route, use 'cover' to fill the entire space
+    if (isThumbnailRoute()) {
+      body.style.backgroundSize = 'cover';
+    }
   } else {
-    body.removeAttribute('style');
+    if (isThumbnailRoute()) {
+      // Only set backgroundSize when in thumbnail route
+      body.style.backgroundSize = 'cover';
+    } else {
+      body.removeAttribute('style');
+    }
   }
 }
 
-let body = document.body;
-let img = document.getElementsByTagName('img')[0];
+const body = document.body;
+const img = document.getElementsByTagName('img')[0];
 
 (new ResizeObserver(resize)).observe(body);


### PR DESCRIPTION


Modifies the preview-image.js file to detect when images are being displayed under the /thumbnail route and applies background-size: cover to fill the entire iframe space, eliminating wasted space.

Fixes #4296

- Added URL path detection to determine if we're in the /thumbnail route
- Applied background-size: cover when in thumbnail mode to fill the entire iframe
- Maintained original behavior for /preview route

Tested with different image sizes to ensure proper display in both routes.