### PR TITLE
Split CI GitHub workflows into 3 files

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Docs
 
 on:
   push:
@@ -11,9 +11,6 @@ on:
 defaults:
   run:
     shell: bash
-
-env:
-  RUSTFLAGS: --deny warnings
 
 jobs:
   docs:
@@ -60,53 +57,3 @@ jobs:
         github_token: ${{secrets.GITHUB_TOKEN}}
         publish_branch: gh-pages
         publish_dir: docs/build/html
-
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v5
-
-    - name: Install Rust Toolchain Components
-      uses: actions-rs/toolchain@v1
-      with:
-        components: clippy, rustfmt
-        override: true
-        toolchain: stable
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Clippy
-      run: cargo clippy --all --all-targets
-
-    - name: Format
-      run: cargo fmt --all -- --check
-
-    - name: Check for Forbidden Words
-      run: |
-        sudo apt-get install ripgrep
-        ./bin/forbid
-
-  test:
-    strategy:
-      matrix:
-        os:
-        - macos-latest
-        - ubuntu-latest
-        - windows-latest
-
-    runs-on: ${{matrix.os}}
-
-    steps:
-    - uses: actions/checkout@v5
-
-    - name: Install Rust Toolchain Components
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Test
-      run: cargo test --all

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -1,0 +1,43 @@
+name: CI Lint
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  RUSTFLAGS: --deny warnings
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install Rust Toolchain Components
+      uses: actions-rs/toolchain@v1
+      with:
+        components: clippy, rustfmt
+        override: true
+        toolchain: stable
+
+    - uses: Swatinem/rust-cache@v2
+
+    - name: Clippy
+      run: cargo clippy --all --all-targets
+
+    - name: Format
+      run: cargo fmt --all -- --check
+
+    - name: Check for Forbidden Words
+      run: |
+        sudo apt-get install ripgrep
+        ./bin/forbid

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -1,0 +1,45 @@
+name: CI Test
+
+on:
+  push:
+    branches:
+    - master
+    paths-ignore:
+    - 'docs/**'
+  pull_request:
+    branches:
+    - master
+    paths-ignore:
+    - 'docs/**'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  RUSTFLAGS: --deny warnings
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os:
+        - macos-latest
+        - ubuntu-latest
+        - windows-latest
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install Rust Toolchain Components
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+
+    - uses: Swatinem/rust-cache@v2
+
+    - name: Test
+      run: cargo test --all


### PR DESCRIPTION
## Summary
- Split `ci.yaml` into three separate workflow files for better organization and efficiency:
  - `ci-docs.yaml`: Documentation build and GitHub Pages deployment
  - `ci-lint.yaml`: Clippy, rustfmt, and forbidden words checks
  - `ci-test.yaml`: Test suite running on macOS, Ubuntu, and Windows
- Added `paths-ignore: docs/**` to `ci-test.yaml` so docs-only PRs don't trigger the test suite

## Test plan
- [ ] Verify the three new workflow files appear in the Actions tab
- [ ] Create a docs-only PR to verify tests are skipped
- [ ] Create a code PR to verify all workflows run correctly
- [ ] Verify documentation deployment still works on merge to master

Closes #3682

Generated with [Claude Code](https://claude.com/claude-code)