### PR TITLE
Update Dockerfile rust image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79.0-bookworm as builder
+FROM rust:1.81.0-bookworm as builder
 
 WORKDIR /usr/src/ord
 


### PR DESCRIPTION
### Summary
Bumps the Dockerfile's builder image from `rust:1.79.0-bookworm` to `rust:1.81.0-bookworm`.

### Context
The project no longer builds at 1.79 and so this PR bumps it to the minimum `rustc` version at which the project builds again.

### Note
I am not very well-versed in rust dependency chains or module resolution, but `Cargo.toml` currently sets `rust-version = "1.80.0"` which appears to be too low as well. I'm leaving it untouched for now.