### PR TITLE
Allow inscribing JPEG XL

### DIFF
--- a/src/inscriptions/media.rs
+++ b/src/inscriptions/media.rs
@@ -91,7 +91,7 @@ impl Media {
     ("image/avif",                  GENERIC, Image(Auto),      &["avif"]),
     ("image/gif",                   GENERIC, Image(Pixelated), &["gif"]),
     ("image/jpeg",                  GENERIC, Image(Pixelated), &["jpg", "jpeg"]),
-    ("image/jxl",                   GENERIC, Image(Auto),      &[]),
+    ("image/jxl",                   GENERIC, Image(Auto),      &["jxl"]),
     ("image/png",                   GENERIC, Image(Pixelated), &["png"]),
     ("image/svg+xml",               TEXT,    Iframe,           &["svg"]),
     ("image/webp",                  GENERIC, Image(Pixelated), &["webp"]),


### PR DESCRIPTION
JPEG XL is [not widely supported](https://caniuse.com/?search=jpegxl).

However, you can take advantage of the format to create extremely small but visually compelling images, which is perfect for inscribing. [example](https://jxl-art.surma.technology/).

So, we could consider adding the `jxl` extension and allow `ord` to inscribe `jxl` without issue. This would be a different policy than usual, since if people don't know that JPEG XL isn't widely available, they might inscribe it and be disappointed when it only appears correctly in Safari.