### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/crates/ordinals/src/sat_point.rs
+++ b/crates/ordinals/src/sat_point.rs
@@ -3,7 +3,7 @@ use {super::*, bitcoin::transaction::ParseOutPointError};
 /// A satpoint identifies the location of a sat in an output.
 ///
 /// The string representation of a satpoint consists of that of an outpoint,
-/// which identifies and output, followed by `:OFFSET`. For example, the string
+/// which identifies an output, followed by `:OFFSET`. For example, the string
 /// representation of the first sat of the genesis block coinbase output is
 /// `000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:0:0`,
 /// that of the second sat of the genesis block coinbase output is

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -553,7 +553,7 @@ impl InscriptionUpdater<'_, '_> {
     };
 
     // The special outpoints, i.e., the null outpoint and the unbound outpoint,
-    // don't follow the normal rulesr. Unlike real outputs they get written to
+    // don't follow the normal rules. Unlike real outputs they get written to
     // more than once. So we create a new UTXO entry here and commit() will
     // merge it with any existing entry.
     let output_utxo_entry = normal_output_utxo_entry.unwrap_or_else(|| {


### PR DESCRIPTION
This PR fixes two typos:
1. In sat_point.rs: Changed "and output" to "an output" in the documentation comment
2. In inscription_updater.rs: Fixed spelling of "rules" in the comment

These changes improve code documentation clarity without affecting functionality.