### PR TITLE
Return error when exporting addresses without address index

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -707,6 +707,10 @@ impl Index {
   }
 
   pub fn export(&self, filename: &String, include_addresses: bool) -> Result {
+    if include_addresses && !self.index_addresses {
+      bail!("--include-addresses requires index built with --index-addresses");
+    }
+
     let mut writer = BufWriter::new(File::create(filename)?);
     let rtx = self.database.begin_read()?;
 
@@ -749,26 +753,15 @@ impl Index {
         let address = if satpoint.outpoint == unbound_outpoint() {
           "unbound".to_string()
         } else {
-          let script_pubkey = if self.index_addresses {
-            ScriptBuf::from_bytes(
-              outpoint_to_utxo_entry
-                .get(&satpoint.outpoint.store())?
-                .unwrap()
-                .value()
-                .parse(self)
-                .script_pubkey()
-                .to_vec(),
-            )
-          } else {
-            self
-              .get_transaction(satpoint.outpoint.txid)?
+          let script_pubkey = ScriptBuf::from_bytes(
+            outpoint_to_utxo_entry
+              .get(&satpoint.outpoint.store())?
               .unwrap()
-              .output
-              .into_iter()
-              .nth(satpoint.outpoint.vout.try_into().unwrap())
-              .unwrap()
-              .script_pubkey
-          };
+              .value()
+              .parse(self)
+              .script_pubkey()
+              .to_vec(),
+          );
 
           self
             .settings

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -90,3 +90,16 @@ fn export_inscription_number_to_id_tsv() {
     &ord::Object::InscriptionId(inscription),
   );
 }
+
+#[test]
+fn export_with_addresses_requires_address_index() {
+  let core = mockcore::spawn();
+  let temp_dir = TempDir::new().unwrap();
+
+  CommandBuilder::new("index export --include-addresses --tsv foo.tsv")
+    .core(&core)
+    .temp_dir(Arc::new(temp_dir))
+    .expected_exit_code(1)
+    .expected_stderr("error: --include-addresses requires index built with --index-addresses\n")
+    .run_and_extract_stdout();
+}


### PR DESCRIPTION
When `--include-addresses` is used but the index was not built with
`--index-addresses`, export falls back to fetching every transaction
via RPC, which is prohibitively slow.

Return a clear error instead and remove the RPC fallback path.

Fixes #3917