### PR TITLE
Forbid offers from specifying input sighashes

### DIFF
--- a/src/subcommand/wallet/offer/accept.rs
+++ b/src/subcommand/wallet/offer/accept.rs
@@ -29,6 +29,16 @@ impl Accept {
 
     let psbt = Psbt::deserialize(&psbt).context("failed to deserialize PSBT")?;
 
+    for (txin, input) in psbt.unsigned_tx.input.iter().zip(&psbt.inputs) {
+      if let Some(sighash_type) = input.sighash_type {
+        bail!(
+          "input `{}` specifies sighash type `{sighash_type}`: inputs may not specify any sighash \
+           type",
+          txin.previous_output,
+        );
+      }
+    }
+
     let mut outgoing = BTreeMap::new();
 
     for (index, input) in psbt.unsigned_tx.input.iter().enumerate() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,7 +3,8 @@
 use {
   self::{command_builder::CommandBuilder, expected::Expected, test_server::TestServer},
   bitcoin::{
-    Amount, Network, OutPoint, Psbt, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+    Amount, Network, OutPoint, Psbt, ScriptBuf, Sequence, TapSighashType, Transaction, TxIn, TxOut,
+    Txid, Witness,
     address::{Address, NetworkUnchecked},
     blockdata::locktime::absolute::LockTime,
     opcodes, script,

--- a/tests/wallet/offer/accept.rs
+++ b/tests/wallet/offer/accept.rs
@@ -633,3 +633,75 @@ fn seller_input_must_not_be_signed() {
   ))
   .run_and_extract_stdout();
 }
+
+#[test]
+fn inputs_may_not_specify_sighash_type() {
+  #[track_caller]
+  fn case(
+    core: &mockcore::Handle,
+    ord: &TestServer,
+    create: &Create,
+    input: usize,
+    sighash_type: TapSighashType,
+  ) {
+    let mut psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
+
+    psbt.inputs[input].sighash_type = Some(sighash_type.into());
+
+    CommandBuilder::new(format!(
+      "wallet offer accept --inscription {} --amount 1btc --psbt {} --dry-run",
+      create.inscription,
+      base64_encode(&psbt.serialize()),
+    ))
+    .core(core)
+    .ord(ord)
+    .expected_exit_code(1)
+    .expected_stderr(format!(
+      "error: input `{}` specifies sighash type `{sighash_type}`: inputs may not specify any \
+       sighash type\n",
+      psbt.unsigned_tx.input[input].previous_output,
+    ))
+    .run_and_extract_stdout();
+  }
+
+  let core = mockcore::spawn();
+
+  let ord = TestServer::spawn_with_server_args(&core, &[], &[]);
+
+  create_wallet(&core, &ord);
+
+  let (inscription, txid) = inscribe_with_options(&core, &ord, Some(9000), 0);
+
+  let inscription_address = Address::from_script(
+    &core.tx_by_id(txid).output[0].script_pubkey,
+    Network::Bitcoin,
+  )
+  .unwrap();
+
+  core
+    .state()
+    .remove_wallet_address(inscription_address.clone());
+
+  let create = CommandBuilder::new(format!(
+    "wallet offer create --inscription {inscription} --amount 1btc --fee-rate 0"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  core.state().clear_wallet_addresses();
+
+  core.state().add_wallet_address(inscription_address);
+
+  case(
+    &core,
+    &ord,
+    &create,
+    0,
+    TapSighashType::NonePlusAnyoneCanPay,
+  );
+
+  case(&core, &ord, &create, 0, TapSighashType::Default);
+
+  case(&core, &ord, &create, 1, TapSighashType::All);
+}


### PR DESCRIPTION
`bitcoind` checks and forbids non-default sighash flags on unsigned inputs, so this is impossible to exploit, but we shouldn't rely on that. Found and flagged by the inimitable @rob1ham 🙏