### PR TITLE
Move ethereum teleburn address out of details

### DIFF
--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -91,16 +91,8 @@ mod tests {
           <dd><a class=collapse href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
-          <dt>details</dt>
-          <dd>
-            <details>
-              <summary>...</summary>
-              <dl>
-                <dt>ethereum teleburn address</dt>
-                <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
-              </dl>
-            </details>
-          </dd>
+          <dt>ethereum teleburn address</dt>
+          <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
       "
       .unindent()
@@ -282,16 +274,8 @@ mod tests {
           <dd><a class=collapse href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
-          <dt>details</dt>
-          <dd>
-            <details>
-              <summary>...</summary>
-              <dl>
-                <dt>ethereum teleburn address</dt>
-                <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
-              </dl>
-            </details>
-          </dd>
+          <dt>ethereum teleburn address</dt>
+          <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
 "
       .unindent()
@@ -353,16 +337,8 @@ mod tests {
           <dd><a class=collapse href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
-          <dt>details</dt>
-          <dd>
-            <details>
-              <summary>...</summary>
-              <dl>
-                <dt>ethereum teleburn address</dt>
-                <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
-              </dl>
-            </details>
-          </dd>
+          <dt>ethereum teleburn address</dt>
+          <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
       "
       .unindent()
@@ -423,16 +399,8 @@ mod tests {
           <dd><a class=collapse href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
-          <dt>details</dt>
-          <dd>
-            <details>
-              <summary>...</summary>
-              <dl>
-                <dt>ethereum teleburn address</dt>
-                <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
-              </dl>
-            </details>
-          </dd>
+          <dt>ethereum teleburn address</dt>
+          <dd class=collapse>0xa1DfBd1C519B9323FD7Fd8e498Ac16c2E502F059</dd>
         </dl>
       "
       .unindent()

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -132,14 +132,6 @@
   <dd><a class=collapse href=/output/{{ self.satpoint.outpoint }}>{{ self.satpoint.outpoint }}</a></dd>
   <dt>offset</dt>
   <dd>{{ self.satpoint.offset }}</dd>
-  <dt>details</dt>
-  <dd>
-    <details>
-      <summary>...</summary>
-      <dl>
-        <dt>ethereum teleburn address</dt>
-        <dd class=collapse>{{ teleburn::Ethereum::from(self.id) }}</dd>
-      </dl>
-    </details>
-  </dd>
+  <dt>ethereum teleburn address</dt>
+  <dd class=collapse>{{ teleburn::Ethereum::from(self.id) }}</dd>
 </dl>


### PR DESCRIPTION
The `<details>` item on `/inscription` has been bothering me. We initially intended to move more things into it, so it's just kind of pointless right now, since it takes up the same amount of space as the only item it contains.

I think we should remove `<details>` for now, and pull the `ethereum teleburn address` to the top level. If, later, we have multiple items that we really have a strong rationale for moving into `<details>` we can re-introduce it.