### PR TITLE
Don't display `(expected)` when rune has already unlocked

### DIFF
--- a/src/blocktime.rs
+++ b/src/blocktime.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize)]
 pub enum Blocktime {
   Confirmed(DateTime<Utc>),
   Expected(DateTime<Utc>),

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -942,7 +942,7 @@ impl Server {
           StatusCode::NOT_FOUND.into_response()
         } else {
           let unlock = if let Some(height) = rune.unlock_height(server_config.chain.network()) {
-            Some((height, index.block_time(height)?.timestamp()))
+            Some((height, index.block_time(height)?))
           } else {
             None
           };
@@ -2937,7 +2937,7 @@ mod tests {
         rune: Rune(0),
         unlock: Some((
           Height(209999),
-          DateTime::from_timestamp(125998800, 0).unwrap(),
+          Blocktime::Expected(DateTime::from_timestamp(125998800, 0).unwrap()),
         )),
       },
     );

--- a/src/templates/rune_not_found.rs
+++ b/src/templates/rune_not_found.rs
@@ -3,7 +3,7 @@ use super::*;
 #[derive(Boilerplate, Debug, PartialEq, Serialize)]
 pub struct RuneNotFoundHtml {
   pub rune: Rune,
-  pub unlock: Option<(Height, DateTime<Utc>)>,
+  pub unlock: Option<(Height, Blocktime)>,
 }
 
 impl PageContent for RuneNotFoundHtml {
@@ -17,11 +17,11 @@ mod tests {
   use super::*;
 
   #[test]
-  fn display() {
+  fn display_expected() {
     assert_regex_match!(
       RuneNotFoundHtml {
         rune: Rune(u128::MAX),
-        unlock: Some((Height(111), DateTime::default())),
+        unlock: Some((Height(111), Blocktime::Expected(DateTime::default()))),
       },
       r"<h1>BCGDENLQRQWDSLRUGSNLBTMFIJAV</h1>
 <dl>
@@ -29,6 +29,26 @@ mod tests {
   <dd>111</dd>
   <dt>unlock time</dt>
   <dd><time>1970-01-01 00:00:00 UTC</time> \(expected\)</dd>
+  <dt>reserved</dt>
+  <dd>false</dd>
+</dl>
+"
+    );
+  }
+
+  #[test]
+  fn display_confirmed() {
+    assert_regex_match!(
+      RuneNotFoundHtml {
+        rune: Rune(u128::MAX),
+        unlock: Some((Height(111), Blocktime::Confirmed(DateTime::default()))),
+      },
+      r"<h1>BCGDENLQRQWDSLRUGSNLBTMFIJAV</h1>
+<dl>
+  <dt>unlock height</dt>
+  <dd>111</dd>
+  <dt>unlock time</dt>
+  <dd><time>1970-01-01 00:00:00 UTC</time></dd>
   <dt>reserved</dt>
   <dd>false</dd>
 </dl>

--- a/templates/rune-not-found.html
+++ b/templates/rune-not-found.html
@@ -1,10 +1,10 @@
 <h1>{{ self.rune }}</h1>
 <dl>
-%% if let Some((height, time)) = self.unlock {
+%% if let Some((height, blocktime)) = self.unlock {
   <dt>unlock height</dt>
   <dd>{{ height }}</dd>
   <dt>unlock time</dt>
-  <dd><time>{{ time }}</time> (expected)</dd>
+  <dd><time>{{blocktime.timestamp()}}</time>{{blocktime.suffix()}}</dd>
   <dt>reserved</dt>
   <dd>false</dd>
 %% } else {


### PR DESCRIPTION
We reuse the `Blocktime` struct which already does this, instead of only using the timestamp.