### PR TITLE
Document canonical inscription ID encoding

### DIFF
--- a/docs/src/inscriptions.md
+++ b/docs/src/inscriptions.md
@@ -170,6 +170,10 @@ This allows inscriptions to retrieve their own inscription ID with:
 let inscription_id = window.location.pathname.split("/").pop();
 ```
 
+The canonical inscription ID encoding is the reveal transaction ID in
+lowercase hexadecimal, followed by a lowercase `i`, followed by the inscription
+index in decimal without leading zeroes.
+
 If an inscription with ID X delegates to an inscription with ID Y, that is to
 say, if inscription X contains a delegate field with value Y, the content of
 inscription X must be served from the URL path `/content/X`, *not*


### PR DESCRIPTION
Document the canonical text encoding for inscription IDs: lowercase reveal transaction ID, lowercase `i`, and decimal inscription index without leading zeroes.

This follows the maintainer suggestion in #4415 to specify the encoding directly rather than adding a JavaScript normalization function.

Closes #4415.

Validation:
- `git diff --check`

Not run:
- `mdbook build docs -d build` (`mdbook` is not installed in this environment)