### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 software with no warranty. See [LICENSE](LICENSE) for more details.
 
 Ordinal theory imbues satoshis with numismatic value, allowing them to
-be collected and traded as curios.
+be collected and traded as curious.
 
 Ordinal numbers are serial numbers for satoshis, assigned in the order in which
 they are mined, and preserved across transactions.


### PR DESCRIPTION

Fix a minor typo in `README.md`: change “curios” to “curious” for grammatical correctness.

- Before: `be collected and traded as curios.`
- After: `be collected and traded as curious.`

