### PR TITLE
Add recursive child inscription lookup by index

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -90,6 +90,11 @@ pub struct ChildInscriptions {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct ChildInscription {
+  pub child: Option<RelativeInscriptionRecursive>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Gallery {
   pub ids: Vec<InscriptionId>,
   pub more: bool,

--- a/src/index.rs
+++ b/src/index.rs
@@ -1405,6 +1405,38 @@ impl Index {
     Ok((children, more))
   }
 
+  pub fn get_child_by_sequence_number_indexed(
+    &self,
+    sequence_number: u32,
+    child_index: isize,
+  ) -> Result<Option<InscriptionId>> {
+    let rtx = self.database.begin_read()?;
+
+    let sequence_number_to_entry = rtx.open_table(SEQUENCE_NUMBER_TO_INSCRIPTION_ENTRY)?;
+
+    if child_index < 0 {
+      rtx
+        .open_multimap_table(SEQUENCE_NUMBER_TO_CHILDREN)?
+        .get(sequence_number)?
+        .nth_back((child_index + 1).abs_diff(0))
+    } else {
+      rtx
+        .open_multimap_table(SEQUENCE_NUMBER_TO_CHILDREN)?
+        .get(sequence_number)?
+        .nth(child_index.abs_diff(0))
+    }
+    .map(|result| {
+      result
+        .and_then(|sequence_number| {
+          sequence_number_to_entry
+            .get(sequence_number.value())
+            .map(|entry| InscriptionEntry::load(entry.unwrap().value()).id)
+        })
+        .map_err(|err| err.into())
+    })
+    .transpose()
+  }
+
   pub fn get_parents_by_sequence_number_paginated(
     &self,
     parent_sequence_numbers: Vec<u32>,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -295,6 +295,10 @@ impl Server {
           get(r::children_inscriptions),
         )
         .route(
+          "/r/children/{inscription_id}/inscriptions/at/{index}",
+          get(r::child_inscription_at_index),
+        )
+        .route(
           "/r/children/{inscription_id}/inscriptions/{page}",
           get(r::children_inscriptions_paginated),
         )
@@ -7838,6 +7842,11 @@ next
     ));
     assert_eq!(child_inscriptions_json.children.len(), 0);
 
+    let child_inscription_json = server.get_json::<api::ChildInscription>(format!(
+      "/r/children/{parent_inscription_id}/inscriptions/at/-1"
+    ));
+    assert_eq!(child_inscription_json.child, None);
+
     let mut builder = script::Builder::new();
     for _ in 0..111 {
       builder = Inscription {
@@ -7905,6 +7914,29 @@ next
 
     assert!(!child_inscriptions_json.more);
     assert_eq!(child_inscriptions_json.page, 1);
+
+    let first_child = server
+      .get_json::<api::ChildInscription>(format!(
+        "/r/children/{parent_inscription_id}/inscriptions/at/0"
+      ))
+      .child
+      .unwrap();
+    assert_eq!(first_child.id, first_child_inscription_id);
+    assert_eq!(first_child.number, 1);
+
+    let latest_child_response = server.get(format!(
+      "/r/children/{parent_inscription_id}/inscriptions/at/-1"
+    ));
+    assert_eq!(latest_child_response.status(), StatusCode::OK);
+    assert_eq!(
+      latest_child_response.headers().get(header::CACHE_CONTROL),
+      Some(&HeaderValue::from_static("no-store"))
+    );
+
+    let latest_child: api::ChildInscription = latest_child_response.json().unwrap();
+    let latest_child = latest_child.child.unwrap();
+    assert_eq!(latest_child.id, hundred_eleventh_child_inscription_id);
+    assert_eq!(latest_child.number, -110);
   }
 
   #[test]

--- a/src/subcommand/server/r.rs
+++ b/src/subcommand/server/r.rs
@@ -160,6 +160,31 @@ pub(super) async fn children_inscriptions(
   children_inscriptions_paginated(Extension(index), Path((inscription_id, 0))).await
 }
 
+pub(super) async fn child_inscription_at_index(
+  Extension(index): Extension<Arc<Index>>,
+  Path((parent, child_index)): Path<(InscriptionId, isize)>,
+) -> ServerResult<(HeaderMap, Json<api::ChildInscription>)> {
+  task::block_in_place(|| {
+    let parent_sequence_number = index
+      .get_inscription_entry(parent)?
+      .ok_or_not_found(|| format!("inscription {parent}"))?
+      .sequence_number;
+
+    let child = index
+      .get_child_by_sequence_number_indexed(parent_sequence_number, child_index)?
+      .map(|inscription_id| get_relative_inscription(&index, inscription_id))
+      .transpose()?;
+
+    let mut headers = HeaderMap::new();
+
+    if child_index < 0 {
+      headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    }
+
+    Ok((headers, Json(api::ChildInscription { child })))
+  })
+}
+
 pub(super) async fn children_inscriptions_paginated(
   Extension(index): Extension<Arc<Index>>,
   Path((parent, page)): Path<(InscriptionId, usize)>,


### PR DESCRIPTION
Summary
- add `/r/children/{inscription_id}/inscriptions/at/{index}`
- support positive indexes from the first child and negative indexes from the latest child
- return `Cache-Control: no-store` for negative lookups because the latest child can change
- add regression coverage for empty, first, and latest-child lookups

Why
Consumers currently need to walk all child inscription pages to find the latest child. This adds the indexed lookup suggested in #3923 while matching the existing `/r/sat/{sat}/at/{index}` convention.

Testing
- cargo +1.93.0 test child_inscriptions_recursive_endpoint
- cargo +1.93.0 fmt -- --check
- cargo +1.93.0 check

Closes #3923.