### PR TITLE
Refresh Bitcoin Core RPC client on authentication failure

### DIFF
--- a/src/index/reorg.rs
+++ b/src/index/reorg.rs
@@ -35,10 +35,8 @@ impl Reorg {
 
         for depth in 1..max_recoverable_reorg_depth {
           let index_block_hash = index.block_hash(height.checked_sub(depth))?;
-          let bitcoind_block_hash = index
-            .client
-            .get_block_hash(u64::from(height.saturating_sub(depth)))
-            .into_option()?;
+          let bitcoind_block_hash =
+            index.rpc_block_hash(u64::from(height.saturating_sub(depth)))?;
 
           if index_block_hash == bitcoind_block_hash {
             return Err(anyhow!(reorg::Error::Recoverable { height, depth }));
@@ -91,7 +89,7 @@ impl Reorg {
       .map(|last_savepoint_height| last_savepoint_height.value())
       .unwrap_or(0);
 
-    let blocks = index.client.get_blockchain_info()?.headers;
+    let blocks = index.rpc_blockchain_info()?.headers;
 
     let savepoint_interval = u64::try_from(index.settings.savepoint_interval()).unwrap();
     let max_savepoints = u64::try_from(index.settings.max_savepoints()).unwrap();

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -43,7 +43,7 @@ pub(crate) struct Updater<'index> {
 impl Updater<'_> {
   pub(crate) fn update_index(&mut self, mut wtx: WriteTransaction) -> Result {
     let start = Instant::now();
-    let starting_height = u32::try_from(self.index.client.get_block_count()?).unwrap() + 1;
+    let starting_height = u32::try_from(self.index.rpc_block_count()?).unwrap() + 1;
     let starting_index_height = self.height;
 
     wtx
@@ -90,7 +90,7 @@ impl Updater<'_> {
         progress_bar.inc(1);
 
         if progress_bar.position() > progress_bar.length().unwrap() {
-          if let Ok(count) = self.index.client.get_block_count() {
+          if let Ok(count) = self.index.rpc_block_count() {
             progress_bar.set_length(count + 1);
           } else {
             log::warn!("Failed to fetch latest block height");
@@ -367,9 +367,9 @@ impl Updater<'_> {
         event_sender: self.index.event_sender.as_ref(),
         block_time: block.header.time,
         burned: HashMap::new(),
-        client: &self.index.client,
         height: self.height,
         id_to_entry: &mut rune_id_to_rune_entry,
+        index: self.index,
         inscription_id_to_sequence_number: &mut inscription_id_to_sequence_number,
         minimum: Rune::minimum_at_height(
           self.index.settings.chain().network(),


### PR DESCRIPTION
When Bitcoin Core restarts, it regenerates the `.cookie` file with new credentials. Previously, `ord` would fail with 401 errors until restarted.

This is particularly useful when running `ord server` long-term while occasionally restarting Bitcoin Core for configuration changes (peer adjustments, network tuning, etc.). With this change, `ord` automatically recovers without manual intervention.

Changes:
- Wrap `Index.client` in `RwLock` to allow runtime credential refresh
- Add `with_retry()` wrapper that detects 401 errors and re-reads the cookie file
- Apply retry logic to all Bitcoin Core RPC calls
- Add similar retry logic to the async `Fetcher` used during indexing