### PR TITLE
Enfore nLocktime to current blockheight for anti-fee-sniping

### DIFF
--- a/src/subcommand/wallet/batch_command.rs
+++ b/src/subcommand/wallet/batch_command.rs
@@ -68,6 +68,7 @@ impl Batch {
       dry_run: self.shared.dry_run,
       etching: batchfile.etching,
       inscriptions,
+      lock_time: wallet.lock_time()?,
       mode: batchfile.mode,
       no_backup: self.shared.no_backup,
       no_limit: self.shared.no_limit,

--- a/src/subcommand/wallet/burn.rs
+++ b/src/subcommand/wallet/burn.rs
@@ -166,6 +166,7 @@ impl Burn {
         Target::ExactPostage(burn_amount),
         wallet.chain().network(),
       )
+      .with_lock_time(wallet.lock_time()?)
       .build_transaction()?,
     )
   }

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -115,6 +115,7 @@ impl Inscribe {
       mode: batch::Mode::SeparateOutputs,
       no_backup: self.shared.no_backup,
       no_limit: self.shared.no_limit,
+      lock_time: wallet.lock_time()?,
       parent_info: wallet.get_parent_info(self.parent.as_slice())?,
       postages: vec![self.postage.unwrap_or(TARGET_POSTAGE)],
       reinscribe: self.reinscribe,

--- a/src/subcommand/wallet/mint.rs
+++ b/src/subcommand/wallet/mint.rs
@@ -74,7 +74,7 @@ impl Mint {
 
     let unfunded_transaction = Transaction {
       version: Version(2),
-      lock_time: LockTime::ZERO,
+      lock_time: wallet.lock_time()?,
       input: Vec::new(),
       output: vec![
         TxOut {

--- a/src/subcommand/wallet/offer/create.rs
+++ b/src/subcommand/wallet/offer/create.rs
@@ -51,7 +51,7 @@ impl Create {
 
     let tx = Transaction {
       version: Version(2),
-      lock_time: LockTime::ZERO,
+      lock_time: wallet.lock_time()?,
       input: vec![TxIn {
         previous_output: inscription.satpoint.outpoint,
         script_sig: ScriptBuf::new(),

--- a/src/subcommand/wallet/split.rs
+++ b/src/subcommand/wallet/split.rs
@@ -136,6 +136,7 @@ impl Split {
       &wallet.get_change_address()?,
       self.postage,
       &splits,
+      wallet.lock_time()?,
     )?;
 
     let unsigned_transaction = fund_raw_transaction(
@@ -159,6 +160,7 @@ impl Split {
     change_address: &Address,
     postage: Option<Amount>,
     splits: &Splitfile,
+    lock_time: LockTime,
   ) -> Result<Transaction, Error> {
     if splits.outputs.is_empty() {
       return Err(Error::NoOutputs);
@@ -302,7 +304,7 @@ impl Split {
 
     let tx = Transaction {
       version: Version(2),
-      lock_time: LockTime::ZERO,
+      lock_time,
       input: inputs
         .into_iter()
         .map(|previous_output| TxIn {
@@ -344,6 +346,7 @@ mod tests {
           outputs: Vec::new(),
           rune_info: BTreeMap::new(),
         },
+          LockTime::ZERO,
       )
       .unwrap_err(),
       Error::NoOutputs,
@@ -366,6 +369,7 @@ mod tests {
           }],
           rune_info: BTreeMap::new(),
         },
+          LockTime::ZERO,
       )
       .unwrap_err(),
       Error::DustPostage {
@@ -403,6 +407,7 @@ mod tests {
           )]
           .into()
         },
+          LockTime::ZERO,
       )
       .unwrap_err(),
       Error::ZeroValue {
@@ -447,6 +452,7 @@ mod tests {
           )]
           .into()
         },
+          LockTime::ZERO,
       )
       .unwrap_err(),
       Error::ZeroValue {
@@ -487,6 +493,7 @@ mod tests {
           )]
           .into(),
         },
+          LockTime::ZERO,
       )
       .unwrap_err(),
       Error::Shortfall {
@@ -533,6 +540,7 @@ mod tests {
           )]
           .into()
         },
+          LockTime::ZERO,
       )
       .unwrap_err(),
       Error::Shortfall {
@@ -582,6 +590,7 @@ mod tests {
           )]
           .into(),
         },
+          LockTime::ZERO,
       )
       .unwrap_err(),
       Error::DustOutput {
@@ -624,6 +633,7 @@ mod tests {
           )]
           .into()
         },
+          LockTime::ZERO,
       )
       .unwrap_err(),
       Error::DustOutput {
@@ -664,7 +674,7 @@ mod tests {
       .into(),
     };
 
-    let tx = Split::build_transaction(false, balances, &change(0), None, &splits).unwrap();
+    let tx = Split::build_transaction(false, balances, &change(0), None, &splits, LockTime::ZERO).unwrap();
 
     pretty_assert_eq!(
       tx,
@@ -732,7 +742,7 @@ mod tests {
       .into(),
     };
 
-    let tx = Split::build_transaction(false, balances, &change, None, &splits).unwrap();
+    let tx = Split::build_transaction(false, balances, &change, None, &splits, LockTime::ZERO).unwrap();
 
     pretty_assert_eq!(
       tx,
@@ -810,6 +820,7 @@ mod tests {
       &change,
       Some(Amount::from_sat(500)),
       &splits,
+      LockTime::ZERO,
     )
     .unwrap();
 
@@ -881,7 +892,7 @@ mod tests {
       .into(),
     };
 
-    let tx = Split::build_transaction(false, balances, &change, None, &splits).unwrap();
+    let tx = Split::build_transaction(false, balances, &change, None, &splits, LockTime::ZERO).unwrap();
 
     pretty_assert_eq!(
       tx,
@@ -955,7 +966,7 @@ mod tests {
       .into(),
     };
 
-    let tx = Split::build_transaction(false, balances, &change(0), None, &splits).unwrap();
+    let tx = Split::build_transaction(false, balances, &change(0), None, &splits, LockTime::ZERO).unwrap();
 
     pretty_assert_eq!(
       tx,
@@ -1026,7 +1037,7 @@ mod tests {
       .into(),
     };
 
-    let tx = Split::build_transaction(false, balances, &change(0), None, &splits).unwrap();
+    let tx = Split::build_transaction(false, balances, &change(0), None, &splits, LockTime::ZERO).unwrap();
 
     pretty_assert_eq!(
       tx,
@@ -1096,7 +1107,7 @@ mod tests {
       .into(),
     };
 
-    let tx = Split::build_transaction(false, balances, &change(0), None, &splits).unwrap();
+    let tx = Split::build_transaction(false, balances, &change(0), None, &splits, LockTime::ZERO).unwrap();
 
     pretty_assert_eq!(
       tx,
@@ -1177,7 +1188,7 @@ mod tests {
       .into(),
     };
 
-    let tx = Split::build_transaction(false, balances, &change(0), None, &splits).unwrap();
+    let tx = Split::build_transaction(false, balances, &change(0), None, &splits, LockTime::ZERO).unwrap();
 
     pretty_assert_eq!(
       tx,
@@ -1270,7 +1281,7 @@ mod tests {
       .into(),
     };
 
-    let tx = Split::build_transaction(false, balances, &change(0), None, &splits).unwrap();
+    let tx = Split::build_transaction(false, balances, &change(0), None, &splits, LockTime::ZERO).unwrap();
 
     pretty_assert_eq!(
       tx,
@@ -1350,7 +1361,7 @@ mod tests {
     };
 
     assert_eq!(
-      Split::build_transaction(false, balances, &change(0), None, &splits).unwrap_err(),
+      Split::build_transaction(false, balances, &change(0), None, &splits, LockTime::ZERO).unwrap_err(),
       Error::RunestoneSize { size: 85 },
     );
   }
@@ -1383,7 +1394,7 @@ mod tests {
     };
 
     pretty_assert_eq!(
-      Split::build_transaction(true, balances, &change(0), None, &splits).unwrap(),
+      Split::build_transaction(true, balances, &change(0), None, &splits, LockTime::ZERO).unwrap(),
       Transaction {
         version: Version(2),
         lock_time: LockTime::ZERO,

--- a/src/subcommand/wallet/sweep.rs
+++ b/src/subcommand/wallet/sweep.rs
@@ -125,7 +125,7 @@ impl Sweep {
 
     let tx = Transaction {
       version: Version::TWO,
-      lock_time: LockTime::ZERO,
+      lock_time: wallet.lock_time()?,
       input,
       output,
     };

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -404,6 +404,17 @@ impl Wallet {
     )
   }
 
+  /// Returns the current chain height as an absolute `LockTime` for use as the
+  /// `nLockTime` of newly-created transactions. Setting `nLockTime` to the
+  /// current tip height is an anti-fee-sniping heuristic: it forces the
+  /// transaction to be mined no earlier than the next block, so a fee-sniping
+  /// miner cannot use it to replace a previously-confirmed transaction of ours
+  /// at a lower fee. See <https://bitcoinops.org/en/topics/fee-sniping/>.
+  pub(crate) fn lock_time(&self) -> Result<LockTime> {
+    let height = u32::try_from(self.bitcoin_client().get_block_count()?)?;
+    Ok(LockTime::from_height(height)?)
+  }
+
   pub(crate) fn check_maturity(&self, rune: Rune, commit: &Transaction) -> Result<Maturity> {
     Ok(
       if let Some(commit_tx) = self
@@ -905,7 +916,7 @@ impl Wallet {
 
     let unfunded_transaction = Transaction {
       version: Version(2),
-      lock_time: LockTime::ZERO,
+      lock_time: self.lock_time()?,
       input: Vec::new(),
       output: vec![TxOut {
         script_pubkey: destination.script_pubkey(),
@@ -967,6 +978,7 @@ impl Wallet {
         postage,
         self.chain().network(),
       )
+      .with_lock_time(self.lock_time()?)
       .build_transaction()?,
     )
   }
@@ -1061,6 +1073,7 @@ impl Wallet {
 
     let runestone;
     let postage = postage.unwrap_or(TARGET_POSTAGE);
+    let lock_time = self.lock_time()?;
 
     let unfunded_transaction = if let Some(destination) = destination {
       runestone = Runestone {
@@ -1074,7 +1087,7 @@ impl Wallet {
 
       Transaction {
         version: Version(2),
-        lock_time: LockTime::ZERO,
+        lock_time,
         input: inputs
           .into_iter()
           .map(|previous_output| TxIn {
@@ -1118,7 +1131,7 @@ impl Wallet {
 
       Transaction {
         version: Version(2),
-        lock_time: LockTime::ZERO,
+        lock_time,
         input: inputs
           .into_iter()
           .map(|previous_output| TxIn {

--- a/src/wallet/batch/plan.rs
+++ b/src/wallet/batch/plan.rs
@@ -6,6 +6,7 @@ pub struct Plan {
   pub(crate) dry_run: bool,
   pub(crate) etching: Option<Etching>,
   pub(crate) inscriptions: Vec<Inscription>,
+  pub(crate) lock_time: LockTime,
   pub(crate) mode: Mode,
   pub(crate) no_backup: bool,
   pub(crate) no_limit: bool,
@@ -25,6 +26,7 @@ impl Default for Plan {
       dry_run: false,
       etching: None,
       inscriptions: Vec::new(),
+      lock_time: LockTime::ZERO,
       mode: Mode::SharedOutput,
       no_backup: false,
       no_limit: false,
@@ -512,6 +514,7 @@ impl Plan {
       reveal_inputs.clone(),
       &reveal_script,
       rune.is_some(),
+      self.lock_time,
     );
 
     let mut target_value = reveal_fee;
@@ -536,6 +539,7 @@ impl Plan {
       Target::Value(target_value),
       chain.network(),
     )
+    .with_lock_time(self.lock_time)
     .build_transaction()?;
 
     let (vout, _commit_output) = unsigned_commit_tx
@@ -558,6 +562,7 @@ impl Plan {
       reveal_inputs,
       &reveal_script,
       rune.is_some(),
+      self.lock_time,
     );
 
     for output in reveal_tx.output.iter() {
@@ -716,6 +721,7 @@ impl Plan {
     input: Vec<OutPoint>,
     script: &Script,
     etching: bool,
+    lock_time: LockTime,
   ) -> (Transaction, Amount) {
     let reveal_tx = Transaction {
       input: input
@@ -732,7 +738,7 @@ impl Plan {
         })
         .collect(),
       output,
-      lock_time: LockTime::ZERO,
+      lock_time,
       version: Version(2),
     };
 

--- a/src/wallet/transaction_builder.rs
+++ b/src/wallet/transaction_builder.rs
@@ -119,6 +119,7 @@ pub struct TransactionBuilder {
   inputs: Vec<OutPoint>,
   inscriptions: BTreeMap<SatPoint, Vec<InscriptionId>>,
   locked_utxos: BTreeSet<OutPoint>,
+  lock_time: LockTime,
   network: Network,
   outgoing: SatPoint,
   outputs: Vec<TxOut>,
@@ -157,6 +158,7 @@ impl TransactionBuilder {
       inputs: Vec::new(),
       inscriptions,
       locked_utxos,
+      lock_time: LockTime::ZERO,
       outgoing,
       outputs: Vec::new(),
       recipient,
@@ -165,6 +167,14 @@ impl TransactionBuilder {
       unused_change_addresses: change.to_vec(),
       network,
     }
+  }
+
+  /// Sets the `nLockTime` of the transaction produced by `build_transaction`.
+  /// Defaults to `LockTime::ZERO` for backwards compatibility. Callers that
+  /// want anti-fee-sniping protection should pass the current chain height.
+  pub fn with_lock_time(mut self, lock_time: LockTime) -> Self {
+    self.lock_time = lock_time;
+    self
   }
 
   pub fn build_transaction(self) -> Result<Transaction> {
@@ -480,7 +490,7 @@ impl TransactionBuilder {
   fn build(self) -> Result<Transaction> {
     let transaction = Transaction {
       version: Version(2),
-      lock_time: LockTime::ZERO,
+      lock_time: self.lock_time,
       input: self
         .inputs
         .iter()
@@ -788,6 +798,7 @@ mod tests {
       outgoing: satpoint(1, 0),
       inscriptions: BTreeMap::new(),
       locked_utxos: BTreeSet::new(),
+      lock_time: LockTime::ZERO,
       runic_utxos: BTreeSet::new(),
       recipient: recipient(),
       unused_change_addresses: vec![change(0), change(1)],
@@ -1361,6 +1372,7 @@ mod tests {
       fee_rate: FeeRate::try_from(1.0).unwrap(),
       utxos: BTreeSet::new(),
       locked_utxos: BTreeSet::new(),
+      lock_time: LockTime::ZERO,
       runic_utxos: BTreeSet::new(),
       outgoing: satpoint(1, 0),
       inscriptions: BTreeMap::new(),
@@ -1402,6 +1414,7 @@ mod tests {
       fee_rate: FeeRate::try_from(1.0).unwrap(),
       utxos: BTreeSet::new(),
       locked_utxos: BTreeSet::new(),
+      lock_time: LockTime::ZERO,
       runic_utxos: BTreeSet::new(),
       outgoing: satpoint(1, 0),
       inscriptions: BTreeMap::new(),

--- a/tests/wallet/offer/create.rs
+++ b/tests/wallet/offer/create.rs
@@ -72,7 +72,7 @@ fn created_offer_is_correct() {
     psbt.unsigned_tx,
     Transaction {
       version: Version(2),
-      lock_time: LockTime::ZERO,
+      lock_time: LockTime::from_height(3).unwrap(),
       input: vec![
         TxIn {
           previous_output: OutPoint {


### PR DESCRIPTION
The ord protocol accounts for a substantial portion of fees in each block but does not participate in anti-fee-sniping for block creation. This PR adds default support for nLocktime to follow the current blockheight. Unlike Core/Electrum this does not add the ~10% backdating up to 100 blocks. I am open to adding that if the complexity is worth it.

It is my understanding that nothing in the ord protocol demands nLocktime to be Zero unless I am misunderstanding. As well considering the nLocktime is always 1 byte in the transaction regardles of the amount this will not impact fees overtime even in aggregate.