### PR TITLE
Add burn height to inscription API

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -106,6 +106,7 @@ pub struct ParentInscriptions {
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Inscription {
   pub address: Option<String>,
+  pub burn_height: Option<u32>,
   pub charms: Vec<Charm>,
   pub child_count: u64,
   pub children: Vec<InscriptionId>,

--- a/src/index.rs
+++ b/src/index.rs
@@ -2327,6 +2327,27 @@ impl Index {
       Charm::Lost.set(&mut charms);
     }
 
+    let burn_height = if Charm::Burned.is_set(charms)
+      && satpoint.outpoint != OutPoint::null()
+      && satpoint.outpoint != unbound_outpoint()
+    {
+      let info = self
+        .client
+        .get_raw_transaction_info(&satpoint.outpoint.txid, None)
+        .into_option()?;
+
+      match info.and_then(|info| info.blockhash) {
+        Some(blockhash) => self
+          .client
+          .get_block_header_info(&blockhash)
+          .into_option()?
+          .map(|header| header.height.try_into().unwrap()),
+        None => None,
+      }
+    } else {
+      None
+    };
+
     let effective_mime_type = if let Some(delegate_id) = inscription.delegate() {
       let delegate_result = self.get_inscription_by_id(delegate_id);
       if let Ok(Some(delegate)) = delegate_result {
@@ -2350,6 +2371,7 @@ impl Index {
               .ok()
           })
           .map(|address| address.to_string()),
+        burn_height,
         charms: Charm::charms(charms),
         child_count,
         children,

--- a/tests/json_api.rs
+++ b/tests/json_api.rs
@@ -167,6 +167,7 @@ fn get_inscription() {
     inscription_json,
     api::Inscription {
       address: None,
+      burn_height: None,
       charms: vec![Charm::Coin, Charm::Uncommon],
       child_count: 0,
       children: Vec::new(),
@@ -189,6 +190,40 @@ fn get_inscription() {
       metaprotocol: None
     }
   )
+}
+
+#[test]
+fn get_burned_inscription_includes_burn_height() {
+  let core = mockcore::spawn();
+
+  let ord = TestServer::spawn_with_server_args(&core, &[], &[]);
+
+  create_wallet(&core, &ord);
+
+  core.mine_blocks(1);
+
+  let (inscription_id, _) = inscribe(&core, &ord);
+
+  core.mine_blocks(1);
+
+  let output = CommandBuilder::new(format!("wallet burn --fee-rate 1 {inscription_id}"))
+    .core(&core)
+    .ord(&ord)
+    .stdout_regex(r".*")
+    .run_and_deserialize_output::<Send>();
+
+  assert_eq!(core.mempool()[0].compute_txid(), output.txid);
+
+  core.mine_blocks(1);
+
+  let response = ord.json_request(format!("/inscription/{inscription_id}"));
+
+  assert_eq!(response.status(), StatusCode::OK);
+
+  let inscription_json: api::Inscription = serde_json::from_str(&response.text().unwrap()).unwrap();
+
+  assert_eq!(inscription_json.burn_height, Some(5));
+  assert!(inscription_json.charms.contains(&Charm::Burned));
 }
 
 #[test]
@@ -224,6 +259,7 @@ fn get_inscription_with_metaprotocol_and_properties() {
     inscription_json,
     api::Inscription {
       address: None,
+      burn_height: None,
       charms: vec![Charm::Coin, Charm::Uncommon],
       child_count: 0,
       children: Vec::new(),


### PR DESCRIPTION
Expose the block height where a burned inscription was mined by adding `burn_height` to inscription JSON responses. The field is `null` for non-burned inscriptions and set from the burn transaction block header when the inscription has the burned charm.

Closes #4431.

Tests:
- `cargo +1.93.0 test get_burned_inscription_includes_burn_height --test integration`
- `cargo +1.93.0 test json_api --test integration`
- `cargo +1.93.0 fmt -- --check`
- `cargo +1.93.0 check`
- `git diff --check`