### PR TITLE
chore: fix typo in src/fund_raw_transaction.rs

### DIFF
--- a/src/fund_raw_transaction.rs
+++ b/src/fund_raw_transaction.rs
@@ -65,7 +65,7 @@ struct FundRawTransactionOptions {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub lock_unspents: Option<bool>,
   /// The fee rate to pay per kvB. NB. This field is converted to camelCase
-  /// when serialized, so it is receeived by fundrawtransaction as `feeRate`,
+  /// when serialized, so it is received by fundrawtransaction as `feeRate`,
   /// which fee rate per kvB, and *not* `fee_rate`, which is per vB.
   #[serde(
     with = "bitcoin::amount::serde::as_btc::opt",


### PR DESCRIPTION
fix typo in src/fund_raw_transaction.rs