### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/src/bounty/3.md
+++ b/docs/src/bounty/3.md
@@ -17,7 +17,7 @@ considered.
 
 Both parts use [frequency.tsv](frequency.tsv), a list of words and the number
 of times they occur in the [Google Books Ngram
-dataset](http://storage.googleapis.com/books/ngrams/books/datasetsv2.html).
+dataset](https://storage.googleapis.com/books/ngrams/books/datasetsv3.html).
 filtered to only include the names of sats which will have been mined by the
 end of the submission period, that appear at least 5000 times in the corpus.
 


### PR DESCRIPTION
Replaced broken link http://storage.googleapis.com/books/ngrams/books/datasetsv2.html
with correct one https://storage.googleapis.com/books/ngrams/books/datasetsv3.html