### PR TITLE
Add feng shui based satoshi numeric luck score

### DIFF
--- a/crates/ordinals/src/sat.rs
+++ b/crates/ordinals/src/sat.rs
@@ -129,6 +129,32 @@ impl Sat {
     charms
   }
 
+  pub fn luck(self) -> i64 {
+    let mut n = self.n();
+    let mut luck = 0;
+
+    loop {
+      let digit = n % 10;
+      luck += match digit {
+        0 => 0,
+        1 => 0,
+        2 => 0,
+        3 => 0,
+        4 => -1,
+        5 => 0,
+        6 => 0,
+        7 => 0,
+        8 => 1,
+        9 => 0,
+        10..=u64::MAX => unreachable!(),
+      };
+      n = n / 10;
+      if n == 0 {
+        return luck;
+      }
+    }
+  }
+
   fn from_name(s: &str) -> Result<Self, Error> {
     let mut x = 0;
     for c in s.chars() {
@@ -832,6 +858,22 @@ mod tests {
     assert!(Charm::Palindrome.is_set(Sat(0).charms()));
     assert!(!Charm::Palindrome.is_set(Sat(10).charms()));
     assert!(Charm::Palindrome.is_set(Sat(11).charms()));
+  }
+
+  #[test]
+  fn luck() {
+    assert_eq!(Sat(0).luck(), 0);
+    assert_eq!(Sat(1).luck(), 0);
+    assert_eq!(Sat(4).luck(), -1);
+    assert_eq!(Sat(8).luck(), 1);
+    assert_eq!(Sat(10).luck(), 0);
+    assert_eq!(Sat(40).luck(), -1);
+    assert_eq!(Sat(48).luck(), 0);
+    assert_eq!(Sat(80).luck(), 1);
+    assert_eq!(Sat(84).luck(), 0);
+    assert_eq!(Sat(88).luck(), 2);
+    assert_eq!(Sat::LAST.luck(), 1);
+    assert_eq!(Sat(u64::MAX).luck(), -3);
   }
 
   #[test]

--- a/crates/ordinals/src/sat.rs
+++ b/crates/ordinals/src/sat.rs
@@ -148,7 +148,7 @@ impl Sat {
         9 => 0,
         10..=u64::MAX => unreachable!(),
       };
-      n = n / 10;
+      n /= 10;
       if n == 0 {
         return luck;
       }

--- a/src/templates/sat.rs
+++ b/src/templates/sat.rs
@@ -49,6 +49,7 @@ mod tests {
             <span title=mythic>🎃</span>
             <span title=palindrome>🦋</span>
           </dd>
+          <dt>luck</dt><dd>0</dd>
         </dl>
         .*
         prev
@@ -87,6 +88,7 @@ mod tests {
           <dd>
             <span title=uncommon>🌱</span>
           </dd>
+          <dt>luck</dt><dd>1</dd>
         </dl>
         .*
         <a class=prev href=/sat/2099999997689998>prev</a>

--- a/templates/sat.html
+++ b/templates/sat.html
@@ -22,6 +22,7 @@
 %% }
   </dd>
 %% }
+  <dt>luck</dt><dd>{{ self.sat.luck() }}</dd>
 %% if !self.inscriptions.is_empty() {
   <dt>inscriptions</dt>
   <dd class=thumbnails>


### PR DESCRIPTION
This is just a draft PR. I'd like to make this more comprehensive:

- Assign unique luck scores to each digit, not just four and eight. Will require a consultation with a feng shui expert.
- Display digits in both 大寫 and 小寫
- Consider a more mathematically complex scheme for calculating the luck score. For example, the place of the digit could contribute to the luck score, with leftmost digits contributing more and right most digits contributing less. An example of an interesting scheme is a balanced-base-B polynomial. Big-place digits act like Heavenly Mandates dominating lesser earthly whispers below.
- Use a bijective mapping?
- Use 60ths because of https://en.wikipedia.org/wiki/Sexagenary_cycle
- Should repeated digits magnify the effect of the digit?