### PR TITLE
Fix rune sends reusing mempool-spent UTXOs

### DIFF
--- a/crates/mockcore/src/server.rs
+++ b/crates/mockcore/src/server.rs
@@ -240,9 +240,13 @@ impl Api for Server {
     &self,
     txid: Txid,
     vout: u32,
-    _include_mempool: Option<bool>,
+    include_mempool: Option<bool>,
   ) -> Result<Option<GetTxOutResult>, jsonrpc_core::Error> {
     let state = self.state();
+
+    if include_mempool.unwrap_or(true) && state.is_spent_in_mempool(&OutPoint { txid, vout }) {
+      return Ok(None);
+    }
 
     let Some(value) = state.utxos.get(&OutPoint { txid, vout }) else {
       return Ok(None);
@@ -406,6 +410,10 @@ impl Api for Server {
 
     if (output_value + estimated_fee) > input_value {
       for (value, outpoint) in utxos {
+        if state.is_spent_in_mempool(&outpoint) {
+          continue;
+        }
+
         if state.locked.contains(&outpoint) {
           continue;
         }
@@ -767,6 +775,10 @@ impl Api for Server {
     let mut unspent = Vec::new();
 
     for (outpoint, &amount) in &state.utxos {
+      if state.is_spent_in_mempool(outpoint) {
+        continue;
+      }
+
       if state.locked.contains(outpoint) {
         continue;
       }

--- a/crates/mockcore/src/state.rs
+++ b/crates/mockcore/src/state.rs
@@ -300,6 +300,14 @@ impl State {
     &self.mempool
   }
 
+  pub(crate) fn is_spent_in_mempool(&self, outpoint: &OutPoint) -> bool {
+    self
+      .mempool
+      .iter()
+      .flat_map(|transaction| transaction.input.iter())
+      .any(|input| input.previous_output == *outpoint)
+  }
+
   pub(crate) fn get_confirmations(&self, tx: &Transaction) -> i32 {
     for (confirmations, hash) in self.hashes.iter().rev().enumerate() {
       if self.blocks.get(hash).unwrap().txdata.contains(tx) {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -182,6 +182,7 @@ impl Wallet {
       .filter(|utxo| inscriptions.contains(utxo))
       .chain(self.get_runic_outputs()?.unwrap_or_default().iter())
       .cloned()
+      .filter(|utxo| self.utxos().contains_key(utxo))
       .filter(|utxo| !locked.contains(utxo))
       .collect::<Vec<OutPoint>>();
 
@@ -864,7 +865,7 @@ impl Wallet {
     let mut fee = 0;
     for txin in unsigned_transaction.input.iter() {
       let Some(txout) = unspent_outputs.get(&txin.previous_output) else {
-        panic!("input {} not found in utxos", txin.previous_output);
+        bail!("input {} not found in wallet utxos", txin.previous_output);
       };
       fee += txout.value.to_sat();
     }
@@ -1003,6 +1004,7 @@ impl Wallet {
       .unwrap_or_default()
       .into_iter()
       .filter(|output| !inscribed_outputs.contains(output))
+      .filter(|output| self.utxos().contains_key(output))
       .map(|output| {
         self.get_runes_balances_in_output(&output).map(|balance| {
           (

--- a/src/wallet/wallet_constructor.rs
+++ b/src/wallet/wallet_constructor.rs
@@ -230,7 +230,7 @@ impl WalletConstructor {
     let mut utxos = BTreeMap::new();
 
     for outpoint in outpoints {
-      let Some(tx_out) = bitcoin_client.get_tx_out(&outpoint.txid, outpoint.vout, Some(false))?
+      let Some(tx_out) = bitcoin_client.get_tx_out(&outpoint.txid, outpoint.vout, Some(true))?
       else {
         continue;
       };

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -731,6 +731,35 @@ fn sending_rune_with_insufficient_balance_is_an_error() {
 }
 
 #[test]
+fn sending_rune_again_before_confirmation_ignores_spent_runic_output() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+
+  CommandBuilder::new(format!(
+    "--chain regtest --index-runes wallet send --fee-rate 1 bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 1000:{}",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  CommandBuilder::new(format!(
+    "--chain regtest --index-runes wallet send --fee-rate 1 bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 1:{}",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .expected_stderr("error: insufficient `AAAAAAAAAAAAA` balance, only 0\u{A0}¢ in wallet\n")
+  .run_and_extract_stdout();
+}
+
+#[test]
 fn sending_rune_works() {
   let core = mockcore::builder().network(Network::Regtest).build();
 


### PR DESCRIPTION
## Summary
- treat locked wallet outpoints spent by mempool transactions as unavailable
- filter runic outputs against the wallet UTXO snapshot before locking/selecting them
- return a normal wallet error instead of panicking if a funded transaction contains an input outside the wallet UTXO snapshot
- update mockcore mempool-spend behavior and add a regression test for rapid repeated rune sends

Closes #4364.

## Tests
- `cargo +1.89.0 fmt -- --check`
- `cargo +1.89.0 test sending_rune_again_before_confirmation_ignores_spent_runic_output --test integration`
- `cargo +1.89.0 test wallet::send --test integration`
- `cargo +1.89.0 test -p mockcore`