### PR TITLE
Warn when exporting addresses without address index

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -707,6 +707,13 @@ impl Index {
   }
 
   pub fn export(&self, filename: &String, include_addresses: bool) -> Result {
+    if include_addresses && !self.index_addresses {
+      eprintln!(
+        "warning: exporting addresses without `--index-addresses` requires fetching every \
+         transaction over RPC, which is slow"
+      );
+    }
+
     let mut writer = BufWriter::new(File::create(filename)?);
     let rtx = self.database.begin_read()?;
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -709,8 +709,8 @@ impl Index {
   pub fn export(&self, filename: &String, include_addresses: bool) -> Result {
     if include_addresses && !self.index_addresses {
       eprintln!(
-        "warning: exporting addresses without `--index-addresses` requires fetching every \
-         transaction over RPC, which is slow"
+        "warning: exporting addresses without `--index-addresses` fetches every transaction over \
+         RPC, which is very slow",
       );
     }
 

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -90,31 +90,3 @@ fn export_inscription_number_to_id_tsv() {
     &ord::Object::InscriptionId(inscription),
   );
 }
-
-#[test]
-fn export_addresses_without_address_index_warns() {
-  let core = mockcore::spawn();
-  let ord = TestServer::spawn(&core);
-
-  create_wallet(&core, &ord);
-
-  inscribe(&core, &ord);
-
-  core.mine_blocks(1);
-
-  let tsv = CommandBuilder::new("index export --include-addresses --tsv foo.tsv")
-    .core(&core)
-    .temp_dir(Arc::new(TempDir::new().unwrap()))
-    .stderr_regex("(?s).*warning: exporting addresses without `--index-addresses`.*")
-    .run_and_extract_file("foo.tsv");
-
-  let addresses = tsv
-    .lines()
-    .filter(|line| !line.is_empty() && !line.starts_with('#'))
-    .map(|line| line.split('\t').nth(3).unwrap())
-    .collect::<Vec<&str>>();
-
-  assert_eq!(addresses.len(), 1);
-
-  assert!(addresses[0].parse::<Address<NetworkUnchecked>>().is_ok());
-}

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -90,3 +90,31 @@ fn export_inscription_number_to_id_tsv() {
     &ord::Object::InscriptionId(inscription),
   );
 }
+
+#[test]
+fn export_addresses_without_address_index_warns() {
+  let core = mockcore::spawn();
+  let ord = TestServer::spawn(&core);
+
+  create_wallet(&core, &ord);
+
+  inscribe(&core, &ord);
+
+  core.mine_blocks(1);
+
+  let tsv = CommandBuilder::new("index export --include-addresses --tsv foo.tsv")
+    .core(&core)
+    .temp_dir(Arc::new(TempDir::new().unwrap()))
+    .stderr_regex("(?s).*warning: exporting addresses without `--index-addresses`.*")
+    .run_and_extract_file("foo.tsv");
+
+  let addresses = tsv
+    .lines()
+    .filter(|line| !line.is_empty() && !line.starts_with('#'))
+    .map(|line| line.split('\t').nth(3).unwrap())
+    .collect::<Vec<&str>>();
+
+  assert_eq!(addresses.len(), 1);
+
+  assert!(addresses[0].parse::<Address<NetworkUnchecked>>().is_ok());
+}


### PR DESCRIPTION
Warn instead of erroring, per your comment on #4494.

`eprintln!` and not `log::warn!` because `env_logger::init()` is called
without a default filter, so warn records don't print unless `RUST_LOG`
is set.

Didn't mark #3917 fixed since it asks to skip addresses entirely, which
isn't what this does.