### PR TITLE
Add a complete Japanese translation

### DIFF
--- a/docs/po/ja.po
+++ b/docs/po/ja.po
@@ -901,9 +901,9 @@ msgid ""
 "digital artifacts, more commonly known as NFTs. Inscriptions do not require "
 "a sidechain or separate token."
 msgstr ""
-"銘文には任意の内容が刻まれ、ビットコインネイティブのデジタル人工製品が作られ"
-"ました。通常NFTと呼ばれています。の銘文には側鎖や個別のトークンは必要ありませ"
-"ん。 "
+"碑文は任意のコンテンツをsatoshiに刻み込み、ビットコインネイティブな"
+"デジタルアーティファクト（一般的にNFTとして知られる）を作成します。"
+"碑文にはサイドチェーンや独立したトークンは必要ありません。"
 
 #: src/inscriptions.md:8
 msgid ""
@@ -914,11 +914,12 @@ msgid ""
 "transactions must control the order and value of inputs and outputs "
 "according to ordinal theory."
 msgstr ""
-"これらの刻まれたコングは、ビットコイン取引転送を使用してビットコインアドレス"
-"に送信され、ビットコインUTXOに保存されます。これらの取引、アドレス、UTXOはす"
-"べての点で通常のビットコイン取引、アドレス、UTXOです。は単一の聡を送るために"
-"加えて、取引は序数理論に基づいて入力と出力の順序と値を制御しなければなりませ"
-"ん"
+"これらの碑文が刻まれたsatoshiは、ビットコイントランザクションを使用して転送し、"
+"ビットコインアドレスに送信し、ビットコインUTXOに保持することができます。"
+"これらのトランザクション、アドレス、UTXOは、個々のsatoshiを送信する際に"
+"オーディナルズ理論に従ってインプットとアウトプットの順序と価値を制御する"
+"必要があることを除いて、すべての点で通常のビットコイントランザクション、"
+"アドレス、UTXOです。"
 
 #: src/inscriptions.md:15
 msgid ""
@@ -928,10 +929,10 @@ msgid ""
 "server, and for creating HTML inscriptions that use and remix the content of "
 "other inscriptions."
 msgstr ""
-"銘文の内容はワールドワイドウェブ基準に基づいている。銘文はコンテンツタイプ"
-"（MI MEタイプとも呼ばれる）とコンテンツ自体（バイト列）で構成されています。こ"
-"れにより、Webサーバーから銘文コンテンツを返すことができ、HTML銘文を作成して使"
-"用し、他の銘文コンテンツを再混合するために使用されます。"
+"碑文のコンテンツモデルはウェブのものと同じです。碑文はコンテンツタイプ"
+"（MIMEタイプとも呼ばれる）とコンテンツ自体（バイト文字列）で構成されます。"
+"これにより、碑文のコンテンツをウェブサーバーから返すことができ、"
+"他の碑文のコンテンツを使用してリミックスするHTML碑文を作成することができます。"
 
 #: src/inscriptions.md:21
 msgid ""
@@ -940,9 +941,9 @@ msgid ""
 "and additionally receive the witness discount, making inscription content "
 "storage relatively economical."
 msgstr ""
-"銘文の内容は完全にチェーン上にあり、保存されているtaproot script-path spendス"
-"クリプト内。のTaprootスクリプトはその内容に対する制限が少なく、証人割引を追加"
-"で受けることで、銘文内容の保存が比較的経済的になります。"
+"碑文のコンテンツは完全にオンチェーンで、taprootスクリプトパス支出スクリプトに"
+"格納されています。taprootスクリプトはコンテンツに対する制限が非常に少なく、"
+"さらにwitness割引を受けることで、碑文のコンテンツ保存を比較的経済的にします。"
 
 #: src/inscriptions.md:26
 msgid ""
@@ -1054,7 +1055,7 @@ msgstr ""
 
 #: src/inscriptions.md:79
 msgid "Currently, there are six defined fields:"
-msgstr ""
+msgstr "現在、6つの定義されたフィールドがあります："
 
 #: src/inscriptions.md:81
 #, fuzzy
@@ -1067,23 +1068,23 @@ msgstr ""
 #: src/inscriptions.md:82
 msgid ""
 "`pointer`, with a tag of `2`, see [pointer docs](inscriptions/pointer.md)."
-msgstr ""
+msgstr "`ポインタ`、タグ`2`、詳細は[ポインタドキュメント](inscriptions/pointer.md)を参照してください。"
 
 #: src/inscriptions.md:83
 msgid ""
 "`parent`, with a tag of `3`, see [provenance](inscriptions/provenance.md)."
-msgstr ""
+msgstr "`親`、タグ`3`、詳細は[出所](inscriptions/provenance.md)を参照してください。"
 
 #: src/inscriptions.md:84
 msgid ""
 "`metadata`, with a tag of `5`, see [metadata](inscriptions/metadata.md)."
-msgstr ""
+msgstr "`メタデータ`、タグ`5`、詳細は[メタデータ](inscriptions/metadata.md)を参照してください。"
 
 #: src/inscriptions.md:85
 msgid ""
 "`metaprotocol`, with a tag of `7`, whose value is the metaprotocol "
 "identifier."
-msgstr ""
+msgstr "`メタプロトコル`、タグ`7`、値はメタプロトコル識別子です。"
 
 #: src/inscriptions.md:86
 #, fuzzy
@@ -1097,7 +1098,7 @@ msgstr ""
 #: src/inscriptions.md:87
 msgid ""
 "`delegate`, with a tag of `11`, see [delegate](inscriptions/delegate.md)."
-msgstr ""
+msgstr "`デリゲート`、タグ`11`、詳細は[デリゲート](inscriptions/delegate.md)を参照してください。"
 
 #: src/inscriptions.md:89
 msgid ""
@@ -1149,7 +1150,7 @@ msgstr ""
 
 #: src/inscriptions.md:109
 msgid "`521f8eccffa4c41a3a7728dd012ea5a4a02feed81f41159231251ecf1e5c79dai0`"
-msgstr ""
+msgstr "`521f8eccffa4c41a3a7728dd012ea5a4a02feed81f41159231251ecf1e5c79dai0`"
 
 #: src/inscriptions.md:111
 msgid ""
@@ -1173,30 +1174,30 @@ msgstr ""
 
 #: src/inscriptions.md:119
 msgid "Input"
-msgstr ""
+msgstr "インプット"
 
 #: src/inscriptions.md:119
 msgid "Inscription Count"
-msgstr ""
+msgstr "碑文数"
 
 #: src/inscriptions.md:119
 msgid "Indices"
-msgstr ""
+msgstr "インデックス"
 
 #: src/inscriptions.md:121 src/inscriptions.md:124
 #: src/runes/specification.md:196 src/runes/specification.md:197
 #: src/runes/specification.md:341 src/runes/specification.md:423
 msgid "0"
-msgstr ""
+msgstr "0"
 
 #: src/inscriptions.md:121 src/inscriptions.md:123
 #: src/runes/specification.md:197 src/runes/specification.md:343
 msgid "2"
-msgstr ""
+msgstr "2"
 
 #: src/inscriptions.md:121
 msgid "i0, i1"
-msgstr ""
+msgstr "i0, i1"
 
 #: src/inscriptions.md:122 src/inscriptions.md:125
 #: src/runes/specification.md:177 src/runes/specification.md:178
@@ -1206,30 +1207,30 @@ msgstr ""
 #: src/runes/specification.md:198 src/runes/specification.md:342
 #: src/runes/specification.md:424
 msgid "1"
-msgstr ""
+msgstr "1"
 
 #: src/inscriptions.md:122
 msgid "i2"
-msgstr ""
+msgstr "i2"
 
 #: src/inscriptions.md:123 src/inscriptions.md:124
 #: src/runes/specification.md:180 src/runes/specification.md:187
 #: src/runes/specification.md:196 src/runes/specification.md:344
 msgid "3"
-msgstr ""
+msgstr "3"
 
 #: src/inscriptions.md:123
 msgid "i3, i4, i5"
-msgstr ""
+msgstr "i3, i4, i5"
 
 #: src/inscriptions.md:125 src/runes/specification.md:178
 #: src/runes/specification.md:189 src/runes/specification.md:198
 msgid "4"
-msgstr ""
+msgstr "4"
 
 #: src/inscriptions.md:125
 msgid "i6"
-msgstr ""
+msgstr "i6"
 
 #: src/inscriptions.md:127
 #, fuzzy
@@ -1241,7 +1242,7 @@ msgid ""
 "Inscriptions are assigned inscription numbers starting at zero, first by the "
 "order reveal transactions appear in blocks, and the order that reveal "
 "envelopes appear in those transactions."
-msgstr ""
+msgstr "碑文には0から始まる碑文番号が割り当てられます。まずブロック内でのリベアルトランザクションの順序、次にそのトランザクション内でのリベアルエンベロープの順序によります。"
 
 #: src/inscriptions.md:134
 msgid ""
@@ -1281,13 +1282,13 @@ msgstr ""
 
 #: src/inscriptions.md:153
 msgid "Self-Reference"
-msgstr ""
+msgstr "自己参照"
 
 #: src/inscriptions.md:156
 msgid ""
 "The content of the inscription with ID `INSCRIPTION_ID` must served from the "
 "URL path `/content/<INSCRIPTION_ID>`."
-msgstr ""
+msgstr "碑文ID `INSCRIPTION_ID` を持つ碑文のコンテンツは、URLパス `/content/<INSCRIPTION_ID>` から提供される必要があります。"
 
 #: src/inscriptions.md:159
 #, fuzzy
@@ -1296,7 +1297,7 @@ msgstr "次のコマンドを使用して、再帰的な碑文を刻むことが
 
 #: src/inscriptions.md:162
 msgid "\"/\""
-msgstr ""
+msgstr "\"/\""
 
 #: src/inscriptions.md:165
 msgid ""
@@ -1313,28 +1314,27 @@ msgid ""
 msgstr ""
 
 #: src/inscriptions.md:173
-#, fuzzy
 msgid "Reinscriptions"
-msgstr "銘文"
+msgstr "再刻印"
 
 #: src/inscriptions.md:176
 msgid ""
 "Previously inscribed sats can be reinscribed with the `--reinscribe` command "
 "if the inscription is present in the wallet. This will only append an "
 "inscription to a sat, not change the initial inscription."
-msgstr ""
+msgstr "以前に碑文が刻まれたsatは、碑文がウォレットにある場合、`--reinscribe` コマンドで再刻印することができます。これはsatに碑文を追加するのみで、初期の碑文を変更することはできません。"
 
 #: src/inscriptions.md:180
 msgid ""
 "Reinscribe with satpoint: `ord wallet inscribe --fee-rate <FEE_RATE> --"
 "reinscribe --file <FILE> --satpoint <SATPOINT>`"
-msgstr ""
+msgstr "satpointでの再刻印: `ord wallet inscribe --fee-rate <FEE_RATE> --reinscribe --file <FILE> --satpoint <SATPOINT>`"
 
 #: src/inscriptions.md:183
 msgid ""
 "Reinscribe on a sat (requires sat index): `ord --index-sats wallet inscribe "
 "--fee-rate <FEE_RATE> --reinscribe --file <FILE> --sat <SAT>`"
-msgstr ""
+msgstr "satでの再刻印 (satインデックスが必要): `ord --index-sats wallet inscribe --fee-rate <FEE_RATE> --reinscribe --file <FILE> --sat <SAT>`"
 
 #: src/inscriptions/delegate.md:4
 msgid ""
@@ -1342,12 +1342,11 @@ msgid ""
 "of an inscription with a delegate will instead return the content, content "
 "type and content encoding of the delegate. This can be used to cheaply "
 "create copies of an inscription."
-msgstr ""
+msgstr "碑文はデリゲート碑文を指名することができます。デリゲートを持つ碑文のコンテンツのリクエストは、代わりにデリゲートのコンテンツ、コンテンツタイプ、およびコンテンツエンコーディングを返します。これは碑文のコピーを安価に作成するために使用できます。"
 
 #: src/inscriptions/delegate.md:11
-#, fuzzy
 msgid "To create an inscription I with delegate inscription D:"
-msgstr "父の銘文Pのために子銘文Cを作り上げます。"
+msgstr "デリゲート碑文Dを持つ碑文Iを作成するには:"
 
 #: src/inscriptions/delegate.md:13
 msgid ""
@@ -1768,16 +1767,14 @@ msgid ""
 msgstr ""
 
 #: src/inscriptions/recursion.md:4
-#, fuzzy
 msgid ""
 "An important exception to [sandboxing](../inscriptions.md#sandboxing) is "
 "recursion. Recursive endpoints are whitelisted endpoints that allow access "
 "to on-chain data, including the content of other inscriptions."
 msgstr ""
-"[サンドボックス化](../inscriptions.md#sandboxing)の重要な例外は再帰です："
-"`ord`の /content`エンドポイントへのアクセスが許可され、碑文が`/content/"
-"<INSCRIPTION_ID>`をリクエストすることで他の碑文のコンテンツにアクセスできるよ"
-"うになります。"
+"[サンドボックス化](../inscriptions.md#sandboxing)の重要な例外は再帰です。再帰エンドポイントは "
+"オンチェーンデータへのアクセスを許可するホワイトリスト化されたエンドポイントで、他の碑文の "
+"コンテンツも含まれます。"
 
 #: src/inscriptions/recursion.md:8
 msgid ""
@@ -1785,16 +1782,19 @@ msgid ""
 "them, recursive endpoints have backwards-compatibility guarantees not shared "
 "by `ord server`'s other endpoints. In particular:"
 msgstr ""
+"再帰エンドポイントへの変更は、それらに依存する碑文を破壊する可能性があるため、再帰 "
+"エンドポイントには `ord server` の他のエンドポイントと共有されない後方互換性の保証があります。特に："
 
 #: src/inscriptions/recursion.md:12
 msgid "Recursive endpoints will not be removed"
-msgstr ""
+msgstr "再帰エンドポイントは削除されません"
 
 #: src/inscriptions/recursion.md:13
 msgid ""
 "Object fields returned by recursive endpoints will not be renamed or change "
 "types"
 msgstr ""
+"再帰エンドポイントが返すオブジェクトフィールドは、名前の変更や型の変更は行われません"
 
 #: src/inscriptions/recursion.md:15
 msgid ""
@@ -1802,6 +1802,9 @@ msgid ""
 "must handle additional, unexpected fields, and must not expect fields to be "
 "returned in a specific order."
 msgstr ""
+"ただし、追加のオブジェクトフィールドが追加または並び替えされる可能性があるため、"
+"碑文は追加の予期しないフィールドを処理する必要があり、フィールドが特定の順序で"
+"返されることを期待してはいけません。"
 
 #: src/inscriptions/recursion.md:19
 #, fuzzy
@@ -1840,7 +1843,7 @@ msgstr ""
 
 #: src/inscriptions/recursion.md:33 src/guides/api.md:5
 msgid "Endpoints"
-msgstr ""
+msgstr "エンドポイント"
 
 #: src/inscriptions/recursion.md:41 src/inscriptions/recursion.md:61
 #: src/inscriptions/recursion.md:81 src/inscriptions/recursion.md:103
@@ -1873,7 +1876,7 @@ msgstr "銘文"
 
 #: src/inscriptions/recursion.md:43 src/guides/api.md:5140
 msgid "The content of the inscription with `<INSCRIPTION_ID>`."
-msgstr ""
+msgstr "`<INSCRIPTION_ID>` の碑文のコンテンツ。"
 
 #: src/inscriptions/recursion.md:48 src/inscriptions/recursion.md:132
 #: src/inscriptions/recursion.md:178 src/inscriptions/recursion.md:260
@@ -1898,11 +1901,11 @@ msgstr ""
 #: src/guides/api.md:8390 src/guides/api.md:8421 src/guides/api.md:8459
 #: src/guides/api.md:8485 src/guides/api.md:8501
 msgid "\"Accept: application/json\""
-msgstr ""
+msgstr "\"Accept: application/json\""
 
 #: src/inscriptions/recursion.md:52 src/guides/api.md:5149
 msgid "<i>no terminal output, just file creation</i>"
-msgstr ""
+msgstr "<i>ターミナル出力なし、ファイルの作成のみ</i>"
 
 #: src/inscriptions/recursion.md:62 src/guides/api.md:5159
 #, fuzzy
@@ -1911,7 +1914,7 @@ msgstr "`/blockhash`：最新のブロックハッシュ。"
 
 #: src/inscriptions/recursion.md:71 src/guides/api.md:5168
 msgid "\"00000000000000000002891b440944e0ce40b37b6ccaa138c280e9edfc319d5d\""
-msgstr ""
+msgstr "\"00000000000000000002891b440944e0ce40b37b6ccaa138c280e9edfc319d5d\""
 
 #: src/inscriptions/recursion.md:83 src/guides/api.md:5180
 #, fuzzy
@@ -1921,7 +1924,7 @@ msgstr "`/blockhash/<HEIGHT>`：指定されたブロック高さのブロック
 #: src/inscriptions/recursion.md:93 src/inscriptions/recursion.md:190
 #: src/guides/api.md:5190 src/guides/api.md:5287
 msgid "\"0000000000000000000320283a032748cef8227873ff4872689bf23f1cda83a5\""
-msgstr ""
+msgstr "\"0000000000000000000320283a032748cef8227873ff4872689bf23f1cda83a5\""
 
 #: src/inscriptions/recursion.md:105 src/guides/api.md:5202
 #, fuzzy
@@ -1930,61 +1933,61 @@ msgstr "`/blockheight`：最新のブロック高度。"
 
 #: src/inscriptions/recursion.md:127 src/guides/api.md:5224
 msgid "Block info. `<QUERY>` may be a block height or block hash."
-msgstr ""
+msgstr "ブロック情報。`<QUERY>` はブロック高さまたはブロックハッシュです。"
 
 #: src/inscriptions/recursion.md:129 src/guides/api.md:5226
 msgid "Example (blockheight)"
-msgstr ""
+msgstr "例（ブロック高さ）"
 
 #: src/inscriptions/recursion.md:138 src/inscriptions/recursion.md:184
 #: src/guides/api.md:5235 src/guides/api.md:5281
 msgid "\"average_fee\""
-msgstr ""
+msgstr "\"average_fee\""
 
 #: src/inscriptions/recursion.md:139 src/inscriptions/recursion.md:185
 #: src/guides/api.md:5236 src/guides/api.md:5282
 msgid "\"average_fee_rate\""
-msgstr ""
+msgstr "\"average_fee_rate\""
 
 #: src/inscriptions/recursion.md:140 src/inscriptions/recursion.md:186
 #: src/guides/api.md:5237 src/guides/api.md:5283
 msgid "\"bits\""
-msgstr ""
+msgstr "\"bits\""
 
 #: src/inscriptions/recursion.md:141 src/inscriptions/recursion.md:187
 #: src/guides/api.md:5238 src/guides/api.md:5284
 msgid "\"chainwork\""
-msgstr ""
+msgstr "\"chainwork\""
 
 #: src/inscriptions/recursion.md:141 src/guides/api.md:5238
 msgid "\"0000000000000000000000000000000000000000000000000000000100010001\""
-msgstr ""
+msgstr "\"0000000000000000000000000000000000000000000000000000000100010001\""
 
 #: src/inscriptions/recursion.md:142 src/inscriptions/recursion.md:188
 #: src/guides/api.md:5239 src/guides/api.md:5285
 msgid "\"confirmations\""
-msgstr ""
+msgstr "\"confirmations\""
 
 #: src/inscriptions/recursion.md:143 src/inscriptions/recursion.md:189
 #: src/guides/api.md:5240 src/guides/api.md:5286
 msgid "\"difficulty\""
-msgstr ""
+msgstr "\"difficulty\""
 
 #: src/inscriptions/recursion.md:144 src/inscriptions/recursion.md:190
 #: src/guides/api.md:108 src/guides/api.md:157 src/guides/api.md:5241
 #: src/guides/api.md:5287
 msgid "\"hash\""
-msgstr ""
+msgstr "\"hash\""
 
 #: src/inscriptions/recursion.md:144 src/guides/api.md:108
 #: src/guides/api.md:157 src/guides/api.md:5241
 msgid "\"000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f\""
-msgstr ""
+msgstr "\"000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f\""
 
 #: src/inscriptions/recursion.md:145 src/inscriptions/recursion.md:191
 #: src/guides/api.md:5242 src/guides/api.md:5288
 msgid "\"feerate_percentiles\""
-msgstr ""
+msgstr "\"feerate_percentiles\""
 
 #: src/inscriptions/recursion.md:152 src/inscriptions/recursion.md:199
 #: src/inscriptions/recursion.md:200 src/inscriptions/recursion.md:524
@@ -2195,87 +2198,87 @@ msgstr ""
 #: src/guides/api.md:8183 src/guides/api.md:8196 src/guides/api.md:8209
 #: src/guides/api.md:8222 src/guides/api.md:8235 src/guides/api.md:8289
 msgid "\"height\""
-msgstr ""
+msgstr "\"height\""
 
 #: src/inscriptions/recursion.md:153 src/inscriptions/recursion.md:201
 #: src/guides/api.md:5250 src/guides/api.md:5298
 msgid "\"max_fee\""
-msgstr ""
+msgstr "\"max_fee\""
 
 #: src/inscriptions/recursion.md:154 src/inscriptions/recursion.md:202
 #: src/guides/api.md:5251 src/guides/api.md:5299
 msgid "\"max_fee_rate\""
-msgstr ""
+msgstr "\"max_fee_rate\""
 
 #: src/inscriptions/recursion.md:155 src/inscriptions/recursion.md:203
 #: src/guides/api.md:5252 src/guides/api.md:5300
 msgid "\"max_tx_size\""
-msgstr ""
+msgstr "\"max_tx_size\""
 
 #: src/inscriptions/recursion.md:156 src/inscriptions/recursion.md:204
 #: src/inscriptions/recursion.md:205 src/guides/api.md:5253
 #: src/guides/api.md:5301 src/guides/api.md:5302
 msgid "\"median_fee\""
-msgstr ""
+msgstr "\"median_fee\""
 
 #: src/inscriptions/recursion.md:157 src/inscriptions/recursion.md:206
 #: src/guides/api.md:5254 src/guides/api.md:5303
 msgid "\"median_time\""
-msgstr ""
+msgstr "\"median_time\""
 
 #: src/inscriptions/recursion.md:158 src/inscriptions/recursion.md:207
 #: src/guides/api.md:5255 src/guides/api.md:5304
 msgid "\"merkle_root\""
-msgstr ""
+msgstr "\"merkle_root\""
 
 #: src/inscriptions/recursion.md:158 src/guides/api.md:5255
 msgid "\"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b\""
-msgstr ""
+msgstr "\"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b\""
 
 #: src/inscriptions/recursion.md:159 src/inscriptions/recursion.md:208
 #: src/guides/api.md:5256 src/guides/api.md:5305
 msgid "\"min_fee\""
-msgstr ""
+msgstr "\"min_fee\""
 
 #: src/inscriptions/recursion.md:160 src/inscriptions/recursion.md:209
 #: src/guides/api.md:5257 src/guides/api.md:5306
 msgid "\"min_fee_rate\""
-msgstr ""
+msgstr "\"min_fee_rate\""
 
 #: src/inscriptions/recursion.md:161 src/inscriptions/recursion.md:210
 #: src/guides/api.md:5258 src/guides/api.md:5307
 msgid "\"next_block\""
-msgstr ""
+msgstr "\"next_block\""
 
 #: src/inscriptions/recursion.md:161 src/guides/api.md:5258
 msgid "\"00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048\""
-msgstr ""
+msgstr "\"00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048\""
 
 #: src/inscriptions/recursion.md:162 src/inscriptions/recursion.md:211
 #: src/guides/api.md:5259 src/guides/api.md:5308
 msgid "\"nonce\""
-msgstr ""
+msgstr "\"nonce\""
 
 #: src/inscriptions/recursion.md:163 src/inscriptions/recursion.md:212
 #: src/guides/api.md:5260 src/guides/api.md:5309
 msgid "\"previous_block\""
-msgstr ""
+msgstr "\"previous_block\""
 
 #: src/inscriptions/recursion.md:164 src/inscriptions/recursion.md:213
 #: src/guides/api.md:5261 src/guides/api.md:5310
 msgid "\"subsidy\""
-msgstr ""
+msgstr "\"subsidy\""
 
 #: src/inscriptions/recursion.md:165 src/inscriptions/recursion.md:214
 #: src/guides/api.md:112 src/guides/api.md:161 src/guides/api.md:5262
 #: src/guides/api.md:5311
 msgid "\"target\""
-msgstr ""
+msgstr "\"target\""
 
 #: src/inscriptions/recursion.md:165 src/guides/api.md:112
 #: src/guides/api.md:161 src/guides/api.md:5262
 msgid "\"00000000ffff0000000000000000000000000000000000000000000000000000\""
-msgstr ""
+msgstr "\"00000000ffff0000000000000000000000000000000000000000000000000000\""
 
 #: src/inscriptions/recursion.md:166 src/inscriptions/recursion.md:215
 #: src/inscriptions/recursion.md:530 src/inscriptions/recursion.md:543
@@ -2484,43 +2487,41 @@ msgstr ""
 #: src/guides/api.md:8215 src/guides/api.md:8228 src/guides/api.md:8241
 #: src/guides/api.md:8295
 msgid "\"timestamp\""
-msgstr ""
+msgstr "\"timestamp\""
 
 #: src/inscriptions/recursion.md:167 src/inscriptions/recursion.md:216
 #: src/guides/api.md:5264 src/guides/api.md:5313
 msgid "\"total_fee\""
-msgstr ""
+msgstr "\"total_fee\""
 
 #: src/inscriptions/recursion.md:168 src/inscriptions/recursion.md:217
 #: src/guides/api.md:5265 src/guides/api.md:5314
 msgid "\"total_size\""
-msgstr ""
+msgstr "\"total_size\""
 
 #: src/inscriptions/recursion.md:169 src/inscriptions/recursion.md:218
 #: src/guides/api.md:5266 src/guides/api.md:5315
 msgid "\"total_weight\""
-msgstr ""
+msgstr "\"total_weight\""
 
 #: src/inscriptions/recursion.md:170 src/inscriptions/recursion.md:219
 #: src/guides/api.md:5267 src/guides/api.md:5316
-#, fuzzy
 msgid "\"transaction_count\""
-msgstr "取引"
+msgstr "\"transaction_count\""
 
 #: src/inscriptions/recursion.md:171 src/inscriptions/recursion.md:220
 #: src/guides/api.md:115 src/guides/api.md:164 src/guides/api.md:5102
 #: src/guides/api.md:5268 src/guides/api.md:5317
-#, fuzzy
 msgid "\"version\""
-msgstr "再帰"
+msgstr "\"version\""
 
 #: src/inscriptions/recursion.md:175 src/guides/api.md:5272
 msgid "Example (blockhash)"
-msgstr ""
+msgstr "例（ブロックハッシュ）"
 
 #: src/inscriptions/recursion.md:187 src/guides/api.md:5284
 msgid "\"0000000000000000000000000000000000000000753bdab0e0d745453677442b\""
-msgstr ""
+msgstr "\"0000000000000000000000000000000000000000753bdab0e0d745453677442b\""
 
 #: src/inscriptions/recursion.md:207 src/guides/api.md:5304
 msgid "\"031b417c3a1828ddf3d6527fc210daafcc9218e81f98257f88d4d43bd7a5894f\""
@@ -2545,7 +2546,7 @@ msgstr "`/blocktime`：最新のブロックのUNIXタイムスタンプ。"
 
 #: src/inscriptions/recursion.md:255 src/guides/api.md:5352
 msgid "The first 100 child inscription ids."
-msgstr ""
+msgstr "最初の100件の子碑文ID。"
 
 #: src/inscriptions/recursion.md:266 src/inscriptions/recursion.md:393
 #: src/inscriptions/recursion.md:3245 src/inscriptions/recursion.md:3273
@@ -7297,23 +7298,23 @@ msgstr ""
 msgid ""
 "Runes allow Bitcoin transactions to etch, mint, and transfer Bitcoin-native "
 "digital commodities."
-msgstr ""
+msgstr "ルーンはビットコイントランザクションでビットコインネイティブのデジタルコモディティをエッチング、ミント、転送することを可能にします。"
 
 #: src/runes.md:7
 msgid ""
 "Whereas every inscription is unique, every unit of a rune is the same. They "
 "are interchangeable tokens, fit for a variety of purposes."
-msgstr ""
+msgstr "すべての碑文がユニークであるのに対し、ルーンの各単位は同じです。これらは交換可能なトークンであり、様々な目的に適しています。"
 
 #: src/runes.md:10 src/runes/specification.md:20
 msgid "Runestones"
-msgstr ""
+msgstr "ルーンストーン"
 
 #: src/runes.md:13
 msgid ""
 "Rune protocol messages, called runestones, are stored in Bitcoin transaction "
 "outputs."
-msgstr ""
+msgstr "ルーンストーンと呼ばれるルーンプロトコルメッセージは、ビットコイントランザクションアウトプットに格納されます。"
 
 #: src/runes.md:16
 msgid ""
@@ -7321,21 +7322,21 @@ msgid ""
 "`OP_13`, followed by zero or more data pushes. These data pushes are "
 "concatenated and decoded into a sequence of 128-bit integers, and finally "
 "parsed into a runestone."
-msgstr ""
+msgstr "ルーンストーンアウトプットのスクリプト pubkey は `OP_RETURN` で始まり、続いて `OP_13`、その後ゼロ個以上のデータプッシュが続きます。これらのデータプッシュは連結され、128ビット整数のシーケンスにデコードされ、最終的にルーンストーンに解析されます。"
 
 #: src/runes.md:21
 msgid "A transaction may have at most one runestone."
-msgstr ""
+msgstr "トランザクションには最大1つのルーンストーンが含まれる可能性があります。"
 
 #: src/runes.md:23
 msgid ""
 "A runestone may etch a new rune, mint an existing rune, and transfer runes "
 "from a transaction's inputs to its outputs."
-msgstr ""
+msgstr "ルーンストーンは新しいルーンをエッチング、既存のルーンをミント、またはトランザクションのインプットからアウトプットへルーンを転送することができます。"
 
 #: src/runes.md:26
 msgid "A transaction output may hold balances of any number of runes."
-msgstr ""
+msgstr "トランザクションアウトプットには任意の数のルーンの残高を保持することができます。"
 
 #: src/runes.md:28
 msgid ""
@@ -7343,17 +7344,17 @@ msgid ""
 "etched and the index of the etching transaction within that block, "
 "represented in text as `BLOCK:TX`. For example, the ID of the rune etched in "
 "the 20th transaction of the 500th block is `500:20`."
-msgstr ""
+msgstr "ルーンはIDによって識別されます。IDはルーンがエッチングされたブロックと、そのブロック内でのエッチングトランザクションのインデックスから構成され、テキストでは `BLOCK:TX` として表現されます。たとえば、500番目のブロックの20番目のトランザクションでエッチングされたルーンのIDは `500:20` です。"
 
 #: src/runes.md:33
 msgid "Etching"
-msgstr ""
+msgstr "エッチング"
 
 #: src/runes.md:36
 msgid ""
 "Runes come into existence by being etched. Etching creates a rune and sets "
 "its properties. Once set, these properties are immutable, even to its etcher."
-msgstr ""
+msgstr "ルーンはエッチングされることで存在します。エッチングはルーンを作成し、そのプロパティを設定します。一度設定されたこれらのプロパティは、エッチングした者であっても不変です。"
 
 #: src/runes.md:39 src/runes/specification.md:421
 #, fuzzy
@@ -7364,31 +7365,31 @@ msgstr "名前"
 msgid ""
 "Names consist of the letters A through Z and are between one and twenty-six "
 "letters long. For example `UNCOMMONGOODS` is a rune name."
-msgstr ""
+msgstr "名前はAからZの文字から構成され、1文字から26文字の長さです。たとえば、`UNCOMMONGOODS` はルーン名です。"
 
 #: src/runes.md:44
 msgid ""
 "Names may contain spacers, represented as bullets, to aid readability. "
 "`UNCOMMONGOODS` might be etched as `UNCOMMON•GOODS`."
-msgstr ""
+msgstr "名前には可読性を高めるために、ブリットで表現されるスペーサーを含めることができます。`UNCOMMONGOODS` は `UNCOMMON•GOODS` としてエッチングされる場合があります。"
 
 #: src/runes.md:47
 msgid ""
 "The uniqueness of a name does not depend on spacers. Thus, a rune may not be "
 "etched with the same sequence of letters as an existing rune, even if it has "
 "different spacers."
-msgstr ""
+msgstr "名前の一意性はスペーサーに依存しません。したがって、別のスペーサーを持つ場合であっても、既存のルーンと同じ文字の配列でルーンをエッチングすることはできません。"
 
 #: src/runes.md:51
 msgid ""
 "Spacers can only be placed between two letters. Finally, spacers do not "
 "count towards the letter count."
-msgstr ""
+msgstr "スペーサーは2つの文字の間にのみ配置できます。また、スペーサーは文字数にカウントされません。"
 
 #: src/runes.md:54 src/runes/specification.md:331
 #: src/runes/specification.md:339
 msgid "Divisibility"
-msgstr ""
+msgstr "分割可能性"
 
 #: src/runes.md:56
 msgid ""
@@ -7398,42 +7399,53 @@ msgid ""
 "divided. A unit of a rune with divisibility 1 may be divided into ten sub-"
 "units, a rune with divisibility 2 may be divided into a hundred, and so on."
 msgstr ""
+"ルーンの分割可能性とは、そのルーンが原子単位にどれだけ細かく分割できるかを示します。"
+"分割可能性は、ルーン量における小数点以下の許可される桁数として表されます。分割可能性が0の"
+"ルーンは分割できません。分割可能性が1のルーンの単位は10のサブユニットに分割でき、"
+"分割可能性が2のルーンは100に分割でき、以下同様に続きます。"
 
 #: src/runes.md:62 src/runes/specification.md:366
 msgid "Symbol"
-msgstr ""
+msgstr "シンボル"
 
 #: src/runes.md:64
 msgid ""
 "A rune's currency symbol is a single Unicode code point, for example `$`, "
 "`⧉`, or `🧿`, displayed after quantities of that rune."
 msgstr ""
+"ルーンの通貨シンボルは単一のUnicodeコードポイントです。例えば`$`、`⧉`、または`🧿`などで、"
+"そのルーンの数量の後に表示されます。"
 
 #: src/runes.md:67
 msgid ""
 "101 atomic units of a rune with divisibility 2 and symbol `🧿` would be "
 "rendered as `1.01 🧿`."
 msgstr ""
+"分割可能性が2でシンボルが`🧿`のルーンの101原子単位は`1.01 🧿`として"
+"表示されます。"
 
 #: src/runes.md:70
 msgid ""
 "If a rune does not have a symbol, the generic currency sign `¤`, also called "
 "a scarab, should be used."
 msgstr ""
+"ルーンにシンボルがない場合は、スカラベとも呼ばれる汎用通貨記号`¤`を使用する必要があります。"
 
 #: src/runes.md:73 src/runes/specification.md:290
 msgid "Premine"
-msgstr ""
+msgstr "プリマイン"
 
 #: src/runes.md:75
 msgid ""
 "The etcher of a rune may optionally allocate to themselves units of the rune "
 "being etched. This allocation is called a premine."
 msgstr ""
+"ルーンのエッチャー（作成者）は、オプションでエッチされるルーンの単位を自分自身に割り当てることが"
+"できます。この割り当てはプリマインと呼ばれます。"
 
 #: src/runes.md:78
 msgid "Terms"
-msgstr ""
+msgstr "条件"
 
 #: src/runes.md:80
 msgid ""
@@ -7441,6 +7453,8 @@ msgid ""
 "of that rune for themselves. An open mint is subject to terms, which are set "
 "upon etching."
 msgstr ""
+"ルーンはオープンミントを持つことができ、誰でもそのルーンの単位を自分のために作成し割り当てることが"
+"できます。オープンミントは、エッチング時に設定される条件に従います。"
 
 #: src/runes.md:84
 msgid ""
@@ -7449,66 +7463,73 @@ msgid ""
 "height, an ending height, and a cap, and will be open between the starting "
 "height and ending height, or until the cap is reached, whichever comes first."
 msgstr ""
+"ミントは、ミントのすべての条件が満たされている間はオープンし、いずれかが満たされなくなると"
+"クローズします。例えば、ミントは開始ブロック高、終了ブロック高、上限に制限される場合があり、"
+"開始ブロック高から終了ブロック高の間、または上限に達するまで、どちらか早い方まで開いています。"
 
 #: src/runes.md:89 src/runes/specification.md:294
 msgid "Cap"
-msgstr ""
+msgstr "上限"
 
 #: src/runes.md:91
 msgid ""
 "The number of times a rune may be minted is its cap. A mint is closed once "
 "the cap is reached."
 msgstr ""
+"ルーンがミントできる回数がその上限です。上限に達すると、ミントは閉じられます。"
 
 #: src/runes.md:94 src/runes/specification.md:298
 msgid "Amount"
-msgstr ""
+msgstr "金額"
 
 #: src/runes.md:96
 msgid "Each mint transaction creates a fixed amount of new units of a rune."
-msgstr ""
+msgstr "各ミントトランザクションは、ルーンの固定量の新しい単位を作成します。"
 
 #: src/runes.md:98
 msgid "Start Height"
-msgstr ""
+msgstr "開始ブロック高"
 
 #: src/runes.md:100
 msgid "A mint is open starting in the block with the given start height."
-msgstr ""
+msgstr "指定された開始ブロック高のブロックからミントが開始されます。"
 
 #: src/runes.md:102
 msgid "End Height"
-msgstr ""
+msgstr "終了ブロック高"
 
 #: src/runes.md:104
 msgid ""
 "A rune may not be minted in or after the block with the given end height."
 msgstr ""
+"指定された終了ブロック高のブロック以降では、ルーンをミントすることはできません。"
 
 #: src/runes.md:106
-#, fuzzy
 msgid "Start Offset"
-msgstr "塵を重ねば、山となる"
+msgstr "開始オフセット"
 
 #: src/runes.md:108
 msgid ""
 "A mint is open starting in the block whose height is equal to the start "
 "offset plus the height of the block in which the rune was etched."
 msgstr ""
+"ミントは、開始オフセット＋ルーンがエッチされたブロックの高さに等しい高さのブロックから開始されます。"
 
 #: src/runes.md:111
 msgid "End Offset"
-msgstr ""
+msgstr "終了オフセット"
 
 #: src/runes.md:113
 msgid ""
 "A rune may not be minted in or after the block whose height is equal to the "
 "end offset plus the height of the block in which the rune was etched."
 msgstr ""
+"ルーンは、終了オフセット＋ルーンがエッチされたブロックの高さに等しい高さのブロック以降では"
+"ミントすることはできません。"
 
 #: src/runes.md:116 src/runes/specification.md:479
 msgid "Minting"
-msgstr ""
+msgstr "ミンティング"
 
 #: src/runes.md:119
 msgid ""
@@ -7516,10 +7537,12 @@ msgid ""
 "creates a fixed amount of new units of that rune, subject to the terms of "
 "the mint."
 msgstr ""
+"ルーンのミントがオープンしている間、誰でもミントの条件に従って、そのルーンの固定量の新しい単位を"
+"作成するミントトランザクションを作成することができます。"
 
 #: src/runes.md:122 src/runes/specification.md:491
 msgid "Transferring"
-msgstr ""
+msgstr "転送"
 
 #: src/runes.md:125
 msgid ""
@@ -7527,10 +7550,13 @@ msgid ""
 "or mint, those runes are transferred to that transaction's outputs. A "
 "transaction's runestone may change how input runes transfer to outputs."
 msgstr ""
+"トランザクションの入力にルーンが含まれるか、プリマインやミントによって新しいルーンが作成される場合、"
+"それらのルーンはそのトランザクションの出力に転送されます。トランザクションのルーンストーンは、入力"
+"ルーンが出力に転送される方法を変更することがあります。"
 
 #: src/runes.md:129
 msgid "Edicts"
-msgstr ""
+msgstr "命令"
 
 #: src/runes.md:131
 msgid ""
@@ -7538,6 +7564,8 @@ msgid ""
 "an amount, and an output number. Edicts are processed in order, allocating "
 "unallocated runes to outputs."
 msgstr ""
+"ルーンストーンには任意の数の命令を含めることができます。命令はルーンID、金額、出力番号で構成されます。"
+"命令は順番に処理され、未割り当てのルーンを出力に割り当てます。"
 
 #: src/runes.md:137
 msgid ""
@@ -7545,16 +7573,20 @@ msgid ""
 "to the transaction's first non-`OP_RETURN` output. A runestone may "
 "optionally contain a pointer that specifies an alternative default output."
 msgstr ""
+"すべての命令が処理された後、残った未割り当てのルーンは、トランザクションの最初の非`OP_RETURN`"
+"出力に転送されます。ルーンストーンには、オプションで代替のデフォルト出力を指定するポインターを"
+"含めることができます。"
 
 #: src/runes.md:143
 msgid ""
 "Runes may be burned by transferring them to an `OP_RETURN` output with an "
 "edict or pointer."
 msgstr ""
+"ルーンは、命令やポインターで`OP_RETURN`出力に転送することでバーン（無効化）することができます。"
 
 #: src/runes.md:146 src/runes/specification.md:379
 msgid "Cenotaphs"
-msgstr ""
+msgstr "空墓（セノタフ）"
 
 #: src/runes.md:149
 msgid ""
@@ -7562,12 +7594,16 @@ msgid ""
 "opcodes in the runestone `OP_RETURN`, invalid varints, or unrecognized "
 "runestone fields."
 msgstr ""
+"ルーンストーンは、ルーンストーン`OP_RETURN`内の非プッシュデータオプコード、無効なvarint、"
+"または認識されないルーンストーンフィールドなど、いくつかの理由で形式が不正になることがあります。"
 
 #: src/runes.md:153
 msgid ""
 "Malformed runestones are termed [cenotaphs](https://en.wikipedia.org/wiki/"
 "Cenotaph)."
 msgstr ""
+"形式不正のルーンストーンは[空墓（cenotaphs）](https://en.wikipedia.org/wiki/Cenotaph)と"
+"呼ばれます。"
 
 #: src/runes.md:156
 msgid ""
@@ -7575,6 +7611,9 @@ msgid ""
 "transaction with a cenotaph are set as unmintable. Mints in a transaction "
 "with a cenotaph count towards the mint cap, but the minted runes are burned."
 msgstr ""
+"空墓を持つトランザクションに入力されるルーンはバーンされます。空墓を持つトランザクションで"
+"エッチされるルーンはミント不可に設定されます。空墓を持つトランザクションのミントはミント上限に"
+"カウントされますが、ミントされたルーンはバーンされます。"
 
 #: src/runes.md:160
 msgid ""
@@ -7583,16 +7622,21 @@ msgid ""
 "misleading unupgraded clients as to the location of those runes, as "
 "unupgraded clients will see those runes as having been burned."
 msgstr ""
+"空墓はアップグレードメカニズムであり、ルーンストーンにルーンの作成と転送方法を変更する新しい"
+"セマンティクスを与えることを可能にします。アップグレードしていないクライアントがそれらのルーンを"
+"バーンされたものとして見るため、アップグレードしていないクライアントを惑わせることはありません。"
 
 #: src/runes/specification.md:1
 msgid "Runes Does Not Have a Specification"
-msgstr ""
+msgstr "ルーンには仕様書がありません"
 
 #: src/runes/specification.md:4
 msgid ""
 "The Runes reference implementation, `ord`, is the normative specification of "
 "the Runes protocol."
 msgstr ""
+"ルーンプロトコルのリファレンス実装である `ord` が、ルーンプロトコルの "
+"規範的仕様です。"
 
 #: src/runes/specification.md:7
 msgid ""
@@ -7601,6 +7645,9 @@ msgid ""
 "guide to the behavior of `ord`, and the code of `ord` itself should always "
 "be consulted to confirm the correctness of any prose description."
 msgstr ""
+"`ord` のコード以外で、ここや他の場所で読んでいるものは仕様ではありません。 "
+"このルーンプロトコルの散文記述は `ord` の動作のガイドとして提供されており、 "
+"任意の散文記述の正しさを確認するためには常に `ord` のコード自体を参照する必要があります。"
 
 #: src/runes/specification.md:12
 msgid ""
@@ -7608,6 +7655,9 @@ msgid ""
 "of `ord` and it is impractically disruptive to change `ord`'s behavior, this "
 "document will be amended to agree with `ord`'s actual behavior."
 msgstr ""
+"`ord` のバグによってこのドキュメントが `ord` の実際の動作から逸脱し、 "
+"`ord` の動作を変更することが非現実的に破壊的である場合、このドキュメントは "
+"`ord` の実際の動作に合わせて修正されます。"
 
 #: src/runes/specification.md:16
 msgid ""
@@ -7616,32 +7666,37 @@ msgid ""
 "make Runes transactions, and to determine the state of runes, mints, and "
 "balances."
 msgstr ""
+"代替実装のユーザーは自己責任で行い、ルーンの統合を希望するサービスは、 "
+"ルーントランザクションを作成し、ルーン、ミント、残高の状態を判定するために "
+"`ord` 自体を使用することを強く推奨します。"
 
 #: src/runes/specification.md:23
 msgid "Rune protocol messages are termed \"runestones\"."
-msgstr ""
+msgstr "ルーンプロトコルメッセージは「ルーンストーン」と呼ばれます。"
 
 #: src/runes/specification.md:25
 msgid ""
 "The Runes protocol activates on block 840,000. Runestones in earlier blocks "
 "are ignored."
 msgstr ""
+"ルーンプロトコルはブロック 840,000 で有効化されます。それ以前のブロックの "
+"ルーンストーンは無視されます。"
 
 #: src/runes/specification.md:28
 msgid "Abstractly, runestones contain the following fields:"
-msgstr ""
+msgstr "抽象的に、ルーンストーンには以下のフィールドが含まれています："
 
 #: src/runes/specification.md:39
 msgid "Runes are created by etchings:"
-msgstr ""
+msgstr "ルーンはエッチングによって作成されます："
 
 #: src/runes/specification.md:52
 msgid "Which may contain mint terms:"
-msgstr ""
+msgstr "これにはミント条件が含まれる場合があります："
 
 #: src/runes/specification.md:63 src/runes/specification.md:493
 msgid "Runes are transferred by edict:"
-msgstr ""
+msgstr "ルーンは勅令によって転送されます："
 
 #: src/runes/specification.md:73
 msgid ""
@@ -7651,53 +7706,58 @@ msgstr ""
 
 #: src/runes/specification.md:83
 msgid "Rune IDs are represented in text as `BLOCK:TX`."
-msgstr ""
+msgstr "ルーンIDはテキストで `BLOCK:TX` として表現されます。"
 
 #: src/runes/specification.md:85
 msgid "Rune names are encoded as modified base-26 integers:"
-msgstr ""
+msgstr "ルーン名は修正されたbase-26整数としてエンコードされます："
 
 #: src/runes/specification.md:91
 msgid "Deciphering"
-msgstr ""
+msgstr "解読"
 
 #: src/runes/specification.md:93
 msgid "Runestones are deciphered from transactions with the following steps:"
-msgstr ""
+msgstr "ルーンストーンは、以下の手順でトランザクションから解読されます："
 
 #: src/runes/specification.md:95
 msgid ""
 "Find the first transaction output whose script pubkey begins with `OP_RETURN "
 "OP_13`."
 msgstr ""
+"スクリプト公開鍵が `OP_RETURN OP_13` で始まる最初のトランザクション出力を見つけます。"
 
 #: src/runes/specification.md:98
 msgid "Concatenate all following data pushes into a payload buffer."
-msgstr ""
+msgstr "以降のすべてのデータプッシュをペイロードバッファに連結します。"
 
 #: src/runes/specification.md:100
 msgid ""
 "Decode a sequence 128-bit [LEB128](https://en.wikipedia.org/wiki/LEB128) "
 "integers from the payload buffer."
 msgstr ""
+"ペイロードバッファから128ビット [LEB128](https://en.wikipedia.org/wiki/LEB128) "
+"整数のシーケンスをデコードします。"
 
 #: src/runes/specification.md:103
 msgid "Parse the sequence of integers into an untyped message."
-msgstr ""
+msgstr "整数のシーケンスを型付けされていないメッセージにパースします。"
 
 #: src/runes/specification.md:105
 msgid "Parse the untyped message into a runestone."
-msgstr ""
+msgstr "型付けされていないメッセージをルーンストーンにパースします。"
 
 #: src/runes/specification.md:107
 msgid ""
 "Deciphering may produce a malformed runestone, termed a [cenotaph](https://"
 "en.wikipedia.org/wiki/Cenotaph)."
 msgstr ""
+"解読によって不正形のルーンストーンが生成される場合があり、これは [cenotaph](https://"
+"en.wikipedia.org/wiki/Cenotaph) と呼ばれます。"
 
 #: src/runes/specification.md:110
 msgid "Locating the Runestone Output"
-msgstr ""
+msgstr "ルーンストーン出力の特定"
 
 #: src/runes/specification.md:112
 msgid ""
@@ -8584,7 +8644,7 @@ msgstr "これらの詳細な情報はどこで見つけることができます
 
 #: src/faq.md:104
 msgid "[The BIP!](https://github.com/ordinals/ord/blob/master/bip.mediawiki)"
-msgstr ""
+msgstr "[BIP仕様書!](https://github.com/ordinals/ord/blob/master/bip.mediawiki)"
 
 #: src/faq.md:106
 msgid ""
@@ -8843,7 +8903,7 @@ msgstr ""
 
 #: src/faq.md:216
 msgid "_Inscriptions have a richer data model._"
-msgstr "_铭文有更丰富的数据模型_"
+msgstr "_碑文はより豊富なデータモデルを持っています_"
 
 #: src/faq.md:218
 msgid ""
@@ -8961,14 +9021,14 @@ msgid ""
 "not yet launched on mainnet. This gives you an opportunity to be an early "
 "adopter, and explore the medium as it evolves."
 msgstr ""
-"_铭文还处于项目早期_ 铭文仍在开发中，尚未在主网上发布（建议更新）。 这使您有"
-"机会成为早期采用者，并随着媒体的发展探索它。"
+"_碑文はまだ初期段階です！_ 碑文はまだ開発中であり、メインネットではまだローンチしていません。これは、"
+"あなたが早期採用者になり、メディアが発展するにつれてこの分野を探求する機会を与えます。"
 
 #: src/faq.md:270
 msgid ""
 "_Inscriptions are simple._ Inscriptions do not require writing or "
 "understanding smart contracts."
-msgstr "_铭文很简单_ 铭文不需要你编写或理解智能合约。"
+msgstr "_碑文はシンプルです_ 碑文はスマートコントラクトを書いたり理解したりする必要がありません。"
 
 #: src/faq.md:273
 msgid ""
@@ -9441,7 +9501,7 @@ msgstr ""
 
 #: src/guides/api.md:1
 msgid "JSON-API"
-msgstr ""
+msgstr "JSON API"
 
 #: src/guides/api.md:3
 msgid ""
@@ -9450,16 +9510,20 @@ msgid ""
 "structure of these objects closely follows what is shown in the HTML.  These "
 "endpoints are:"
 msgstr ""
+"デフォルトでは、`ord server` は HTTP ヘッダー `Accept: application/json` を設定すると "
+"HTML の代わりに JSON を返すエンドポイントへのアクセスを提供します。これらのオブジェクトの "
+"構造は HTML で表示される内容とほぼ同じです。これらのエンドポイントは以下の通りです："
 
 #: src/guides/api.md:15
 msgid ""
 "List all assets of an address. Requires index with `--index-addresses` flag."
 msgstr ""
+"アドレスのすべてのアセットを一覧表示します。`--index-addresses` フラグでのインデックスが必要です。"
 
 #: src/guides/api.md:26
 #, fuzzy
 msgid "\"outputs\""
-msgstr "輸出"
+msgstr "\"outputs\""
 
 #: src/guides/api.md:27
 msgid "\"ddf44a0e0080f458a1a1b6255a9fa0957f2611883a483c1901ccb0f59e3eb302:0\""
@@ -9587,11 +9651,11 @@ msgstr ""
 
 #: src/guides/api.md:61
 msgid "\"sat_balance\""
-msgstr ""
+msgstr "\"sat_balance\""
 
 #: src/guides/api.md:62
 msgid "\"runes_balances\""
-msgstr ""
+msgstr "\"runes_balances\""
 
 #: src/guides/api.md:64
 msgid "\"RSIC•AUBERGINE\""
@@ -9643,29 +9707,29 @@ msgstr ""
 
 #: src/guides/api.md:96 src/guides/api.md:145
 msgid "Returns info about the specified block."
-msgstr ""
+msgstr "指定されたブロックに関する情報を返します。"
 
 #: src/guides/api.md:107 src/guides/api.md:156
 msgid "\"best_height\""
-msgstr ""
+msgstr "\"best_height\""
 
 #: src/guides/api.md:113 src/guides/api.md:162
 #, fuzzy
 msgid "\"transactions\""
-msgstr "取引"
+msgstr "\"transactions\""
 
 #: src/guides/api.md:116 src/guides/api.md:165 src/guides/api.md:5103
 msgid "\"lock_time\""
-msgstr ""
+msgstr "\"lock_time\""
 
 #: src/guides/api.md:117 src/guides/api.md:166 src/guides/api.md:496
 #: src/guides/api.md:5104
 msgid "\"input\""
-msgstr ""
+msgstr "\"input\""
 
 #: src/guides/api.md:119 src/guides/api.md:168 src/guides/api.md:5106
 msgid "\"previous_output\""
-msgstr ""
+msgstr "\"previous_output\""
 
 #: src/guides/api.md:119 src/guides/api.md:168
 msgid "\"0000000000000000000000000000000000000000000000000000000000000000:4294967295\""
@@ -9673,7 +9737,7 @@ msgstr ""
 
 #: src/guides/api.md:120 src/guides/api.md:169 src/guides/api.md:5107
 msgid "\"script_sig\""
-msgstr ""
+msgstr "\"script_sig\""
 
 #: src/guides/api.md:120 src/guides/api.md:169
 msgid "\"04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73\""
@@ -9681,17 +9745,17 @@ msgstr ""
 
 #: src/guides/api.md:121 src/guides/api.md:170 src/guides/api.md:5108
 msgid "\"sequence\""
-msgstr ""
+msgstr "\"sequence\""
 
 #: src/guides/api.md:122 src/guides/api.md:171 src/guides/api.md:5109
 msgid "\"witness\""
-msgstr ""
+msgstr "\"witness\""
 
 #: src/guides/api.md:128 src/guides/api.md:177 src/guides/api.md:1811
 #: src/guides/api.md:1848 src/guides/api.md:1860 src/guides/api.md:1927
 #: src/guides/api.md:1944 src/guides/api.md:5119
 msgid "\"script_pubkey\""
-msgstr ""
+msgstr "\"script_pubkey\""
 
 #: src/guides/api.md:128 src/guides/api.md:177
 msgid "\"4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac\""
@@ -9699,31 +9763,32 @@ msgstr ""
 
 #: src/guides/api.md:194 src/guides/api.md:261
 msgid "Returns the height of the latest block."
-msgstr ""
+msgstr "最新ブロックの高さを返します。"
 
 #: src/guides/api.md:216
-#, fuzzy
 msgid "Returns blockhash for the latest block."
-msgstr "`/blockhash`：最新のブロックハッシュ。"
+msgstr "最新ブロックのブロックハッシュを返します。"
 
 #: src/guides/api.md:239
 msgid "Returns blockhash of specified block."
-msgstr ""
+msgstr "指定されたブロックのブロックハッシュを返します。"
 
 #: src/guides/api.md:283
 msgid ""
 "Returns the height of the latest block, the blockhashes of the last 100 "
 "blocks, and featured inscriptions from them."
 msgstr ""
+"最新ブロックの高さ、直近100ブロックのブロックハッシュ、およびそれらからの "
+"注目すべき碑文を返します。"
 
 #: src/guides/api.md:294
 msgid "\"last\""
-msgstr ""
+msgstr "\"last\""
 
 #: src/guides/api.md:295
 #, fuzzy
 msgid "\"blocks\""
-msgstr "ブロック"
+msgstr "\"blocks\""
 
 #: src/guides/api.md:296 src/guides/api.md:438
 msgid "\"00000000000000000002794398a350a04cc371ee33659296a980214f0f060adc\""
@@ -10440,7 +10505,7 @@ msgstr ""
 
 #: src/guides/api.md:1378
 msgid "Returns the inscription information for the specified child."
-msgstr ""
+msgstr "指定された子の碑文情報を返します。"
 
 #: src/guides/api.md:1389 src/guides/api.md:1438 src/guides/api.md:1462
 msgid "\"bc1pnhyyzpetra3zvm376ng8ncnv9phtt45fczpt7sv2eatedtjj9vjqwhj080\""
@@ -11315,7 +11380,7 @@ msgstr ""
 
 #: src/guides/api.md:1794
 msgid "Returns information about a UTXO, including inscriptions within it."
-msgstr ""
+msgstr "UTXOに関する情報を、その中に含まれる碑文を含めて返します。"
 
 #: src/guides/api.md:1805 src/guides/api.md:1842
 msgid "\"bc1pz4kvfpurqc2hwgrq0nwtfve2lfxvdpfcdpzc6ujchyr3ztj6gd9sfr6ayf\""
@@ -11324,12 +11389,12 @@ msgstr ""
 #: src/guides/api.md:1806 src/guides/api.md:1843 src/guides/api.md:1855
 #: src/guides/api.md:1901 src/guides/api.md:1934
 msgid "\"indexed\""
-msgstr ""
+msgstr "\"indexed\""
 
 #: src/guides/api.md:1808 src/guides/api.md:1845 src/guides/api.md:1857
 #: src/guides/api.md:1903 src/guides/api.md:1936
 msgid "\"outpoint\""
-msgstr ""
+msgstr "\"outpoint\""
 
 #: src/guides/api.md:1808 src/guides/api.md:1845
 msgid "\"bc4c30829a9564c0d58e6287195622b53ced54a25711d1b86be7cd3a70ef61ed:0\""
@@ -11462,10 +11527,11 @@ msgid ""
 "Returns details about the specified rune. Requires index with `--index-"
 "runes` flag."
 msgstr ""
+"指定されたルーンの詳細を返します。`--index-runes` フラグでのインデックスが必要です。"
 
 #: src/guides/api.md:1972
 msgid "\"entry\""
-msgstr ""
+msgstr "\"entry\""
 
 #: src/guides/api.md:1973 src/guides/api.md:2027 src/guides/api.md:2055
 #: src/guides/api.md:2083 src/guides/api.md:2111 src/guides/api.md:2139
@@ -12519,6 +12585,7 @@ msgid ""
 "Returns details about a specific satoshi. Requires index with `--index-sats` "
 "flag."
 msgstr ""
+"特定のsatoshiの詳細を返します。`--index-sats` フラグでのインデックスが必要です。"
 
 #: src/guides/api.md:5017
 msgid "\"cycle\""
@@ -12577,7 +12644,7 @@ msgstr "普通ではないの"
 
 #: src/guides/api.md:5042
 msgid "Returns details about the server installation and index."
-msgstr ""
+msgstr "サーバーのインストールとインデックスに関する詳細を返します。"
 
 #: src/guides/api.md:5053
 msgid "\"address_index\""
@@ -12656,7 +12723,7 @@ msgstr ""
 
 #: src/guides/api.md:5087
 msgid "Returns details about the specified transaction."
-msgstr ""
+msgstr "指定されたトランザクションの詳細を返します。"
 
 #: src/guides/api.md:5100
 #, fuzzy
@@ -13018,6 +13085,8 @@ msgid ""
 "Details on creating or modifying your `bitcoin.conf` file can be found [here]"
 "(https://github.com/bitcoin/bitcoin/blob/master/doc/bitcoin-conf.md)."
 msgstr ""
+"`bitcoin.conf` ファイルの作成または変更についての詳細は"
+"[こちら](https://github.com/bitcoin/bitcoin/blob/master/doc/bitcoin-conf.md)で確認できます。"
 
 #: src/guides/wallet.md:73
 msgid "Syncing the Bitcoin Blockchain"
@@ -13051,6 +13120,9 @@ msgid ""
 "`datadir` option because the cookie file will still be in the default "
 "location for `bitcoin-cli` and `ord` to find."
 msgstr ""
+"ブロックチェーンは約600GBのディスク容量を必要とします。ブロックを保存したい外付けドライブがある場合は、"
+"設定オプション `blocksdir=<external_drive_path>` を使用してください。これは `datadir` オプションを使用するよりもはるかに簡単です。"
+"クッキーファイルが `bitcoin-cli` や `ord` が見つけられるデフォルトの場所にあり続けるためです。"
 
 #: src/guides/wallet.md:98 src/guides/collecting/sparrow-wallet.md:173
 msgid "Troubleshooting"
@@ -13061,12 +13133,14 @@ msgid ""
 "Make sure you can access `bitcoind` with `bitcoin-cli -getinfo` and that it "
 "is fully synced."
 msgstr ""
+"`bitcoin-cli -getinfo` で `bitcoind` にアクセスできることと、完全に同期されていることを確認してください。"
 
 #: src/guides/wallet.md:104
 msgid ""
 "If `bitcoin-cli -getinfo` returns `Could not connect to the server`, "
 "`bitcoind` is not running."
 msgstr ""
+"`bitcoin-cli -getinfo` が `Could not connect to the server` を返す場合、`bitcoind` が実行されていません。"
 
 #: src/guides/wallet.md:107
 msgid ""
@@ -13074,6 +13148,7 @@ msgid ""
 "`bitcoin.conf` file. `ord` requires using cookie authentication. Make sure "
 "there is a file `.cookie` in your bitcoin data directory."
 msgstr ""
+"`bitcoin.conf` ファイルに `rpcuser`、`rpcpassword`、または `rpcauth` が設定されて_いない_ことを確認してください。`ord` はクッキー認証の使用が必要です。Bitcoinデータディレクトリに `.cookie` ファイルがあることを確認してください。"
 
 #: src/guides/wallet.md:111
 msgid ""
@@ -13084,6 +13159,7 @@ msgid ""
 "cookie -getinfo`. When running `ord` you must specify the cookie file "
 "location with `--cookie-file=<your_bitcoin_datadir>/.cookie`."
 msgstr ""
+"`bitcoin-cli -getinfo` が `Could not locate RPC credentials` を返す場合、クッキーファイルの場所を指定する必要があります。カスタムデータディレクトリを使用している場合（`datadir` オプションを指定）、`bitcoin-cli -rpccookiefile=<your_bitcoin_datadir>/.cookie -getinfo` のようにクッキーの場所を指定する必要があります。`ord` を実行する際は、`--cookie-file=<your_bitcoin_datadir>/.cookie` でクッキーファイルの場所を指定する必要があります。"
 
 #: src/guides/wallet.md:119
 msgid ""
@@ -13091,24 +13167,26 @@ msgid ""
 "If `bitcoin-cli listwallets` returns `Method not found` then the wallet is "
 "disabled and you won't be able to use `ord`."
 msgstr ""
+"`bitcoin.conf` ファイルに `disablewallet=1` が設定されて_いない_ことを確認してください。`bitcoin-cli listwallets` が `Method not found` を返す場合、ウォレットが無効になっており、`ord` を使用できません。"
 
 #: src/guides/wallet.md:123
 msgid ""
 "Make sure `txindex=1` is set. Run `bitcoin-cli getindexinfo` and it should "
 "return something like"
 msgstr ""
+"`txindex=1` が設定されていることを確認してください。`bitcoin-cli getindexinfo` を実行すると、次のような結果が返されるはずです"
 
 #: src/guides/wallet.md:127
 msgid "\"txindex\""
-msgstr ""
+msgstr "\"txindex\""
 
 #: src/guides/wallet.md:128
 msgid "\"synced\""
-msgstr ""
+msgstr "\"synced\""
 
 #: src/guides/wallet.md:129
 msgid "\"best_block_height\""
-msgstr ""
+msgstr "\"best_block_height\""
 
 #: src/guides/wallet.md:133
 msgid ""
@@ -13116,12 +13194,14 @@ msgid ""
 "false`, `bitcoind` is still creating the `txindex`. Wait until `\"synced\": "
 "true` before using `ord`."
 msgstr ""
+"`{}` のみが返される場合、`txindex` が設定されていません。`\"synced\": false` が返される場合、`bitcoind` がまだ `txindex` を作成中です。`ord` を使用する前に `\"synced\": true` になるまで待ってください。"
 
 #: src/guides/wallet.md:137
 msgid ""
 "If you have `maxuploadtarget` set it can interfere with fetching blocks for "
 "`ord` index. Either remove it or set `whitebind=127.0.0.1:8333`."
 msgstr ""
+"`maxuploadtarget` が設定されている場合、`ord` インデックス用のブロック取得に干渉する可能性があります。これを削除するか、`whitebind=127.0.0.1:8333` を設定してください。"
 
 #: src/guides/wallet.md:140
 msgid "Installing `ord`"
@@ -13139,13 +13219,13 @@ msgstr ""
 
 #: src/guides/wallet.md:147
 msgid "You can install the latest pre-built binary from the command line with:"
-msgstr ""
+msgstr "最新のプリビルドバイナリをコマンドラインから次のコマンドでインストールできます："
 "コマンドラインで次のコマンドを使用して、最新のファイルをインストールすること"
 "もできます。："
 
 #: src/guides/wallet.md:150
 msgid "'=https'"
-msgstr ""
+msgstr "'=https'"
 
 #: src/guides/wallet.md:153
 msgid "Once `ord` is installed, you should be able to run:"
@@ -13179,7 +13259,7 @@ msgstr "『ord』という名前のBitcoin Coreウォレットを作成し、運
 
 #: src/guides/wallet.md:183
 msgid "This will print out your seed phrase mnemonic, store it somewhere safe."
-msgstr ""
+msgstr "これによりシードフレーズニーモニックが表示されます。安全な場所に保存してください。"
 
 #: src/guides/wallet.md:185
 msgid ""
@@ -13191,12 +13271,20 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
+"```\n"
+"{\n"
+"  \"mnemonic\": \"dignity buddy actor toast talk crisp city annual tourist "
+"orient similar federal\",\n"
+"  \"passphrase\": \"\"\n"
+"}\n"
+"```"
 
 #: src/guides/wallet.md:192
 msgid ""
 "If you want to specify a different name or use an `ord server` running on a "
 "non-default URL you can set these options:"
 msgstr ""
+"異なる名前を指定したい場合や、デフォルト以外のURLで動作している `ord server` を使用したい場合は、以下のオプションを設定できます："
 
 #: src/guides/wallet.md:195
 msgid ""
@@ -13204,14 +13292,17 @@ msgid ""
 "ord wallet --name foo --server-url http://127.0.0.1:8080 create\n"
 "```"
 msgstr ""
+"```\n"
+"ord wallet --name foo --server-url http://127.0.0.1:8080 create\n"
+"```"
 
 #: src/guides/wallet.md:199
 msgid "To see all available wallet options you can run:"
-msgstr ""
+msgstr "利用可能なウォレットオプションをすべて確認するには、次のコマンドを実行してください："
 
 #: src/guides/wallet.md:205
 msgid "Restoring and Dumping Wallet"
-msgstr ""
+msgstr "ウォレットの復元とダンプ"
 
 #: src/guides/wallet.md:208
 msgid ""
@@ -13219,6 +13310,7 @@ msgid ""
 "and import them into another descriptor-based wallet. To export the wallet "
 "descriptors, which include your private keys:"
 msgstr ""
+"`ord` ウォレットはディスクリプタを使用しているため、アウトプットディスクリプタをエクスポートして他のディスクリプタベースのウォレットにインポートできます。秘密鍵を含むウォレットディスクリプタをエクスポートするには："
 
 #: src/guides/wallet.md:212
 msgid ""
@@ -13261,28 +13353,67 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
+"```\n"
+"$ ord wallet dump\n"
+"==========================================\n"
+"= この文字列には秘密鍵が含まれています =\n"
+"=        誰とも共有しないでください        =\n"
+"==========================================\n"
+"{\n"
+"  \"wallet_name\": \"ord\",\n"
+"  \"descriptors\": [\n"
+"    {\n"
+"      \"desc\": "
+"\"tr([551ac972/86'/1'/0']tprv8h4xBhrfZwX9o1XtUMmz92yNiGRYjF9B1vkvQ858aN1UQcACZNqN9nFzj3vrYPa4jdPMfw4ooMuNBfR4gcYm7LmhKZNTaF4etbN29Tj7UcH/0/"
+"*)#uxn94yt5\",\n"
+"      \"timestamp\": 1296688602,\n"
+"      \"active\": true,\n"
+"      \"internal\": false,\n"
+"      \"range\": [\n"
+"        0,\n"
+"        999\n"
+"      ],\n"
+"      \"next\": 0\n"
+"    },\n"
+"    {\n"
+"      \"desc\": "
+"\"tr([551ac972/86'/1'/0']tprv8h4xBhrfZwX9o1XtUMmz92yNiGRYjF9B1vkvQ858aN1UQcACZNqN9nFzj3vrYPa4jdPMfw4ooMuNBfR4gcYm7LmhKZNTaF4etbN29Tj7UcH/1/"
+"*)#djkyg3mv\",\n"
+"      \"timestamp\": 1296688602,\n"
+"      \"active\": true,\n"
+"      \"internal\": true,\n"
+"      \"range\": [\n"
+"        0,\n"
+"        999\n"
+"      ],\n"
+"      \"next\": 0\n"
+"    }\n"
+"  ]\n"
+"}\n"
+"```"
 
 #: src/guides/wallet.md:247
 msgid "An `ord` wallet can be restored from a mnemonic:"
-msgstr ""
+msgstr "`ord` ウォレットはニーモニックから復元できます："
 
 #: src/guides/wallet.md:253
 msgid "Type your mnemonic and press return."
-msgstr ""
+msgstr "ニーモニックを入力してEnterキーを押してください。"
 
 #: src/guides/wallet.md:255
 msgid "To restore from a descriptor in `descriptor.json`:"
-msgstr ""
+msgstr "`descriptor.json` のディスクリプタから復元するには："
 
 #: src/guides/wallet.md:261
 msgid "To restore from a descriptor in the clipboard:"
-msgstr ""
+msgstr "クリップボードのディスクリプタから復元するには："
 
 #: src/guides/wallet.md:267
 msgid ""
 "Paste the descriptor into the terminal and press CTRL-D on unix and CTRL-Z "
 "on Windows."
 msgstr ""
+"ディスクリプタをターミナルに貼り付け、UnixではCTRL-D、WindowsではCTRL-Zを押してください。"
 
 #: src/guides/wallet.md:270
 msgid "Receiving Sats"
@@ -13419,6 +13550,8 @@ msgid ""
 "Parent-child inscriptions enable what is colloquially known as collections, "
 "see [provenance](../inscriptions/provenance.md) for more information."
 msgstr ""
+"親子関係の碑文は、一般的にコレクションと呼ばれる機能を可能にします。"
+"詳しくは [provenance](../inscriptions/provenance.md) を参照してください。"
 
 #: src/guides/wallet.md:348
 msgid ""
@@ -13426,6 +13559,8 @@ msgid ""
 "inscribed and present in the wallet. To choose a parent run `ord wallet "
 "inscriptions` and copy the inscription id (`<PARENT_INSCRIPTION_ID>`)."
 msgstr ""
+"碑文を他の碑文の子にするためには、親碑文が碑文されておりウォレットに存在する必要があります。"
+"親を選ぶには `ord wallet inscriptions` を実行し、碑文ID（`<PARENT_INSCRIPTION_ID>`）をコピーしてください。"
 
 #: src/guides/wallet.md:352
 #, fuzzy
@@ -13437,6 +13572,7 @@ msgid ""
 "This relationship cannot be added retroactively, the parent has to be "
 "present at inception of the child."
 msgstr ""
+"この関係は後から追加することはできません。親は子の作成時に存在している必要があります。"
 
 #: src/guides/wallet.md:361
 msgid "Sending Inscriptions"
@@ -13478,6 +13614,8 @@ msgid ""
 "the name of the rune. For example if you want to send 1000 of the EXAMPLE "
 "rune, you would use `1000:EXAMPLE`."
 msgstr ""
+"`RUNES_AMOUNT` は送信するルーンの数、`:` 文字、そしてルーンの名前です。"
+"例えば、EXAMPLEルーンを1000個送信したい場合は、`1000:EXAMPLE` を使用します。"
 
 #: src/guides/wallet.md:418
 #, fuzzy
@@ -13514,20 +13652,24 @@ msgid ""
 "parent, since the parent can passed into a reveal transaction that creates "
 "multiple children."
 msgstr ""
+"[ポインターフィールド](./../inscriptions/pointer.md) を使用して複数の碑文を同時に作成できます。"
+"これは特にコレクションや、複数の碑文が同じ親を共有すべき場合に役立ちます。"
+"親は複数の子を作成するリビール取引に渡すことができるためです。"
 
 #: src/guides/batch-inscribing.md:10
 msgid ""
 "To create a batch inscription using a batchfile in `batch.yaml`, run the "
 "following command:"
 msgstr ""
+"`batch.yaml` のバッチファイルを使用してバッチ碑文を作成するには、次のコマンドを実行してください："
 
 #: src/guides/batch-inscribing.md:17
 msgid "Example `batch.yaml`"
-msgstr ""
+msgstr "`batch.yaml` の例"
 
 #: src/guides/batch-inscribing.md:21
 msgid "# example batch file\n"
-msgstr ""
+msgstr "# バッチファイルの例\n"
 
 #: src/guides/batch-inscribing.md:22
 msgid ""
@@ -13538,10 +13680,16 @@ msgid ""
 "# - `shared-output`: inscribe on a single output separated by postage\n"
 "mode"
 msgstr ""
+"# 碑文モード:\n"
+"# - `same-sat`: 同じsatに碑文を刻む\n"
+"# - `satpoints`: 指定されたsatpointのアウトプットの最初のsatに碑文を刻む\n"
+"# - `separate-outputs`: 個別の送料サイズのアウトプットに碑文を刻む\n"
+"# - `shared-output`: 送料で区切られた単一のアウトプットに碑文を刻む\n"
+"mode"
 
 #: src/guides/batch-inscribing.md:28
 msgid "separate-outputs"
-msgstr ""
+msgstr "separate-outputs"
 
 #: src/guides/batch-inscribing.md:29
 #, fuzzy
@@ -13552,53 +13700,67 @@ msgstr "聡は他のルーンと比較します"
 
 #: src/guides/batch-inscribing.md:32 src/guides/batch-inscribing.md:82
 msgid "6ac5cacb768794f4fd7a78bf00f2074891fce68bd65c4ff36e77177237aacacai0"
-msgstr ""
+msgstr "6ac5cacb768794f4fd7a78bf00f2074891fce68bd65c4ff36e77177237aacacai0"
 
 #: src/guides/batch-inscribing.md:33
 msgid ""
 "# postage for each inscription:\n"
 "postage"
 msgstr ""
+"# 各碑文の送料：\n"
+"postage"
 
 #: src/guides/batch-inscribing.md:36
 msgid ""
 "# allow reinscribing\n"
 "reinscribe"
 msgstr ""
+"# 再碑文を許可\n"
+"reinscribe"
 
 #: src/guides/batch-inscribing.md:39
 msgid ""
 "# sat to inscribe on, can only be used with `same-sat`:\n"
 "# sat: 5000000000\n"
 msgstr ""
+"# 碑文を刻むsat、`same-sat`でのみ使用可能：\n"
+"# sat: 5000000000\n"
 
 #: src/guides/batch-inscribing.md:42
 msgid ""
 "# rune to etch (optional)\n"
 "etching"
 msgstr ""
+"# エッチするルーン（オプション）\n"
+"etching"
 
 #: src/guides/batch-inscribing.md:45
 msgid ""
 "# rune name\n"
 "  rune"
 msgstr ""
+"# ルーン名\n"
+"  rune"
 
 #: src/guides/batch-inscribing.md:46
 msgid "THE•BEST•RUNE"
-msgstr ""
+msgstr "THE•BEST•RUNE"
 
 #: src/guides/batch-inscribing.md:47
 msgid ""
 "# allow subdividing super-unit into `10^divisibility` sub-units\n"
 "  divisibility"
 msgstr ""
+"# スーパーユニットを`10^divisibility`サブユニットに細分化を許可\n"
+"  divisibility"
 
 #: src/guides/batch-inscribing.md:49
 msgid ""
 "# premine\n"
 "  premine"
 msgstr ""
+"# プレマイン\n"
+"  premine"
 
 #: src/guides/batch-inscribing.md:51
 msgid ""
@@ -14826,46 +14988,56 @@ msgid ""
 "Ordinals are numbers for satoshis. Every satoshi has an ordinal number and "
 "every ordinal number has a satoshi."
 msgstr ""
+"オーディナルズはsatoshiの番号です。すべてのsatoshiにはオーディナル番号があり、"
+"すべてのオーディナル番号にはsatoshiがあります。"
 
 #: src/guides/sat-hunting.md:10
 msgid "Preparation"
-msgstr ""
+msgstr "準備"
 
 #: src/guides/sat-hunting.md:13
 msgid "There are a few things you'll need before you start."
-msgstr ""
+msgstr "始める前に必要なものがいくつかあります。"
 
 #: src/guides/sat-hunting.md:15
 msgid ""
 "First, you'll need a synced Bitcoin Core node with a transaction index. To "
 "turn on transaction indexing, pass `-txindex` on the command-line:"
 msgstr ""
+"まず、トランザクションインデックスを持つ同期されたBitcoin Coreノードが必要です。"
+"トランザクションインデックシングを有効にするには、コマンドラインで `-txindex` を渡してください："
 
 #: src/guides/sat-hunting.md:22
 msgid ""
 "Or put the following in your [Bitcoin configuration file](https://github.com/"
 "bitcoin/bitcoin/blob/master/doc/bitcoin-conf.md#configuration-file-path):"
 msgstr ""
+"または、[Bitcoin設定ファイル](https://github.com/bitcoin/bitcoin/blob/master/doc/bitcoin-conf.md#configuration-file-path)"
+"に以下を追加してください："
 
 #: src/guides/sat-hunting.md:29
 msgid ""
 "Launch it and wait for it to catch up to the chain tip, at which point the "
 "following command should print out the current block height:"
 msgstr ""
+"起動してチェーンの最新部分に追いつくまで待ち、その時点で次のコマンドが"
+"現在のブロック高を出力するはずです："
 
 #: src/guides/sat-hunting.md:36
 msgid "Second, you'll need a synced `ord` index."
-msgstr ""
+msgstr "二番目に、同期された `ord` インデックスが必要です。"
 
 #: src/guides/sat-hunting.md:38
 msgid "Get a copy of `ord` from [the repo](https://github.com/ordinals/ord/)."
-msgstr ""
+msgstr "[repo](https://github.com/ordinals/ord/) から `ord` のコピーを取得してください。"
 
 #: src/guides/sat-hunting.md:40
 msgid ""
 "Run `ord --index-sats server`. It should connect to your bitcoin core node "
 "and start indexing."
 msgstr ""
+"`ord --index-sats server` を実行してください。Bitcoin Coreノードに接続し、"
+"インデックシングを開始するはずです。"
 
 #: src/guides/sat-hunting.md:42
 msgid ""
@@ -15122,18 +15294,23 @@ msgid ""
 "`ord` can be configured with the command line, environment variables, a "
 "configuration file, and default values."
 msgstr ""
+"`ord`はコマンドライン、環境変数、設定ファイル、デフォルト値で設定できます。"
 
 #: src/guides/settings.md:7
 msgid ""
 "The command line takes precedence over environment variables, which take "
 "precedence over the configuration file, which takes precedence over defaults."
 msgstr ""
+"コマンドラインは環境変数より優先され、環境変数は設定ファイルより優先され、設定ファイルは"
+"デフォルト値より優先されます。"
 
 #: src/guides/settings.md:10
 msgid ""
 "The path to the configuration file can be given with `--config "
 "<CONFIG_PATH>`. `ord` will error if `<CONFIG_PATH>` doesn't exist."
 msgstr ""
+"設定ファイルのパスは`--config <CONFIG_PATH>`で指定できます。`<CONFIG_PATH>`が存在しない場合、`ord`は"
+"エラーを返します。"
 
 #: src/guides/settings.md:13
 msgid ""
@@ -15142,12 +15319,17 @@ msgid ""
 "<DATA_DIR_PATH>` in which case the config path is `<CONFIG_DIR_PATH>/ord."
 "yaml` or `<DATA_DIR_PATH>/ord.yaml`. It is not an error if it does not exist."
 msgstr ""
+"`ord.yaml`という名前の設定ファイルを含むディレクトリのパスは、`--config-dir <CONFIG_DIR_PATH>`または"
+"`--datadir <DATA_DIR_PATH>`で指定できます。この場合、設定パスは`<CONFIG_DIR_PATH>/ord.yaml`または"
+"`<DATA_DIR_PATH>/ord.yaml`になります。ファイルが存在しなくてもエラーではありません。"
 
 #: src/guides/settings.md:18
 msgid ""
 "If none of `--config`, `--config-dir`, or `--datadir` are given, and a file "
 "named `ord.yaml` exists in the default data directory, it will be loaded."
 msgstr ""
+"`--config`、`--config-dir`、`--datadir`のいずれも指定されておらず、デフォルトのデータディレクトリに`ord.yaml`"
+"という名前のファイルが存在する場合、それが読み込まれます。"
 
 #: src/guides/settings.md:21
 msgid ""
@@ -15157,16 +15339,20 @@ msgid ""
 "`--datadir` on the command line, the `ORD_DATA_DIR` environment variable, or "
 "`data_dir` in the config file."
 msgstr ""
+"コマンドラインで`--setting-name`という名前の設定について、環境変数は`ORD_SETTING_NAME`という名前になり、"
+"設定ファイルのフィールドは`setting_name`という名前になります。例えば、データディレクトリはコマンドライン"
+"では`--datadir`、環境変数では`ORD_DATA_DIR`、設定ファイルでは`data_dir`で設定できます。"
 
 #: src/guides/settings.md:27
 msgid "See `ord --help` for documentation of all the settings."
-msgstr ""
+msgstr "すべての設定のドキュメントについては、`ord --help`を参照してください。"
 
 #: src/guides/settings.md:29
 msgid ""
 "`ord`'s current configuration can be viewed as JSON with the `ord settings` "
 "command."
 msgstr ""
+"`ord`の現在の設定は、`ord settings`コマンドでJSONとして確認できます。"
 
 #: src/guides/settings.md:32
 msgid "Example Configuration"


### PR DESCRIPTION

https://github.com/ordinals/ord/pull/4189

In the previous pull request, I only translated the introduction and overview sections.
This pull request adds a complete Japanese translation of the existing ordinals documentation.

Merging this would greatly help increase Japanese users and contributors.