### PR TITLE
Update minimum Rust version to 1.85.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ edition = "2021"
 homepage = "https://github.com/ordinals/ord"
 license = "CC0-1.0"
 repository = "https://github.com/ordinals/ord"
-rust-version = "1.81.0"
+rust-version = "1.85.0"
 
 [workspace.dependencies]
 base64 = "0.22.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.87.0-bookworm AS builder
+FROM rust:1.85.0-bookworm AS builder
 
 WORKDIR /usr/src/ord
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81.0-bookworm as builder
+FROM rust:1.87.0-bookworm AS builder
 
 WORKDIR /usr/src/ord
 

--- a/tests/wallet/inscribe.rs
+++ b/tests/wallet/inscribe.rs
@@ -522,7 +522,7 @@ fn inscribe_with_no_limit() {
 
   core.mine_blocks(1);
 
-  let one_megger = std::iter::repeat(0).take(1_000_000).collect::<Vec<u8>>();
+  let one_megger = std::iter::repeat_n(0, 1_000_000).collect::<Vec<u8>>();
   CommandBuilder::new("wallet inscribe --no-limit --file degenerate.png --fee-rate 1")
     .write("degenerate.png", one_megger)
     .core(&core)


### PR DESCRIPTION
rust version 1.85.0 minimum is required for this build. Upgrading to latest stable release (1.87.0). Fixing the error below


```
3.806 error: failed to parse manifest at `/usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/redb-2.5.0/Cargo.toml`
3.806 
3.806 Caused by:
3.806   feature `edition2024` is required
3.806 
3.806   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.81.0 (2dbb1af80 2024-08-20)).
3.806   Consider trying a newer version of Cargo (this may require the nightly release).
3.806   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```
