### PR TITLE
Fix typo in API route example

### DIFF
--- a/docs/src/guides/api.md
+++ b/docs/src/guides/api.md
@@ -475,7 +475,7 @@ curl -s -H "Accept: application/json" \
 <details>
   <summary>
     <code>GET</code>
-    <code><b>/decode/&lt;TRANSCATION_ID&gt;</b></code>
+    <code><b>/decode/&lt;TRANSACTION_ID&gt;</b></code>
   </summary>
 
 ### Description


### PR DESCRIPTION
Corrected a typo in the API documentation route path:

- TRANSCATION_ID → TRANSACTION_ID

This fix ensures accurate reference to the /decode/<TRANSACTION_ID> endpoint and prevents confusion for users interacting with the API.