### PR TITLE
Rpc client retries when "Resource temporarily unavailable"

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -453,8 +453,7 @@ impl Settings {
         }
         Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
           if err.code == -28 => {}
-        Err(err)
-          if err.to_string().contains("Resource temporarily unavailable") => {}
+        Err(err) if err.to_string().contains("Resource temporarily unavailable") => {}
         Err(err) => bail!("Failed to connect to Bitcoin Core RPC at `{rpc_url}`:  {err}"),
       }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -453,6 +453,8 @@ impl Settings {
         }
         Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
           if err.code == -28 => {}
+        Err(err)
+          if err.to_string().contains("Resource temporarily unavailable") => {}
         Err(err) => bail!("Failed to connect to Bitcoin Core RPC at `{rpc_url}`:  {err}"),
       }
 


### PR DESCRIPTION
The bitcoin RPC client would sometimes fail to connect with a "Resource temporarily unavailable" error.

Retrying the connection on this error solved the issue for me.