### PR TITLE
ADD /r/block/{query}/tx for block tx recursion

### DIFF
--- a/docs/src/inscriptions/recursion.md
+++ b/docs/src/inscriptions/recursion.md
@@ -225,6 +225,37 @@ curl -s \
 <details>
   <summary>
     <code>GET</code>
+    <code><b>/r/block/&lt;HEIGHT_OR_BLOCK_HASH&gt;/tx</b></code>
+  </summary>
+
+### Description
+
+Hex-encoded raw transactions in the block at the given height or with the given
+block hash, in block order. Bypasses the index and fetches the block via Bitcoin RPC.
+
+### Example (by height)
+
+```bash
+curl -s http://0.0.0.0:80/r/block/0/tx
+```
+
+```json
+["01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000"]
+```
+
+### Example (by block hash)
+
+```bash
+curl -s "http://0.0.0.0:80/r/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f/tx"
+```
+
+Returns the same array of hex-encoded transactions.
+
+</details>
+
+<details>
+  <summary>
+    <code>GET</code>
     <code><b>/r/blocktime</b></code>
   </summary>
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -288,6 +288,7 @@ impl Server {
         .route("/r/blockhash/{height}", get(r::blockhash_at_height))
         .route("/r/blockheight", get(r::blockheight_string))
         .route("/r/blockinfo/{query}", get(r::blockinfo))
+        .route("/r/block/{query}/tx", get(r::block_tx))
         .route("/r/blocktime", get(r::blocktime_string))
         .route(
           "/r/children/{inscription_id}/inscriptions",
@@ -4344,6 +4345,21 @@ mod tests {
       "/r/tx/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
       StatusCode::OK,
       "\"01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000\""
+    );
+  }
+
+  #[test]
+  fn recursive_block_tx_endpoint() {
+    let test_server = TestServer::new();
+
+    let blocks = test_server.mine_blocks(1);
+    let coinbase_hex =
+      bitcoin::consensus::encode::serialize_hex(&blocks[0].txdata[0]);
+
+    test_server.assert_response(
+      "/r/block/1/tx",
+      StatusCode::OK,
+      format!("[\"{coinbase_hex}\"]"),
     );
   }
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -4353,13 +4353,44 @@ mod tests {
     let test_server = TestServer::new();
 
     let blocks = test_server.mine_blocks(1);
-    let coinbase_hex =
-      bitcoin::consensus::encode::serialize_hex(&blocks[0].txdata[0]);
+    let coinbase_hex = bitcoin::consensus::encode::serialize_hex(&blocks[0].txdata[0]);
 
     test_server.assert_response(
       "/r/block/1/tx",
       StatusCode::OK,
-      format!("[\"{coinbase_hex}\"]"),
+      &format!("[\"{coinbase_hex}\"]"),
+    );
+  }
+
+  #[test]
+  fn recursive_block_tx_endpoint_for_genesis_by_height() {
+    let test_server = TestServer::new();
+
+    test_server.mine_blocks(1);
+
+    let genesis_coinbase_hex =
+      "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000";
+    test_server.assert_response(
+      "/r/block/0/tx",
+      StatusCode::OK,
+      &format!("[\"{genesis_coinbase_hex}\"]"),
+    );
+  }
+
+  #[test]
+  fn recursive_block_tx_endpoint_for_genesis_by_hash() {
+    let test_server = TestServer::new();
+
+    test_server.mine_blocks(1);
+
+    let genesis_block_hash =
+      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+    let genesis_coinbase_hex =
+      "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000";
+    test_server.assert_response(
+      format!("/r/block/{genesis_block_hash}/tx"),
+      StatusCode::OK,
+      &format!("[\"{genesis_coinbase_hex}\"]"),
     );
   }
 

--- a/src/subcommand/server/r.rs
+++ b/src/subcommand/server/r.rs
@@ -133,6 +133,28 @@ pub(super) async fn blockinfo(
   })
 }
 
+pub(super) async fn block_tx(
+  Extension(index): Extension<Arc<Index>>,
+  Path(DeserializeFromStr(query)): Path<DeserializeFromStr<query::Block>>,
+) -> ServerResult<Json<Vec<String>>> {
+  task::block_in_place(|| {
+    let block = match query {
+      query::Block::Height(height) => index
+        .get_block_by_height(height)?
+        .ok_or_not_found(|| format!("block {height}"))?,
+      query::Block::Hash(hash) => index
+        .get_block_by_hash(hash)?
+        .ok_or_not_found(|| format!("block {hash}"))?,
+    };
+    let txs = block
+      .txdata
+      .iter()
+      .map(bitcoin::consensus::encode::serialize_hex)
+      .collect::<Vec<_>>();
+    Ok(Json(txs))
+  })
+}
+
 pub(super) async fn blocktime_string(
   Extension(index): Extension<Arc<Index>>,
 ) -> ServerResult<String> {


### PR DESCRIPTION
Adds support for `/r/block/{query}/tx` for recursive query of the transactions contained in a block.

Open to feedback/change on the endpoint and how the data should be returned.

Adds a requested endpoint discussed here:
https://github.com/ordinals/ord/discussions/4480