### PR TITLE
avoid temporary value drop in fund_raw_transaction

### DIFF
--- a/src/fund_raw_transaction.rs
+++ b/src/fund_raw_transaction.rs
@@ -100,7 +100,7 @@ pub(crate) fn fund_raw_transaction(
       .consensus_encode(&mut buffer)?;
   }
 
-  let options = Some(&FundRawTransactionOptions {
+  let options = Some(FundRawTransactionOptions {
     // NB. This is `fundrawtransaction`'s `feeRate`, which is fee per kvB
     // and *not* fee per vB. So, we multiply the fee rate given by the user
     // by 1000.


### PR DESCRIPTION
currently unable to build on master due to the error below. Managed to get it working with this fix.

thanks!

```bash
➜  ord git:(fix/fund_raw_transaction) cargo test
   Compiling ord v0.23.2 (/Users/stu/labitbu/ord)
warning: unknown lint: `mismatched_lifetime_syntaxes`
 --> src/lib.rs:6:3
  |
6 |   mismatched_lifetime_syntaxes
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unknown_lints)]` on by default

error[E0716]: temporary value dropped while borrowed
   --> src/fund_raw_transaction.rs:103:23
    |
103 |     let options = Some(&FundRawTransactionOptions {
    |  _______________________^
...   |
110 | |     ..default()
111 | |   });
    | |   ^ - temporary value is freed at the end of this statement
    | |___|
    |     creates a temporary value which is freed while still in use
...
115 |       opt_into_json(options)?,
    |                     ------- borrow later used here
    |
```